### PR TITLE
test: add usePreferences hook tests

### DIFF
--- a/apps/akari/__tests__/hooks/queries/usePreferences.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/usePreferences.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { usePreferences } from '@/hooks/queries/usePreferences';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+  })),
+}));
+
+describe('usePreferences query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+  });
+
+  it('fetches user preferences', async () => {
+    const preferencesResponse = { preferences: [{ $type: 'test' }] };
+    mockGetPreferences.mockResolvedValue(preferencesResponse);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockGetPreferences).toHaveBeenCalledWith('token');
+    expect(result.current.data).toEqual(preferencesResponse);
+  });
+
+  it('throws error when token is missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+
+    const fetchResult = await result.current.refetch();
+    expect((fetchResult.error as Error).message).toBe('No access token');
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('throws error when PDS URL is missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: {} });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePreferences(), { wrapper });
+
+    const fetchResult = await result.current.refetch();
+    expect((fetchResult.error as Error).message).toBe('No PDS URL available');
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});
+

--- a/apps/akari/__tests__/hooks/queries/useSavedFeeds.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useSavedFeeds.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useSavedFeeds } from '@/hooks/queries/usePreferences';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useFeedGenerators } from '@/hooks/queries/useFeedGenerators';
+
+const mockGetPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useFeedGenerators', () => ({
+  useFeedGenerators: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+  })),
+}));
+
+describe('useSavedFeeds hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+  });
+
+  it('returns saved feeds with metadata', async () => {
+    mockGetPreferences.mockResolvedValue({
+      preferences: [
+        {
+          $type: 'app.bsky.actor.defs#savedFeedsPrefV2',
+          items: [
+            { type: 'timeline', value: 'timeline', pinned: false, id: '1' },
+            { type: 'feed', value: 'at://feed1', pinned: true, id: '2' },
+          ],
+        },
+      ],
+    });
+
+    (useFeedGenerators as jest.Mock).mockReturnValue({
+      data: { feeds: [{ uri: 'at://feed1', displayName: 'Feed 1' }] },
+      isLoading: false,
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSavedFeeds(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current).toEqual({
+      data: [
+        { type: 'timeline', value: 'timeline', pinned: false, id: '1', metadata: null },
+        {
+          type: 'feed',
+          value: 'at://feed1',
+          pinned: true,
+          id: '2',
+          metadata: { uri: 'at://feed1', displayName: 'Feed 1' },
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('returns empty list when preferences missing', async () => {
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    (useFeedGenerators as jest.Mock).mockReturnValue({
+      data: { feeds: [] },
+      isLoading: false,
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSavedFeeds(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current).toEqual({ data: [], isLoading: false, error: null });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for usePreferences query hook and error states
- add tests for useSavedFeeds to cover metadata merging and empty preferences

## Testing
- `npm run test:coverage -w akari`


------
https://chatgpt.com/codex/tasks/task_e_68c7d531bbf0832b909221f727a61d92