### PR TITLE
ci: skip workflows for docs-only changes

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,6 +1,12 @@
 name: preview
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.mdx'
+      - 'docs/**'
+      - '**/docs/**'
 
 jobs:
   update:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,11 @@ name: test
 
 on:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.mdx'
+      - 'docs/**'
+      - '**/docs/**'
 
 jobs:
   coverage:

--- a/.github/workflows/translation-validation.yml
+++ b/.github/workflows/translation-validation.yml
@@ -2,6 +2,11 @@ name: translation-validation
 
 on:
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.mdx'
+      - 'docs/**'
+      - '**/docs/**'
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary
- update the preview, test, and translation workflows to ignore pull requests that only touch docs files

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d15fd95464832b861f2c11df84fd09