### PR TITLE
fix: localize pending chat labels

### DIFF
--- a/apps/akari/translations/ar.json
+++ b/apps/akari/translations/ar.json
@@ -57,8 +57,8 @@
       "saving": "جاري الحفظ...",
       "mute": "كتم الصوت",
       "unmute": "إلغاء كتم الصوت",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "الدردشات المعلقة",
+      "viewPendingChats": "عرض الدردشات المعلقة"
     },
     "auth": {
       "fillAllFields": "يرجى ملء جميع الحقول",

--- a/apps/akari/translations/cy.json
+++ b/apps/akari/translations/cy.json
@@ -57,8 +57,8 @@
       "saving": "Cadw...",
       "mute": "Tewi",
       "unmute": "Ailgychwyn Sain",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "Sgyrsiau ar y gweill",
+      "viewPendingChats": "Gweld sgyrsiau ar y gweill"
     },
     "auth": {
       "fillAllFields": "Llenwch bob maes",

--- a/apps/akari/translations/de.json
+++ b/apps/akari/translations/de.json
@@ -57,8 +57,8 @@
       "saving": "Speichern...",
       "mute": "Stumm",
       "unmute": "Stummschaltung aufheben",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "Ausstehende Chats",
+      "viewPendingChats": "Ausstehende Chats anzeigen"
     },
     "auth": {
       "fillAllFields": "Bitte fülle alle Felder aus",

--- a/apps/akari/translations/es.json
+++ b/apps/akari/translations/es.json
@@ -57,8 +57,8 @@
       "saving": "Guardando...",
       "mute": "Silenciar",
       "unmute": "Activar sonido",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "Chats pendientes",
+      "viewPendingChats": "Ver chats pendientes"
     },
     "auth": {
       "fillAllFields": "Por favor completa todos los campos",

--- a/apps/akari/translations/fr.json
+++ b/apps/akari/translations/fr.json
@@ -57,8 +57,8 @@
       "saving": "Enregistrement...",
       "mute": "Muet",
       "unmute": "Activer le son",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "Discussions en attente",
+      "viewPendingChats": "Voir les discussions en attente"
     },
     "auth": {
       "fillAllFields": "Veuillez remplir tous les champs",

--- a/apps/akari/translations/hi.json
+++ b/apps/akari/translations/hi.json
@@ -57,8 +57,8 @@
       "saving": "सहेज रहा है...",
       "mute": "म्यूट",
       "unmute": "म्यूट हटाएं",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "लंबित चैट्स",
+      "viewPendingChats": "लंबित चैट्स देखें"
     },
     "auth": {
       "fillAllFields": "कृपया सभी फ़ील्ड भरें",

--- a/apps/akari/translations/id.json
+++ b/apps/akari/translations/id.json
@@ -57,8 +57,8 @@
       "saving": "Menyimpan...",
       "mute": "Bisukan",
       "unmute": "Aktifkan Suara",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "Obrolan tertunda",
+      "viewPendingChats": "Lihat obrolan tertunda"
     },
     "auth": {
       "fillAllFields": "Silakan isi semua kolom",

--- a/apps/akari/translations/it.json
+++ b/apps/akari/translations/it.json
@@ -57,8 +57,8 @@
       "saving": "Salvataggio...",
       "mute": "Silenzia",
       "unmute": "Riattiva audio",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "Chat in sospeso",
+      "viewPendingChats": "Vedi le chat in sospeso"
     },
     "auth": {
       "fillAllFields": "Compila tutti i campi",

--- a/apps/akari/translations/ja.json
+++ b/apps/akari/translations/ja.json
@@ -57,8 +57,8 @@
       "saving": "保存中...",
       "mute": "ミュート",
       "unmute": "ミュート解除",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "保留中のチャット",
+      "viewPendingChats": "保留中のチャットを表示"
     },
     "auth": {
       "fillAllFields": "すべてのフィールドを入力してください",

--- a/apps/akari/translations/ko.json
+++ b/apps/akari/translations/ko.json
@@ -57,8 +57,8 @@
       "saving": "저장 중...",
       "mute": "음소거",
       "unmute": "음소거 해제",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "보류 중인 채팅",
+      "viewPendingChats": "보류 중인 채팅 보기"
     },
     "auth": {
       "fillAllFields": "모든 필드를 입력해주세요",

--- a/apps/akari/translations/nl.json
+++ b/apps/akari/translations/nl.json
@@ -57,8 +57,8 @@
       "saving": "Opslaan...",
       "mute": "Dempen",
       "unmute": "Dempen opheffen",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "Openstaande chats",
+      "viewPendingChats": "Openstaande chats bekijken"
     },
     "auth": {
       "fillAllFields": "Vul alle velden in",

--- a/apps/akari/translations/pl.json
+++ b/apps/akari/translations/pl.json
@@ -57,8 +57,8 @@
       "saving": "Zapisywanie...",
       "mute": "Wycisz",
       "unmute": "Włącz dźwięk",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "Oczekujące czaty",
+      "viewPendingChats": "Zobacz oczekujące czaty"
     },
     "auth": {
       "fillAllFields": "Wypełnij wszystkie pola",

--- a/apps/akari/translations/pt.json
+++ b/apps/akari/translations/pt.json
@@ -57,8 +57,8 @@
       "saving": "Salvando...",
       "mute": "Silenciar",
       "unmute": "Ativar som",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "Conversas pendentes",
+      "viewPendingChats": "Ver conversas pendentes"
     },
     "auth": {
       "fillAllFields": "Preencha todos os campos",

--- a/apps/akari/translations/ru.json
+++ b/apps/akari/translations/ru.json
@@ -57,8 +57,8 @@
       "saving": "Сохранение...",
       "mute": "Отключить звук",
       "unmute": "Включить звук",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "Ожидающие чаты",
+      "viewPendingChats": "Просмотреть ожидающие чаты"
     },
     "auth": {
       "fillAllFields": "Заполните все поля",

--- a/apps/akari/translations/th.json
+++ b/apps/akari/translations/th.json
@@ -57,8 +57,8 @@
       "saving": "กำลังบันทึก...",
       "mute": "ปิดเสียง",
       "unmute": "เปิดเสียง",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "แชทที่รอดำเนินการ",
+      "viewPendingChats": "ดูแชทที่รอดำเนินการ"
     },
     "auth": {
       "fillAllFields": "กรุณากรอกทุกช่อง",

--- a/apps/akari/translations/tr.json
+++ b/apps/akari/translations/tr.json
@@ -57,8 +57,8 @@
       "saving": "Kaydediliyor...",
       "mute": "Sessiz",
       "unmute": "Sesi Aç",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "Bekleyen sohbetler",
+      "viewPendingChats": "Bekleyen sohbetleri görüntüle"
     },
     "auth": {
       "fillAllFields": "Lütfen tüm alanları doldurun",

--- a/apps/akari/translations/vi.json
+++ b/apps/akari/translations/vi.json
@@ -57,8 +57,8 @@
       "saving": "Đang lưu...",
       "mute": "Tắt tiếng",
       "unmute": "Bật tiếng",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "Cuộc trò chuyện đang chờ",
+      "viewPendingChats": "Xem các cuộc trò chuyện đang chờ"
     },
     "auth": {
       "fillAllFields": "Vui lòng điền tất cả các trường",

--- a/apps/akari/translations/zh-CN.json
+++ b/apps/akari/translations/zh-CN.json
@@ -57,8 +57,8 @@
       "saving": "保存中...",
       "mute": "静音",
       "unmute": "取消静音",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "待处理聊天",
+      "viewPendingChats": "查看待处理聊天"
     },
     "auth": {
       "fillAllFields": "请填写所有字段",

--- a/apps/akari/translations/zh-TW.json
+++ b/apps/akari/translations/zh-TW.json
@@ -57,8 +57,8 @@
       "saving": "儲存中...",
       "mute": "靜音",
       "unmute": "取消靜音",
-      "pendingChats": "Pending chats",
-      "viewPendingChats": "View pending chats"
+      "pendingChats": "待處理聊天",
+      "viewPendingChats": "查看待處理聊天"
     },
     "auth": {
       "fillAllFields": "請填寫所有欄位",


### PR DESCRIPTION
## Summary
- translate the pending chat labels in every non-English locale file
- ensure the new locale strings for pending chats appear in each language

## Testing
- not run (localization updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d074798f78832bb7a857b191595c99