### PR TITLE
fix: replace language selector ids with a11y roles

### DIFF
--- a/apps/akari/__tests__/components/LanguageSelector.test.tsx
+++ b/apps/akari/__tests__/components/LanguageSelector.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render } from '@testing-library/react-native';
+import { Modal } from 'react-native';
 
 import { LanguageSelector } from '@/components/LanguageSelector';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -11,35 +12,119 @@ const mockUseTranslation = useTranslation as jest.Mock;
 const mockGetAvailableLocales = getAvailableLocales as jest.Mock;
 const mockGetTranslationData = getTranslationData as jest.Mock;
 
+const englishMetadata = {
+  language: 'English',
+  nativeName: 'English',
+  flag: '🇺🇸',
+};
+
+const spanishMetadata = {
+  language: 'Spanish',
+  nativeName: 'Español',
+  flag: '🇪🇸',
+};
+
 let changeLanguage: jest.Mock;
+
+const renderLanguageSelector = () => render(<LanguageSelector />);
 
 describe('LanguageSelector', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+
     changeLanguage = jest.fn();
     mockUseTranslation.mockReturnValue({
       t: (key: string) => key,
       currentLocale: 'en',
       changeLanguage,
     });
+
     mockGetAvailableLocales.mockReturnValue(['en', 'es']);
     mockGetTranslationData.mockImplementation((locale: string) =>
-      locale === 'en'
-        ? { language: 'English', nativeName: 'English', flag: '🇺🇸' }
-        : { language: 'Spanish', nativeName: 'Español', flag: '🇪🇸' },
+      locale === 'en' ? englishMetadata : spanishMetadata,
     );
   });
 
-  it('renders current language', () => {
-    const { getAllByText, getByText } = render(<LanguageSelector />);
-    expect(getAllByText('English').length).toBe(2);
-    expect(getByText('🇺🇸')).toBeTruthy();
+  it('renders the current language and highlights the selection', () => {
+    const view = renderLanguageSelector();
+
+    expect(view.getAllByText('English')).toHaveLength(2);
+    expect(view.getByText('🇺🇸')).toBeTruthy();
+
+    fireEvent.press(view.getByRole('button', { name: 'settings.language' }));
+    expect(view.getByRole('menu', { name: 'settings.language' })).toBeTruthy();
+    expect(view.getByText('✓')).toBeTruthy();
   });
 
-  it('allows selecting a different language', () => {
-    const { getByText } = render(<LanguageSelector />);
-    fireEvent.press(getByText('▼'));
-    fireEvent.press(getByText('Español'));
+  it('allows selecting a different language from the modal', () => {
+    const view = renderLanguageSelector();
+
+    fireEvent.press(view.getByRole('button', { name: 'settings.language' }));
+    fireEvent.press(view.getByText('Español'));
+
     expect(changeLanguage).toHaveBeenCalledWith('es');
+  });
+
+  it('falls back to the first language when the current locale is unavailable', () => {
+    mockUseTranslation.mockReturnValueOnce({
+      t: (key: string) => key,
+      currentLocale: 'fr',
+      changeLanguage,
+    });
+    mockGetAvailableLocales.mockReturnValueOnce(['es', 'en']);
+
+    const view = renderLanguageSelector();
+
+    expect(view.getAllByText('English')).toHaveLength(2);
+    expect(view.getByText('🇺🇸')).toBeTruthy();
+  });
+
+  it('filters out languages without complete metadata', () => {
+    mockGetTranslationData.mockImplementation((locale: string) =>
+      locale === 'en'
+        ? englishMetadata
+        : { language: 'Spanish', nativeName: 'Español' },
+    );
+
+    const view = renderLanguageSelector();
+
+    expect(view.getAllByText('English')).toHaveLength(2);
+    expect(view.queryByText('Español')).toBeNull();
+  });
+
+  it('logs a warning when translation metadata retrieval fails', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    mockGetTranslationData.mockImplementation((locale: string) => {
+      if (locale === 'es') {
+        throw new Error('boom');
+      }
+
+      return englishMetadata;
+    });
+
+    const { queryByText } = renderLanguageSelector();
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to get metadata for locale: es',
+      expect.any(Error),
+    );
+    expect(queryByText('Español')).toBeNull();
+
+    warnSpy.mockRestore();
+  });
+
+  it('closes the modal when dismissed from overlay press or request close', () => {
+    const view = renderLanguageSelector();
+
+    fireEvent.press(view.getByRole('button', { name: 'settings.language' }));
+    fireEvent.press(view.getByRole('button', { name: 'common.cancel' }));
+
+    expect(changeLanguage).not.toHaveBeenCalled();
+
+    const modal = view.UNSAFE_getByType(Modal);
+    fireEvent(modal, 'requestClose');
+
+    fireEvent.press(view.getByRole('button', { name: 'settings.language' }));
+    fireEvent(modal, 'requestClose');
   });
 });

--- a/apps/akari/components/LanguageSelector.tsx
+++ b/apps/akari/components/LanguageSelector.tsx
@@ -77,6 +77,8 @@ export const LanguageSelector = () => {
       <ThemedText style={styles.title}>{t("settings.language")}</ThemedText>
 
       <TouchableOpacity
+        accessibilityLabel={t("settings.language")}
+        accessibilityRole="button"
         style={styles.selector}
         onPress={() => setIsModalVisible(true)}
       >
@@ -101,11 +103,18 @@ export const LanguageSelector = () => {
         onRequestClose={() => setIsModalVisible(false)}
       >
         <TouchableOpacity
+          accessibilityLabel={t("common.cancel")}
+          accessibilityRole="button"
           style={styles.modalOverlay}
           activeOpacity={1}
           onPress={() => setIsModalVisible(false)}
         >
-          <ThemedView style={styles.modalContent}>
+          <ThemedView
+            accessible
+            accessibilityRole="menu"
+            accessibilityLabel={t("settings.language")}
+            style={styles.modalContent}
+          >
             <ThemedText style={styles.modalTitle}>
               {t("settings.language")}
             </ThemedText>
@@ -113,6 +122,10 @@ export const LanguageSelector = () => {
               {languages.map((language) => (
                 <TouchableOpacity
                   key={language.code}
+                  accessibilityRole="menuitem"
+                  accessibilityState={{
+                    selected: currentLocale === language.code,
+                  }}
                   style={[
                     styles.languageOption,
                     currentLocale === language.code && styles.selectedLanguage,


### PR DESCRIPTION
## Summary
- replace the LanguageSelector modal test IDs with accessible menu semantics and selection state
- ensure the LanguageSelector tests assert accessible menu and overlay roles alongside the existing metadata and dismissal flows

## Testing
- npx turbo run test --filter=akari -- --runTestsByPath __tests__/components/LanguageSelector.test.tsx
- npx jest --coverage --runTestsByPath __tests__/components/LanguageSelector.test.tsx
- npm run test:coverage *(fails: ConversationScreen > sends a message and clears input exceeds the 10000 ms timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68c89e1d1bdc832bbabd9c9319a8ae86