### PR TITLE
test: migrate messages index test to VirtualizedList

### DIFF
--- a/virtualized-list-migration.md
+++ b/virtualized-list-migration.md
@@ -53,7 +53,7 @@ The FlashList-backed `VirtualizedList` component in `apps/akari/components/ui/Vi
   - Verify the divider styling still renders between items when FlashList virtualizes them.
 
 ## Tests
-- [ ] `apps/akari/__tests__/app/tabs/messages-index.test.tsx`
+- [x] `apps/akari/__tests__/app/tabs/messages-index.test.tsx`
   - Update the test to render and inspect `VirtualizedList` instead of `FlatList`, including scroll-to-top assertions.
 - [ ] `apps/akari/__tests__/app/tabs/messages-handle.test.tsx`
   - Adjust imports and `UNSAFE_getByType` calls to point at `VirtualizedList`, and confirm inverted pagination continues to trigger `onEndReached`.


### PR DESCRIPTION
## Summary
- update the messages tab test to assert against the VirtualizedList API and expose the scrollToOffset ref
- render list content in a FlashList mock so existing expectations continue to pass
- tick the migration checklist entry for the messages index test

## Testing
- npm run lint -- --filter=akari
- npm run test -- --runTestsByPath __tests__/app/tabs/messages-index.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d1e7ba6104832b926020f53101c272