### PR TITLE
test: add coverage for storage and notifications utils

### DIFF
--- a/apps/akari/__tests__/utils/notifications.test.ts
+++ b/apps/akari/__tests__/utils/notifications.test.ts
@@ -1,0 +1,29 @@
+const mockSetBadgeCountAsync = jest.fn();
+const mockGetBadgeCountAsync = jest.fn();
+
+jest.mock('expo-notifications', () => ({
+  setNotificationHandler: jest.fn(),
+  setBadgeCountAsync: mockSetBadgeCountAsync,
+  getBadgeCountAsync: mockGetBadgeCountAsync,
+  AndroidImportance: { DEFAULT: 'default', HIGH: 'high', LOW: 'low' },
+}));
+
+describe('notifications utils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sets badge count', async () => {
+    const { setBadgeCount } = require('@/utils/notifications');
+    await setBadgeCount(5);
+    expect(mockSetBadgeCountAsync).toHaveBeenCalledWith(5);
+  });
+
+  it('gets badge count', async () => {
+    mockGetBadgeCountAsync.mockResolvedValueOnce(7);
+    const { getBadgeCount } = require('@/utils/notifications');
+    const count = await getBadgeCount();
+    expect(mockGetBadgeCountAsync).toHaveBeenCalled();
+    expect(count).toBe(7);
+  });
+});

--- a/apps/akari/__tests__/utils/secureStorage.test.ts
+++ b/apps/akari/__tests__/utils/secureStorage.test.ts
@@ -1,0 +1,43 @@
+const store: Record<string, string> = {};
+
+const mockGetString = jest.fn((key: string) => store[key]);
+const mockSet = jest.fn((key: string, value: string) => {
+  store[key] = value;
+});
+const mockDelete = jest.fn((key: string) => {
+  delete store[key];
+});
+
+jest.mock('react-native-mmkv', () => ({
+  MMKV: jest.fn(() => ({
+    getString: mockGetString,
+    set: mockSet,
+    delete: mockDelete,
+  })),
+}));
+
+describe('secureStorage', () => {
+  beforeEach(() => {
+    for (const key of Object.keys(store)) {
+      delete store[key];
+    }
+    mockGetString.mockClear();
+    mockSet.mockClear();
+    mockDelete.mockClear();
+  });
+
+  it('sets and retrieves items as JSON', () => {
+    const { storage } = require('@/utils/secureStorage');
+    storage.setItem('jwtToken', 'token');
+    expect(mockSet).toHaveBeenCalledWith('jwtToken', JSON.stringify('token'));
+    expect(storage.getItem('jwtToken')).toBe('token');
+  });
+
+  it('removes items from storage', () => {
+    const { storage } = require('@/utils/secureStorage');
+    storage.setItem('jwtToken', 'token');
+    storage.removeItem('jwtToken');
+    expect(mockDelete).toHaveBeenCalledWith('jwtToken');
+    expect(storage.getItem('jwtToken')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for secure storage wrapper
- add unit tests for notification badge helpers

## Testing
- `npm --workspace apps/akari run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68c6fba13954832baad2088ce609e7b9