### PR TITLE
refactor: migrate profile FeedsTab to VirtualizedList

### DIFF
--- a/apps/akari/components/profile/FeedsTab.tsx
+++ b/apps/akari/components/profile/FeedsTab.tsx
@@ -1,9 +1,10 @@
-import { FlatList, StyleSheet, TouchableOpacity } from 'react-native';
+import { StyleSheet, TouchableOpacity } from 'react-native';
 
 import { FeedSkeleton } from '@/components/skeletons';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { IconSymbol } from '@/components/ui/IconSymbol';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
 import { useAuthorFeeds } from '@/hooks/queries/useAuthorFeeds';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -16,6 +17,8 @@ type FeedsTabProps = {
 type FeedItemProps = {
   feed: BlueskyFeed;
 };
+
+const ESTIMATED_FEED_CARD_HEIGHT = 180;
 
 function FeedItem({ feed }: FeedItemProps) {
   const backgroundColor = useThemeColor({ light: '#ffffff', dark: '#1c1c1e' }, 'background');
@@ -99,7 +102,7 @@ export function FeedsTab({ handle }: FeedsTabProps) {
   }
 
   return (
-    <FlatList
+    <VirtualizedList
       data={feeds}
       renderItem={renderItem}
       keyExtractor={(item) => item.uri}
@@ -109,6 +112,7 @@ export function FeedsTab({ handle }: FeedsTabProps) {
       showsVerticalScrollIndicator={false}
       scrollEnabled={false}
       style={styles.flatList}
+      estimatedItemSize={ESTIMATED_FEED_CARD_HEIGHT}
     />
   );
 }

--- a/virtualized-list-migration.md
+++ b/virtualized-list-migration.md
@@ -36,7 +36,7 @@ The FlashList-backed `VirtualizedList` component in `apps/akari/components/ui/Vi
 - [x] `apps/akari/components/profile/VideosTab.tsx`
   - Switch to `VirtualizedList`, provide media-appropriate sizing, and maintain the existing non-scrollable behaviour.
   - Validate the loading footer and empty states once FlashList is in place.
-- [ ] `apps/akari/components/profile/FeedsTab.tsx`
+- [x] `apps/akari/components/profile/FeedsTab.tsx`
   - Use `VirtualizedList` for the author feed list, taking care with custom cards and `scrollEnabled={false}`.
   - Provide an `estimatedItemSize` and make sure the `IconSymbol` interactions remain accessible.
 - [ ] `apps/akari/components/profile/StarterpacksTab.tsx`


### PR DESCRIPTION
## Summary
- replace the profile feeds tab FlatList with VirtualizedList and provide an estimated card size
- update the migration checklist to mark the feeds tab as complete

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d1ea18e714832ba987afe04b620f65