### PR TITLE
feat: add bookmarks endpoint support

### DIFF
--- a/packages/bluesky-api/src/api.ts
+++ b/packages/bluesky-api/src/api.ts
@@ -7,6 +7,7 @@ import { BlueskyGraph } from './graph';
 import { BlueskyNotifications } from './notifications';
 import { BlueskySearch } from './search';
 import type {
+  BlueskyBookmarksResponse,
   BlueskyConvosResponse,
   BlueskyFeed,
   BlueskyFeedResponse,
@@ -91,6 +92,14 @@ export class BlueskyApi extends BlueskyApiClient {
 
   async getFeedGenerators(accessJwt: string, feeds: string[]): Promise<{ feeds: BlueskyFeed[] }> {
     return this.feeds.getFeedGenerators(accessJwt, feeds);
+  }
+
+  async getBookmarks(
+    accessJwt: string,
+    limit: number = 50,
+    cursor?: string,
+  ): Promise<BlueskyBookmarksResponse> {
+    return this.feeds.getBookmarks(accessJwt, limit, cursor);
   }
 
   async getPost(accessJwt: string, uri: string): Promise<BlueskyPostView> {

--- a/packages/bluesky-api/src/feeds.test.ts
+++ b/packages/bluesky-api/src/feeds.test.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 
 import { BlueskyFeeds } from './feeds';
+import type { BlueskyBookmarksResponse } from './types';
 
 describe('BlueskyFeeds', () => {
   class MockFeeds extends BlueskyFeeds {
@@ -88,6 +89,36 @@ describe('BlueskyFeeds', () => {
   });
 
   afterAll(() => server.close());
+
+  it('fetches bookmarks with default parameters', async () => {
+    const feeds = new MockFeeds();
+    const response: BlueskyBookmarksResponse = { bookmarks: [] };
+    feeds.makeAuthenticatedRequestMock.mockResolvedValueOnce(response);
+
+    const result = await feeds.getBookmarks('jwt');
+
+    expect(result).toBe(response);
+    expect(feeds.makeAuthenticatedRequestMock).toHaveBeenCalledWith(
+      '/app.bsky.bookmark.getBookmarks',
+      'jwt',
+      { params: { limit: '50' } },
+    );
+  });
+
+  it('fetches bookmarks with custom limit and cursor', async () => {
+    const feeds = new MockFeeds();
+    const response: BlueskyBookmarksResponse = { bookmarks: [], cursor: 'next' };
+    feeds.makeAuthenticatedRequestMock.mockResolvedValueOnce(response);
+
+    const result = await feeds.getBookmarks('jwt', 25, 'cursor123');
+
+    expect(result).toBe(response);
+    expect(feeds.makeAuthenticatedRequestMock).toHaveBeenCalledWith(
+      '/app.bsky.bookmark.getBookmarks',
+      'jwt',
+      { params: { limit: '25', cursor: 'cursor123' } },
+    );
+  });
 
   it('returns a post from a thread response', async () => {
     const feeds = new MockFeeds();

--- a/packages/bluesky-api/src/feeds.ts
+++ b/packages/bluesky-api/src/feeds.ts
@@ -1,5 +1,6 @@
 import { BlueskyApiClient } from './client';
 import type {
+  BlueskyBookmarksResponse,
   BlueskyFeed,
   BlueskyFeedResponse,
   BlueskyFeedsResponse,
@@ -84,6 +85,31 @@ export class BlueskyFeeds extends BlueskyApiClient {
     };
 
     return this.makeAuthenticatedRequest<{ feeds: BlueskyFeed[] }>('/app.bsky.feed.getFeedGenerators', accessJwt, {
+      params,
+    });
+  }
+
+  /**
+   * Gets the authenticated user's bookmarked posts
+   * @param accessJwt - Valid access JWT token
+   * @param limit - Number of bookmarks to fetch (default: 50, max: 100)
+   * @param cursor - Pagination cursor
+   * @returns Promise resolving to bookmarks data
+   */
+  async getBookmarks(
+    accessJwt: string,
+    limit: number = 50,
+    cursor?: string,
+  ): Promise<BlueskyBookmarksResponse> {
+    const params: Record<string, string> = {
+      limit: limit.toString(),
+    };
+
+    if (cursor) {
+      params.cursor = cursor;
+    }
+
+    return this.makeAuthenticatedRequest<BlueskyBookmarksResponse>('/app.bsky.bookmark.getBookmarks', accessJwt, {
       params,
     });
   }

--- a/packages/bluesky-api/src/types.ts
+++ b/packages/bluesky-api/src/types.ts
@@ -447,6 +447,38 @@ export type BlueskyFeedResponse = {
 };
 
 /**
+ * Subject information for a bookmark
+ */
+export type BlueskyBookmarkSubject = {
+  /** The URI of the bookmarked record */
+  uri: string;
+  /** The CID of the bookmarked record */
+  cid: string;
+};
+
+/**
+ * Bluesky bookmark entry containing the bookmarked post and metadata
+ */
+export type BlueskyBookmark = {
+  /** When the bookmark was created */
+  createdAt: string;
+  /** The subject record information */
+  subject: BlueskyBookmarkSubject;
+  /** The bookmarked post */
+  item: BlueskyPostView;
+};
+
+/**
+ * Response from the getBookmarks endpoint
+ */
+export type BlueskyBookmarksResponse = {
+  /** Cursor for pagination */
+  cursor?: string;
+  /** Array of bookmarks */
+  bookmarks: BlueskyBookmark[];
+};
+
+/**
  * Bluesky feed generator response from the getFeeds endpoint
  */
 export type BlueskyFeed = {


### PR DESCRIPTION
## Summary
- add bookmark response types for Bluesky API
- expose getBookmarks helper on the feed and aggregate clients
- cover bookmark retrieval with unit tests

## Testing
- npm run test --workspace bluesky-api

------
https://chatgpt.com/codex/tasks/task_e_68c9ab9c60ec832b9933c50b1d6ad587