### PR TITLE
fix: migrate replies tab to virtualized list

### DIFF
--- a/apps/akari/components/profile/RepliesTab.tsx
+++ b/apps/akari/components/profile/RepliesTab.tsx
@@ -1,7 +1,8 @@
 import { router } from 'expo-router';
-import { FlatList, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 
 import { PostCard } from '@/components/PostCard';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { FeedSkeleton } from '@/components/skeletons';
@@ -12,6 +13,8 @@ import { formatRelativeTime } from '@/utils/timeUtils';
 type RepliesTabProps = {
   handle: string;
 };
+
+const ESTIMATED_POST_CARD_HEIGHT = 320;
 
 export function RepliesTab({ handle }: RepliesTabProps) {
   const { t } = useTranslation();
@@ -88,7 +91,7 @@ export function RepliesTab({ handle }: RepliesTabProps) {
   const filteredReplies = replies.filter((item) => item && item.uri);
 
   return (
-    <FlatList
+    <VirtualizedList
       data={filteredReplies}
       renderItem={renderItem}
       keyExtractor={(item) => `${item.uri}-${item.indexedAt}`}
@@ -98,6 +101,7 @@ export function RepliesTab({ handle }: RepliesTabProps) {
       showsVerticalScrollIndicator={false}
       scrollEnabled={false}
       style={styles.flatList}
+      estimatedItemSize={ESTIMATED_POST_CARD_HEIGHT}
       accessibilityRole="list"
       accessible
     />

--- a/virtualized-list-migration.md
+++ b/virtualized-list-migration.md
@@ -30,7 +30,7 @@ The FlashList-backed `VirtualizedList` component in `apps/akari/components/ui/Vi
 - [x] `apps/akari/components/profile/LikesTab.tsx`
   - Move to `VirtualizedList` with an appropriate `estimatedItemSize` and maintain the non-scrollable embedding inside parent tabs.
   - Re-test pagination and footer rendering.
-- [ ] `apps/akari/components/profile/RepliesTab.tsx`
+- [x] `apps/akari/components/profile/RepliesTab.tsx`
   - Replace `FlatList` usage, add an `estimatedItemSize`, and ensure the component still exposes an accessible list role (tests rely on `getByRole('list')`).
   - Double-check `onEndReached` throttling so mutation hooks do not fire repeatedly.
 - [ ] `apps/akari/components/profile/VideosTab.tsx`


### PR DESCRIPTION
## Summary
- migrate the profile replies tab to use the shared VirtualizedList component with an estimated PostCard height
- keep accessibility role coverage while updating the migration tracker checklist

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d1e3a0b5c4832b9ef2d4d975da0413