### PR TITLE
refactor: migrate videos tab to VirtualizedList

### DIFF
--- a/apps/akari/components/profile/VideosTab.tsx
+++ b/apps/akari/components/profile/VideosTab.tsx
@@ -1,7 +1,8 @@
 import { router } from 'expo-router';
-import { FlatList, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 
 import { PostCard } from '@/components/PostCard';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { FeedSkeleton } from '@/components/skeletons';
@@ -12,6 +13,8 @@ import { formatRelativeTime } from '@/utils/timeUtils';
 type VideosTabProps = {
   handle: string;
 };
+
+const ESTIMATED_VIDEO_POST_CARD_HEIGHT = 360;
 
 export function VideosTab({ handle }: VideosTabProps) {
   const { t } = useTranslation();
@@ -88,7 +91,7 @@ export function VideosTab({ handle }: VideosTabProps) {
   const filteredVideos = videos.filter((item) => item && item.uri);
 
   return (
-    <FlatList
+    <VirtualizedList
       data={filteredVideos}
       renderItem={renderItem}
       keyExtractor={(item) => `${item.uri}-${item.indexedAt}`}
@@ -98,6 +101,7 @@ export function VideosTab({ handle }: VideosTabProps) {
       showsVerticalScrollIndicator={false}
       scrollEnabled={false}
       style={styles.flatList}
+      estimatedItemSize={ESTIMATED_VIDEO_POST_CARD_HEIGHT}
     />
   );
 }

--- a/virtualized-list-migration.md
+++ b/virtualized-list-migration.md
@@ -33,7 +33,7 @@ The FlashList-backed `VirtualizedList` component in `apps/akari/components/ui/Vi
 - [x] `apps/akari/components/profile/RepliesTab.tsx`
   - Replace `FlatList` usage, add an `estimatedItemSize`, and ensure the component still exposes an accessible list role (tests rely on `getByRole('list')`).
   - Double-check `onEndReached` throttling so mutation hooks do not fire repeatedly.
-- [ ] `apps/akari/components/profile/VideosTab.tsx`
+- [x] `apps/akari/components/profile/VideosTab.tsx`
   - Switch to `VirtualizedList`, provide media-appropriate sizing, and maintain the existing non-scrollable behaviour.
   - Validate the loading footer and empty states once FlashList is in place.
 - [ ] `apps/akari/components/profile/FeedsTab.tsx`


### PR DESCRIPTION
## Summary
- swap the profile videos tab to the shared FlashList-backed VirtualizedList with an estimated post card height
- mark the videos tab item as complete in the virtualized list migration tracker

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d1e503d568832bbdc6c96c5e113dbc