### PR TITLE
fix: add HapticTab test and component checklist

### DIFF
--- a/COMPONENT_TESTS.md
+++ b/COMPONENT_TESTS.md
@@ -1,0 +1,61 @@
+# Component Test Coverage
+
+This checklist shows which components under `apps/akari/components` have tests.
+
+- [x] Collapsible.tsx
+- [ ] ExternalEmbed.tsx
+- [x] ExternalLink.tsx
+- [ ] GifEmbed.tsx
+- [ ] GifPicker.tsx
+- [ ] HandleHistoryModal.tsx
+- [x] HapticTab.tsx
+- [ ] ImageViewer.tsx
+- [x] Label.tsx
+- [ ] Labels.tsx
+- [ ] LanguageSelector.tsx
+- [ ] NotificationSettings.tsx
+- [ ] NotificationTest.tsx
+- [ ] ParallaxScrollView.tsx
+- [ ] PostCard.tsx
+- [ ] PostComposer.tsx
+- [ ] ProfileDropdown.tsx
+- [ ] ProfileEditModal.tsx
+- [ ] ProfileHeader.tsx
+- [ ] ProfileTabs.tsx
+- [x] RecordEmbed.tsx
+- [ ] ResponsiveLayout.tsx
+- [ ] RichText.tsx
+- [ ] RichTextWithFacets.tsx
+- [ ] SearchTabs.tsx
+- [ ] Sidebar.tsx
+- [ ] TabBadge.tsx
+- [ ] TabBar.tsx
+- [ ] ThemedCard.tsx
+- [x] ThemedFeatureCard.tsx
+- [ ] ThemedText.tsx
+- [ ] ThemedView.tsx
+- [ ] VideoEmbed.tsx
+- [ ] VideoPlayer.tsx
+- [ ] VideoPlayer.web.tsx
+- [ ] YouTubeEmbed.tsx
+- [ ] profile/FeedsTab.tsx
+- [ ] profile/LikesTab.tsx
+- [ ] profile/MediaTab.tsx
+- [ ] profile/PostsTab.tsx
+- [ ] profile/RepliesTab.tsx
+- [ ] profile/StarterpacksTab.tsx
+- [ ] profile/VideosTab.tsx
+- [ ] skeletons/ConversationSkeleton.tsx
+- [ ] skeletons/FeedSkeleton.tsx
+- [ ] skeletons/NotificationSkeleton.tsx
+- [ ] skeletons/PostCardSkeleton.tsx
+- [ ] skeletons/PostDetailSkeleton.tsx
+- [ ] skeletons/ProfileHeaderSkeleton.tsx
+- [ ] skeletons/SearchResultSkeleton.tsx
+- [ ] skeletons/SettingsSkeleton.tsx
+- [ ] ui/IconSymbol.ios.tsx
+- [ ] ui/IconSymbol.tsx
+- [ ] ui/Skeleton.tsx
+- [ ] ui/TabBarBackground.ios.tsx
+- [ ] ui/TabBarBackground.tsx
+- [ ] ui/withSkeleton.tsx

--- a/apps/akari/__tests__/components/HapticTab.test.tsx
+++ b/apps/akari/__tests__/components/HapticTab.test.tsx
@@ -1,0 +1,39 @@
+import { render } from '@testing-library/react-native';
+import * as Haptics from 'expo-haptics';
+
+const mockPressable = jest.fn(() => null);
+jest.mock('@react-navigation/elements', () => ({
+  PlatformPressable: (props: any) => {
+    mockPressable(props);
+    return null;
+  },
+}));
+
+import { HapticTab } from '@/components/HapticTab';
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  ImpactFeedbackStyle: { Light: 'light' },
+}));
+
+describe('HapticTab', () => {
+  const originalEnv = process.env.EXPO_OS;
+
+  afterEach(() => {
+    process.env.EXPO_OS = originalEnv;
+    jest.clearAllMocks();
+  });
+
+  it('triggers light haptic feedback on iOS press', () => {
+    process.env.EXPO_OS = 'ios';
+    const onTabPress = jest.fn();
+    const onPress = jest.fn();
+    render(<HapticTab onTabPress={onTabPress} onPress={onPress} />);
+    const props = mockPressable.mock.calls[0][0];
+    props.onPressIn({});
+    props.onPress({});
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Light);
+    expect(onTabPress).toHaveBeenCalled();
+    expect(onPress).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test covering HapticTab press behaviour
- track component test coverage in new checklist

## Testing
- `npm run test:coverage -- __tests__/components/HapticTab.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68c6d9d99348832b8e114acd23d97e26