### PR TITLE
refactor: migrate bookmarks tab to virtualized list

### DIFF
--- a/apps/akari/app/(tabs)/bookmarks.tsx
+++ b/apps/akari/app/(tabs)/bookmarks.tsx
@@ -1,24 +1,25 @@
 import { router } from 'expo-router';
 import React, { useEffect, useRef } from 'react';
-import { FlatList, RefreshControl, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import type { BlueskyBookmark } from '@/bluesky-api';
 import { PostCard } from '@/components/PostCard';
+import { VirtualizedList, type VirtualizedListHandle } from '@/components/ui/VirtualizedList';
 import { FeedSkeleton } from '@/components/skeletons';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { useBookmarks } from '@/hooks/queries/useBookmarks';
-import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
 import { tabScrollRegistry } from '@/utils/tabScrollRegistry';
 import { formatRelativeTime } from '@/utils/timeUtils';
 
+const ESTIMATED_POST_CARD_HEIGHT = 320;
+
 export default function BookmarksScreen() {
   const insets = useSafeAreaInsets();
   const { t } = useTranslation();
-  const flatListRef = useRef<FlatList<BlueskyBookmark>>(null);
-  const refreshTintColor = useThemeColor({ light: '#000000', dark: '#ffffff' }, 'text');
+  const flatListRef = useRef<VirtualizedListHandle<BlueskyBookmark>>(null);
 
   const scrollToTop = () => {
     flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
@@ -98,7 +99,7 @@ export default function BookmarksScreen() {
 
   return (
     <ThemedView style={[styles.container, { paddingTop: insets.top }]}>
-      <FlatList
+      <VirtualizedList
         ref={flatListRef}
         data={bookmarks}
         keyExtractor={(item) => `${item.subject.uri}-${item.createdAt}`}
@@ -108,15 +109,11 @@ export default function BookmarksScreen() {
           styles.listContent,
           bookmarks.length === 0 ? styles.emptyListContent : null,
         ]}
-        refreshControl={
-          <RefreshControl
-            refreshing={isRefetching}
-            onRefresh={handleRefresh}
-            tintColor={refreshTintColor}
-          />
-        }
+        refreshing={isRefetching}
+        onRefresh={handleRefresh}
         onEndReached={handleLoadMore}
         onEndReachedThreshold={0.5}
+        estimatedItemSize={ESTIMATED_POST_CARD_HEIGHT}
         ListHeaderComponent={
           <ThemedView style={styles.header}>
             <ThemedText style={styles.title}>{t('common.bookmarks')}</ThemedText>

--- a/virtualized-list-migration.md
+++ b/virtualized-list-migration.md
@@ -15,7 +15,7 @@ The FlashList-backed `VirtualizedList` component in `apps/akari/components/ui/Vi
   - Replace the `FlatList`/`useRef<FlatList>` pair with `VirtualizedList` and `VirtualizedListHandle<SearchResult>`.
   - FlashList expects `refreshing`/`onRefresh` props rather than a `RefreshControl` element—rework pull-to-refresh accordingly.
   - Supply an `estimatedItemSize` that balances profile and post rows, and keep the tab scroll registry hook working.
-- [ ] `apps/akari/app/(tabs)/bookmarks.tsx`
+- [x] `apps/akari/app/(tabs)/bookmarks.tsx`
   - Use `VirtualizedList` instead of `FlatList`, updating the ref type to `VirtualizedListHandle<BlueskyBookmark>`.
   - Convert the `RefreshControl` usage to FlashList-style refreshing and ensure header/footer/empty states render through the wrapper.
   - Choose an `estimatedItemSize` that matches a `PostCard` to keep overscan tight.


### PR DESCRIPTION
## Summary
- swap the bookmarks tab to the shared VirtualizedList component and remove the bespoke RefreshControl usage
- tune the list configuration with a VirtualizedListHandle ref, pull-to-refresh props, and a PostCard-sized estimated item height
- tick the bookmarks entry in the virtualized list migration tracker

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1d6e372d8832b9f33cda3fe7f40e6