### PR TITLE
test: add GifPicker component tests

### DIFF
--- a/COMPONENT_TESTS.md
+++ b/COMPONENT_TESTS.md
@@ -6,7 +6,7 @@ This checklist shows which components under `apps/akari/components` have tests.
 - [ ] ExternalEmbed.tsx
 - [x] ExternalLink.tsx
 - [ ] GifEmbed.tsx
-- [ ] GifPicker.tsx
+- [x] GifPicker.tsx
 - [ ] HandleHistoryModal.tsx
 - [x] HapticTab.tsx
 - [ ] ImageViewer.tsx

--- a/apps/akari/__tests__/components/GifPicker.test.tsx
+++ b/apps/akari/__tests__/components/GifPicker.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import { GifPicker } from '@/components/GifPicker';
+import { useThemeColor } from '@/hooks/useThemeColor';
+import { useTranslation } from '@/hooks/useTranslation';
+import { tenorApi, type TenorGif } from '@/utils/tenor';
+
+jest.mock('@/utils/tenor', () => ({
+  tenorApi: {
+    getTrendingGifs: jest.fn(),
+    searchGifs: jest.fn(),
+    convertGifToAttachedImage: jest.fn(),
+  },
+}));
+
+jest.mock('@/hooks/useThemeColor');
+jest.mock('@/hooks/useTranslation');
+jest.mock('expo-image', () => ({ Image: () => null }));
+jest.mock('@/components/ui/IconSymbol', () => ({ IconSymbol: () => null }));
+
+describe('GifPicker', () => {
+  const mockUseThemeColor = useThemeColor as jest.Mock;
+  const mockUseTranslation = useTranslation as jest.Mock;
+  const mockTenor = tenorApi as jest.Mocked<typeof tenorApi>;
+
+  const sampleGif: TenorGif = {
+    id: '1',
+    title: 'funny',
+    media_formats: {
+      gif: { url: 'https://example.com/1.gif', dims: [1, 1], size: 1 },
+    },
+    created: 0,
+    content_description: 'desc',
+    itemurl: 'item',
+    url: 'https://example.com/1.gif',
+    tags: [],
+    flags: [],
+    hasaudio: false,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseThemeColor.mockReturnValue('#000');
+    mockUseTranslation.mockReturnValue({ t: (key: string) => key });
+    mockTenor.getTrendingGifs.mockResolvedValue({ results: [sampleGif], next: undefined });
+    mockTenor.searchGifs.mockResolvedValue({ results: [sampleGif], next: undefined });
+    mockTenor.convertGifToAttachedImage.mockReturnValue({
+      uri: 'converted',
+      alt: 'alt',
+      mimeType: 'image/gif',
+      tenorId: '1',
+    });
+  });
+
+  it('loads trending GIFs and handles selection', async () => {
+    const onSelectGif = jest.fn();
+    const onClose = jest.fn();
+    const { findAllByRole } = render(
+      <GifPicker visible onClose={onClose} onSelectGif={onSelectGif} />,
+    );
+
+    await waitFor(() => expect(mockTenor.getTrendingGifs).toHaveBeenCalledWith(20));
+
+    const buttons = await findAllByRole('button');
+    fireEvent.press(buttons[1]);
+
+    expect(mockTenor.convertGifToAttachedImage).toHaveBeenCalledWith(sampleGif);
+    expect(onSelectGif).toHaveBeenCalledWith({
+      uri: 'converted',
+      alt: 'alt',
+      mimeType: 'image/gif',
+      tenorId: '1',
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('searches for GIFs on query input', async () => {
+    const { getByPlaceholderText } = render(
+      <GifPicker visible onClose={jest.fn()} onSelectGif={jest.fn()} />,
+    );
+
+    fireEvent.changeText(getByPlaceholderText('gif.searchPlaceholder'), 'cats');
+
+    await waitFor(() => expect(mockTenor.searchGifs).toHaveBeenCalledWith('cats', 20));
+  });
+
+  it('shows error message when trending load fails', async () => {
+    mockTenor.getTrendingGifs.mockRejectedValueOnce(new Error('fail'));
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { findByText } = render(
+      <GifPicker visible onClose={jest.fn()} onSelectGif={jest.fn()} />,
+    );
+
+    expect(await findByText('gif.apiError')).toBeTruthy();
+    consoleError.mockRestore();
+  });
+
+  it('calls onClose when cancel pressed', async () => {
+    const onClose = jest.fn();
+    const { findByRole } = render(
+      <GifPicker visible onClose={onClose} onSelectGif={jest.fn()} />,
+    );
+
+    const cancel = await findByRole('button', { name: 'common.cancel' });
+    fireEvent.press(cancel);
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/akari/components/GifPicker.tsx
+++ b/apps/akari/components/GifPicker.tsx
@@ -9,11 +9,11 @@ import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
 import { tenorApi, TenorGif } from '@/utils/tenor';
 
-interface GifPickerProps {
+type GifPickerProps = {
   visible: boolean;
   onClose: () => void;
   onSelectGif: (gif: { uri: string; alt: string; mimeType: string; tenorId?: string }) => void;
-}
+};
 
 export function GifPicker({ visible, onClose, onSelectGif }: GifPickerProps) {
   const { t } = useTranslation();
@@ -145,7 +145,13 @@ export function GifPicker({ visible, onClose, onSelectGif }: GifPickerProps) {
       }
 
       return (
-        <TouchableOpacity style={styles.gifItem} onPress={() => handleSelectGif(item)} activeOpacity={0.8}>
+        <TouchableOpacity
+          accessibilityRole="button"
+          accessibilityLabel={item.content_description || item.title || 'GIF'}
+          style={styles.gifItem}
+          onPress={() => handleSelectGif(item)}
+          activeOpacity={0.8}
+        >
           <Image
             source={{ uri: gifUrl }}
             style={styles.gifImage}
@@ -193,7 +199,7 @@ export function GifPicker({ visible, onClose, onSelectGif }: GifPickerProps) {
         <ThemedView style={[styles.container, { backgroundColor }]}>
           {/* Header */}
           <View style={[styles.header, { borderBottomColor: borderColor }]}>
-            <TouchableOpacity onPress={onClose} style={styles.headerButton}>
+            <TouchableOpacity accessibilityRole="button" onPress={onClose} style={styles.headerButton}>
               <ThemedText style={[styles.headerButtonText, { color: iconColor }]}>{t('common.cancel')}</ThemedText>
             </TouchableOpacity>
 


### PR DESCRIPTION
## Summary
- add comprehensive tests for GifPicker component
- improve GifPicker accessibility by declaring button roles
- mark GifPicker as tested in component checklist

## Testing
- `npm run test:coverage -w akari`


------
https://chatgpt.com/codex/tasks/task_e_68c6f1640410832bad273f0ae54a14f2