### PR TITLE
fix: navigate to profile when tapping post avatar

### DIFF
--- a/apps/akari/__tests__/components/PostCard.test.tsx
+++ b/apps/akari/__tests__/components/PostCard.test.tsx
@@ -77,8 +77,16 @@ describe('PostCard', () => {
   it('navigates to profile when handle pressed', () => {
     mockUseLikePost.mockReturnValue({ mutate: jest.fn() });
     const { getByRole } = render(<PostCard post={basePost} />);
-    const button = getByRole('button', { name: /view profile of Alice/i });
+    const button = getByRole('button', { name: 'View profile of Alice' });
     fireEvent.press(button);
+    expect(router.push).toHaveBeenCalledWith('/profile/alice');
+  });
+
+  it('navigates to profile when avatar pressed', () => {
+    mockUseLikePost.mockReturnValue({ mutate: jest.fn() });
+    const { getByRole } = render(<PostCard post={basePost} />);
+    const avatarButton = getByRole('button', { name: "View Alice's profile via avatar" });
+    fireEvent.press(avatarButton);
     expect(router.push).toHaveBeenCalledWith('/profile/alice');
   });
 

--- a/apps/akari/components/PostCard.tsx
+++ b/apps/akari/components/PostCard.tsx
@@ -79,6 +79,8 @@ export function PostCard({ post, onPress }: PostCardProps) {
   const { t } = useTranslation();
   const likeMutation = useLikePost();
 
+  const authorName = post.author.displayName || post.author.handle;
+
   const borderColor = useThemeColor(
     {
       light: '#e8eaed',
@@ -494,21 +496,28 @@ export function PostCard({ post, onPress }: PostCardProps) {
 
       <ThemedView style={styles.header}>
         <ThemedView style={styles.authorSection}>
-          <Image
-            source={{
-              uri: post.author.avatar || 'https://bsky.app/static/default-avatar.png',
-            }}
-            style={styles.authorAvatar}
-            contentFit="cover"
-            placeholder={require('@/assets/images/partial-react-logo.png')}
-          />
+          <TouchableOpacity
+            onPress={handleProfilePress}
+            activeOpacity={0.7}
+            accessibilityRole="button"
+            accessibilityLabel={`View ${authorName}'s profile via avatar`}
+          >
+            <Image
+              source={{
+                uri: post.author.avatar || 'https://bsky.app/static/default-avatar.png',
+              }}
+              style={styles.authorAvatar}
+              contentFit="cover"
+              placeholder={require('@/assets/images/partial-react-logo.png')}
+            />
+          </TouchableOpacity>
           <ThemedView style={styles.authorInfo}>
-            <ThemedText style={styles.displayName}>{post.author.displayName || post.author.handle}</ThemedText>
+            <ThemedText style={styles.displayName}>{authorName}</ThemedText>
             <TouchableOpacity
               onPress={handleProfilePress}
               activeOpacity={0.7}
               accessibilityRole="button"
-              accessibilityLabel={`View profile of ${post.author.displayName || post.author.handle}`}
+              accessibilityLabel={`View profile of ${authorName}`}
             >
               <ThemedText style={styles.handle}>@{post.author.handle}</ThemedText>
             </TouchableOpacity>
@@ -599,7 +608,7 @@ export function PostCard({ post, onPress }: PostCardProps) {
           onPress={handleReplyPress}
           activeOpacity={0.7}
           accessibilityRole="button"
-          accessibilityLabel={`Reply to post by ${post.author.displayName || post.author.handle}`}
+          accessibilityLabel={`Reply to post by ${authorName}`}
         >
           <IconSymbol name="bubble.left" size={16} color={iconColor} style={styles.interactionIcon} />
           <ThemedText style={styles.interactionCount}>{post.commentCount || 0}</ThemedText>
@@ -615,8 +624,8 @@ export function PostCard({ post, onPress }: PostCardProps) {
           accessibilityRole="button"
           accessibilityLabel={
             post.viewer?.like
-              ? `Unlike post by ${post.author.displayName || post.author.handle}`
-              : `Like post by ${post.author.displayName || post.author.handle}`
+              ? `Unlike post by ${authorName}`
+              : `Like post by ${authorName}`
           }
         >
           <IconSymbol


### PR DESCRIPTION
## Summary
- make post avatars navigate to the author profile using the existing handler
- update author-related accessibility labels to share a common helper
- add a regression test covering avatar presses

## Testing
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68c9eabacad4832bb4ce069187a6d951