### PR TITLE
refactor: migrate messages handle to VirtualizedList

### DIFF
--- a/apps/akari/app/(tabs)/messages/[handle].tsx
+++ b/apps/akari/app/(tabs)/messages/[handle].tsx
@@ -1,7 +1,7 @@
 import { Image } from 'expo-image';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useEffect, useState } from 'react';
-import { FlatList, Keyboard, KeyboardAvoidingView, Platform, StyleSheet, TextInput, TouchableOpacity } from 'react-native';
+import { Keyboard, KeyboardAvoidingView, Platform, StyleSheet, TextInput, TouchableOpacity } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { BlueskyEmbed } from '@/bluesky-api';
@@ -13,6 +13,7 @@ import { RecordEmbed } from '@/components/RecordEmbed';
 import { VideoEmbed } from '@/components/VideoEmbed';
 import { YouTubeEmbed } from '@/components/YouTubeEmbed';
 import { IconSymbol } from '@/components/ui/IconSymbol';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
 import { useSendMessage } from '@/hooks/mutations/useSendMessage';
 import { useConversations } from '@/hooks/queries/useConversations';
 import { useMessages } from '@/hooks/queries/useMessages';
@@ -22,6 +23,8 @@ import { useTranslation } from '@/hooks/useTranslation';
 import { showAlert } from '@/utils/alert';
 
 const PLACEHOLDER_IMAGE = require('@/assets/images/partial-react-logo.png');
+
+const ESTIMATED_MESSAGE_HEIGHT = 160; // balances standard bubbles and media embeds
 
 type RecordEmbedData = Parameters<typeof RecordEmbed>[0]['embed'];
 type ExternalEmbedData = Parameters<typeof ExternalEmbed>[0]['embed'];
@@ -518,7 +521,7 @@ export default function ConversationScreen() {
               <ThemedText style={styles.loadingText}>Loading messages...</ThemedText>
             </ThemedView>
           ) : (
-            <FlatList
+            <VirtualizedList
               data={messages}
               renderItem={renderMessage}
               keyExtractor={(item) => item.id}
@@ -526,9 +529,10 @@ export default function ConversationScreen() {
               contentContainerStyle={styles.messagesContent}
               showsVerticalScrollIndicator={false}
               onEndReached={handleLoadMore}
-              onEndReachedThreshold={0.5}
+              onEndReachedThreshold={0.2}
               ListFooterComponent={renderFooter}
               inverted={true} // Show newest messages at the bottom
+              estimatedItemSize={ESTIMATED_MESSAGE_HEIGHT}
             />
           )}
 

--- a/virtualized-list-migration.md
+++ b/virtualized-list-migration.md
@@ -7,7 +7,7 @@ The FlashList-backed `VirtualizedList` component in `apps/akari/components/ui/Vi
   - Replace the `FlatList` import with `VirtualizedList` and update `flatListRef` to `React.useRef<VirtualizedListHandle<Conversation>>`.
   - Pass an `estimatedItemSize` that matches the conversation row height and keep `overscan` conservative so the request list stays responsive.
   - Verify `tabScrollRegistry`'s scroll-to-top helper still works and that footer/empty states render correctly after the swap.
-- [ ] `apps/akari/app/(tabs)/messages/[handle].tsx`
+- [x] `apps/akari/app/(tabs)/messages/[handle].tsx`
   - Swap the conversation `FlatList` for `VirtualizedList`, keeping `inverted` pagination behaviour intact.
   - Provide an `estimatedItemSize` for message bubbles and confirm the `ListFooterComponent` continues to show the loading indicator while paging.
   - Re-check `onEndReachedThreshold` against FlashList's behaviour so we do not over-fetch.


### PR DESCRIPTION
## Summary
- swap the messages handle screen to the shared VirtualizedList and keep inverted pagination behaviour intact
- provide an estimated message height and lower onEndReached threshold to suit FlashList heuristics

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d1e1972624832ba6464022e3878cbe