### PR TITLE
refactor: migrate gif picker and tests to virtualized list

### DIFF
--- a/apps/akari/__tests__/app/tabs/messages-handle.test.tsx
+++ b/apps/akari/__tests__/app/tabs/messages-handle.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react-native';
-import { FlatList, Keyboard, KeyboardAvoidingView, Platform, StyleSheet, TouchableOpacity } from 'react-native';
+import { Keyboard, KeyboardAvoidingView, Platform, StyleSheet, TouchableOpacity } from 'react-native';
 
 import ConversationScreen from '@/app/(tabs)/messages/[handle]';
 import { router, useLocalSearchParams } from 'expo-router';
@@ -11,6 +11,9 @@ import { useBorderColor } from '@/hooks/useBorderColor';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
 import { showAlert } from '@/utils/alert';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
+
+jest.mock('@shopify/flash-list', () => require('../../../test-utils/flash-list'));
 
 jest.mock('expo-image', () => {
   const { Image } = require('react-native');
@@ -210,7 +213,7 @@ describe('ConversationScreen', () => {
     const { getByText, UNSAFE_getByType } = render(<ConversationScreen />);
     expect(getByText('common.loading common.messages...')).toBeTruthy();
     act(() => {
-      UNSAFE_getByType(FlatList).props.onEndReached();
+      UNSAFE_getByType(VirtualizedList).props.onEndReached();
     });
     expect(fetchNextPage).not.toHaveBeenCalled();
   });
@@ -231,7 +234,7 @@ describe('ConversationScreen', () => {
 
     const { UNSAFE_getByType } = render(<ConversationScreen />);
     act(() => {
-      UNSAFE_getByType(FlatList).props.onEndReached();
+      UNSAFE_getByType(VirtualizedList).props.onEndReached();
     });
     expect(fetchNextPage).toHaveBeenCalled();
   });

--- a/apps/akari/__tests__/app/tabs/messages-index.test.tsx
+++ b/apps/akari/__tests__/app/tabs/messages-index.test.tsx
@@ -9,58 +9,9 @@ import { useConversations } from '@/hooks/queries/useConversations';
 import { useBorderColor } from '@/hooks/useBorderColor';
 import { useTranslation } from '@/hooks/useTranslation';
 import { VirtualizedList } from '@/components/ui/VirtualizedList';
+import { mockScrollToOffset } from '../../../test-utils/flash-list';
 
-const mockScrollToOffset = jest.fn();
-
-jest.mock('@shopify/flash-list', () => {
-  const React = require('react');
-  const { View } = require('react-native');
-
-  return {
-    FlashList: React.forwardRef((props: any, ref) => {
-      const {
-        data = [],
-        renderItem,
-        ListEmptyComponent,
-        ListFooterComponent,
-        ListHeaderComponent,
-        keyExtractor,
-      } = props;
-
-      React.useImperativeHandle(ref, () => ({
-        scrollToOffset: mockScrollToOffset,
-      }));
-
-      const renderSupplemental = (component: any) => {
-        if (!component) {
-          return null;
-        }
-
-        return typeof component === 'function' ? component() : component;
-      };
-
-      const items =
-        renderItem && data.length > 0
-          ? data.map((item: any, index: number) => {
-              const rendered = renderItem({ item, index });
-              const key = keyExtractor ? keyExtractor(item, index) : index;
-
-              return <React.Fragment key={key}>{rendered}</React.Fragment>;
-            })
-          : null;
-
-      const shouldShowEmpty = data.length === 0 && ListEmptyComponent;
-
-      return (
-        <View>
-          {renderSupplemental(ListHeaderComponent)}
-          {shouldShowEmpty ? renderSupplemental(ListEmptyComponent) : items}
-          {renderSupplemental(ListFooterComponent)}
-        </View>
-      );
-    }),
-  };
-});
+jest.mock('@shopify/flash-list', () => require('../../../test-utils/flash-list'));
 
 jest.mock('expo-image', () => {
   const { Image } = require('react-native');

--- a/apps/akari/__tests__/app/tabs/messages-pending.test.tsx
+++ b/apps/akari/__tests__/app/tabs/messages-pending.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render } from '@testing-library/react-native';
-import { FlatList, TouchableOpacity } from 'react-native';
+import { TouchableOpacity } from 'react-native';
 
 import PendingMessagesScreen from '@/app/(tabs)/messages/pending';
 import { router } from 'expo-router';
@@ -8,6 +8,9 @@ import { tabScrollRegistry } from '@/utils/tabScrollRegistry';
 import { useConversations } from '@/hooks/queries/useConversations';
 import { useBorderColor } from '@/hooks/useBorderColor';
 import { useTranslation } from '@/hooks/useTranslation';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
+
+jest.mock('@shopify/flash-list', () => require('../../../test-utils/flash-list'));
 
 jest.mock('expo-image', () => {
   const { Image } = require('react-native');
@@ -83,14 +86,16 @@ describe('PendingMessagesScreen', () => {
       isFetchingNextPage: false,
     });
 
-    const { getByText, queryByText, UNSAFE_getAllByType, UNSAFE_getByType } = render(<PendingMessagesScreen />);
+    const { getByText, queryByText, UNSAFE_getAllByType, UNSAFE_getByType } = render(
+      <PendingMessagesScreen />,
+    );
 
     expect(mockUseConversations).toHaveBeenCalled();
     const [, , status] = mockUseConversations.mock.calls[0];
     expect(status).toBe('request');
 
     expect(mockRegister).toHaveBeenCalledWith('messages', expect.any(Function));
-    expect(UNSAFE_getByType(FlatList).props.ListFooterComponent()).toBeNull();
+    expect(UNSAFE_getByType(VirtualizedList).props.ListFooterComponent()).toBeNull();
     expect(getByText('common.pendingChats')).toBeTruthy();
     expect(getByText('Pending Pal')).toBeTruthy();
     expect(getByText('common.pending')).toBeTruthy();

--- a/apps/akari/__tests__/app/tabs/search.test.tsx
+++ b/apps/akari/__tests__/app/tabs/search.test.tsx
@@ -9,6 +9,8 @@ import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
 import { VirtualizedList } from '@/components/ui/VirtualizedList';
 
+jest.mock('@shopify/flash-list', () => require('../../../test-utils/flash-list'));
+
 jest.mock('expo-image', () => {
   const { Image } = require('react-native');
   return { Image };

--- a/apps/akari/__tests__/components/FeedsTab.test.tsx
+++ b/apps/akari/__tests__/components/FeedsTab.test.tsx
@@ -1,11 +1,11 @@
 import { fireEvent, render } from '@testing-library/react-native';
-import { FlatList } from 'react-native';
 
 import { FeedsTab } from '@/components/profile/FeedsTab';
 import { useAuthorFeeds } from '@/hooks/queries/useAuthorFeeds';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
 import type { BlueskyFeed } from '@/bluesky-api';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
 
 jest.mock('@/hooks/queries/useAuthorFeeds');
 jest.mock('@/hooks/useThemeColor');
@@ -15,6 +15,8 @@ jest.mock('@/components/skeletons', () => {
   return { FeedSkeleton: () => <Text testID="feed-skeleton" /> };
 });
 jest.mock('@/components/ui/IconSymbol', () => ({ IconSymbol: () => null }));
+
+jest.mock('@shopify/flash-list', () => require('../../test-utils/flash-list'));
 
 const mockUseAuthorFeeds = useAuthorFeeds as jest.Mock;
 const mockUseThemeColor = useThemeColor as jest.Mock;
@@ -81,7 +83,7 @@ describe('FeedsTab', () => {
     expect(getByText('5 likes')).toBeTruthy();
     expect(getByText('Interactive')).toBeTruthy();
 
-    const list = UNSAFE_getByType(FlatList);
+    const list = UNSAFE_getByType(VirtualizedList);
     fireEvent(list, 'onEndReached');
     expect(fetchNextPage).toHaveBeenCalled();
   });

--- a/apps/akari/__tests__/components/GifPicker.test.tsx
+++ b/apps/akari/__tests__/components/GifPicker.test.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
-import { FlatList } from 'react-native';
 
 import { GifPicker } from '@/components/GifPicker';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
 import { tenorApi } from '@/utils/tenor';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
 
 jest.mock('@/utils/tenor', () => ({
   tenorApi: {
@@ -19,6 +19,7 @@ jest.mock('@/hooks/useThemeColor');
 jest.mock('@/hooks/useTranslation');
 jest.mock('expo-image', () => ({ Image: () => null }));
 jest.mock('@/components/ui/IconSymbol', () => ({ IconSymbol: () => null }));
+jest.mock('@shopify/flash-list', () => require('../../test-utils/flash-list'));
 
 describe('GifPicker', () => {
   const mockUseThemeColor = useThemeColor as jest.Mock;
@@ -150,7 +151,7 @@ describe('GifPicker', () => {
 
     await waitFor(() => expect(mockTenor.getTrendingGifs).toHaveBeenCalledTimes(1));
 
-    const list = UNSAFE_getByType(FlatList);
+    const list = UNSAFE_getByType(VirtualizedList);
     fireEvent(list, 'onEndReached');
 
     await waitFor(() => expect(mockTenor.getTrendingGifs).toHaveBeenCalledWith(20, 'next'));
@@ -172,7 +173,7 @@ describe('GifPicker', () => {
     fireEvent.changeText(getByPlaceholderText('gif.searchPlaceholder'), 'cats');
     await waitFor(() => expect(mockTenor.searchGifs).toHaveBeenCalledWith('cats', 20));
 
-    const list = UNSAFE_getByType(FlatList);
+    const list = UNSAFE_getByType(VirtualizedList);
     fireEvent(list, 'onEndReached');
 
     await waitFor(() =>
@@ -192,7 +193,7 @@ describe('GifPicker', () => {
 
     await waitFor(() => expect(mockTenor.getTrendingGifs).toHaveBeenCalledTimes(1));
 
-    fireEvent(UNSAFE_getByType(FlatList), 'onEndReached');
+    fireEvent(UNSAFE_getByType(VirtualizedList), 'onEndReached');
 
     await waitFor(() =>
       expect(consoleError).toHaveBeenCalledWith('Failed to load more GIFs:', expect.any(Error)),

--- a/apps/akari/__tests__/components/profile/FeedsTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/FeedsTab.test.tsx
@@ -1,10 +1,11 @@
 import { act, fireEvent, render } from '@testing-library/react-native';
-import { FlatList, Text } from 'react-native';
+import { Text } from 'react-native';
 
 import { FeedsTab } from '@/components/profile/FeedsTab';
 import { useAuthorFeeds } from '@/hooks/queries/useAuthorFeeds';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
 
 jest.mock('@/hooks/queries/useAuthorFeeds');
 
@@ -21,6 +22,8 @@ jest.mock('@/components/ui/IconSymbol', () => {
   const { Text } = require('react-native');
   return { IconSymbol: ({ name }: { name: string }) => <Text>{name}</Text> };
 });
+
+jest.mock('@shopify/flash-list', () => require('../../../test-utils/flash-list'));
 
 const mockUseAuthorFeeds = useAuthorFeeds as jest.Mock;
 const mockUseTranslation = useTranslation as jest.Mock;
@@ -102,7 +105,7 @@ describe('FeedsTab', () => {
     logSpy.mockRestore();
 
     act(() => {
-      UNSAFE_getByType(FlatList).props.onEndReached();
+      UNSAFE_getByType(VirtualizedList).props.onEndReached();
     });
     expect(fetchNextPage).toHaveBeenCalled();
   });
@@ -127,7 +130,7 @@ describe('FeedsTab', () => {
     const { getByText, UNSAFE_getByType } = render(<FeedsTab handle="alice" />);
     expect(getByText('common.loading')).toBeTruthy();
     act(() => {
-      UNSAFE_getByType(FlatList).props.onEndReached();
+      UNSAFE_getByType(VirtualizedList).props.onEndReached();
     });
     expect(fetchNextPage).not.toHaveBeenCalled();
   });
@@ -151,7 +154,7 @@ describe('FeedsTab', () => {
 
     const { UNSAFE_getByType } = render(<FeedsTab handle="alice" />);
     act(() => {
-      UNSAFE_getByType(FlatList).props.onEndReached();
+      UNSAFE_getByType(VirtualizedList).props.onEndReached();
     });
     expect(fetchNextPage).not.toHaveBeenCalled();
   });

--- a/apps/akari/__tests__/components/profile/LikesTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/LikesTab.test.tsx
@@ -1,10 +1,11 @@
 import { act, fireEvent, render } from '@testing-library/react-native';
-import { Text, FlatList } from 'react-native';
+import { Text } from 'react-native';
 import { router } from 'expo-router';
 
 import { LikesTab } from '@/components/profile/LikesTab';
 import { useAuthorLikes } from '@/hooks/queries/useAuthorLikes';
 import { useTranslation } from '@/hooks/useTranslation';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
 
 jest.mock('@/hooks/queries/useAuthorLikes');
 jest.mock('@/hooks/useTranslation');
@@ -13,6 +14,7 @@ jest.mock('expo-router', () => ({
     push: jest.fn(),
   },
 }));
+jest.mock('@shopify/flash-list', () => require('../../../test-utils/flash-list'));
 jest.mock('@/components/skeletons', () => {
   const React = require('react');
   const { Text } = require('react-native');
@@ -113,7 +115,7 @@ describe('LikesTab', () => {
     fireEvent.press(getByText('liked post'));
     expect(router.push).toHaveBeenCalledWith(`/post/${encodeURIComponent(like.uri)}`);
 
-    const list = UNSAFE_getByType(FlatList);
+    const list = UNSAFE_getByType(VirtualizedList);
     act(() => {
       list.props.onEndReached();
     });
@@ -133,7 +135,7 @@ describe('LikesTab', () => {
     const { getByText, UNSAFE_getByType } = render(<LikesTab handle="tester" />);
     expect(getByText('common.loading')).toBeTruthy();
 
-    const list = UNSAFE_getByType(FlatList);
+    const list = UNSAFE_getByType(VirtualizedList);
     act(() => {
       list.props.onEndReached();
     });

--- a/apps/akari/__tests__/components/profile/MediaTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/MediaTab.test.tsx
@@ -5,6 +5,8 @@ import { VirtualizedList } from '@/components/ui/VirtualizedList';
 import { useAuthorMedia } from '@/hooks/queries/useAuthorMedia';
 import { router } from 'expo-router';
 
+jest.mock('@shopify/flash-list', () => require('../../../test-utils/flash-list'));
+
 jest.mock('@/hooks/queries/useAuthorMedia');
 jest.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => ({ t: (k: string) => k }),

--- a/apps/akari/__tests__/components/profile/PostsTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/PostsTab.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, render } from '@testing-library/react-native';
-import { FlatList } from 'react-native';
 
 let mockPostCard: jest.Mock;
 
@@ -29,12 +28,14 @@ jest.mock('@/hooks/queries/useAuthorPosts');
 jest.mock('@/hooks/useTranslation');
 jest.mock('@/hooks/useThemeColor');
 jest.mock('expo-router', () => ({ router: { push: jest.fn() } }));
+jest.mock('@shopify/flash-list', () => require('../../../test-utils/flash-list'));
 
 import { PostsTab } from '@/components/profile/PostsTab';
 import { useAuthorPosts } from '@/hooks/queries/useAuthorPosts';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
 import { router } from 'expo-router';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
 
 describe('PostsTab', () => {
   const mockUseAuthorPosts = useAuthorPosts as jest.Mock;
@@ -126,7 +127,7 @@ describe('PostsTab', () => {
 
     const { UNSAFE_getByType } = render(<PostsTab handle="alice" />);
     act(() => {
-      UNSAFE_getByType(FlatList).props.onEndReached();
+      UNSAFE_getByType(VirtualizedList).props.onEndReached();
     });
     expect(fetchNextPage).toHaveBeenCalled();
   });
@@ -144,7 +145,7 @@ describe('PostsTab', () => {
     const { getByText, UNSAFE_getByType } = render(<PostsTab handle="alice" />);
     expect(getByText('common.loading')).toBeTruthy();
     act(() => {
-      UNSAFE_getByType(FlatList).props.onEndReached();
+      UNSAFE_getByType(VirtualizedList).props.onEndReached();
     });
     expect(fetchNextPage).not.toHaveBeenCalled();
   });

--- a/apps/akari/__tests__/components/profile/StarterpacksTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/StarterpacksTab.test.tsx
@@ -1,10 +1,11 @@
 import { act, render } from '@testing-library/react-native';
-import { FlatList, Text } from 'react-native';
+import { Text } from 'react-native';
 
 import { StarterpacksTab } from '@/components/profile/StarterpacksTab';
 import { useAuthorStarterpacks } from '@/hooks/queries/useAuthorStarterpacks';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
 
 jest.mock('@/hooks/queries/useAuthorStarterpacks');
 jest.mock('@/hooks/useThemeColor');
@@ -13,6 +14,7 @@ jest.mock('@/components/skeletons', () => {
   const { Text } = require('react-native');
   return { FeedSkeleton: () => <Text>feed skeleton</Text> };
 });
+jest.mock('@shopify/flash-list', () => require('../../../test-utils/flash-list'));
 
 const mockUseAuthorStarterpacks = useAuthorStarterpacks as jest.Mock;
 const mockUseThemeColor = useThemeColor as jest.Mock;
@@ -88,7 +90,7 @@ describe('StarterpacksTab', () => {
     expect(queryByText('common.loading')).toBeNull();
 
     act(() => {
-      UNSAFE_getByType(FlatList).props.onEndReached();
+      UNSAFE_getByType(VirtualizedList).props.onEndReached();
     });
 
     expect(fetchNextPage).toHaveBeenCalled();
@@ -157,7 +159,7 @@ describe('StarterpacksTab', () => {
 
     const { UNSAFE_getByType } = render(<StarterpacksTab handle="alice" />);
     act(() => {
-      UNSAFE_getByType(FlatList).props.onEndReached();
+      UNSAFE_getByType(VirtualizedList).props.onEndReached();
     });
     expect(fetchNextPage).not.toHaveBeenCalled();
   });

--- a/apps/akari/__tests__/components/profile/VideosTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/VideosTab.test.tsx
@@ -1,16 +1,18 @@
 import { act, fireEvent, render } from '@testing-library/react-native';
-import { FlatList, Text } from 'react-native';
+import { Text } from 'react-native';
 
 import { VideosTab } from '@/components/profile/VideosTab';
 import { useAuthorVideos } from '@/hooks/queries/useAuthorVideos';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
 import { router } from 'expo-router';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
 
 jest.mock('@/hooks/queries/useAuthorVideos');
 jest.mock('@/hooks/useThemeColor');
 jest.mock('@/hooks/useTranslation');
 jest.mock('expo-router', () => ({ router: { push: jest.fn() } }));
+jest.mock('@shopify/flash-list', () => require('../../../test-utils/flash-list'));
 
 let mockPostCard: jest.Mock;
 jest.mock('@/components/PostCard', () => {
@@ -120,7 +122,7 @@ describe('VideosTab', () => {
     });
 
     const { UNSAFE_getByType } = render(<VideosTab handle="alice" />);
-    const list = UNSAFE_getByType(FlatList);
+    const list = UNSAFE_getByType(VirtualizedList);
     act(() => {
       list.props.onEndReached();
     });
@@ -164,7 +166,7 @@ describe('VideosTab', () => {
     });
 
     const { UNSAFE_getByType } = render(<VideosTab handle="alice" />);
-    const list = UNSAFE_getByType(FlatList);
+    const list = UNSAFE_getByType(VirtualizedList);
     act(() => {
       list.props.onEndReached();
     });

--- a/apps/akari/components/GifPicker.tsx
+++ b/apps/akari/components/GifPicker.tsx
@@ -1,10 +1,11 @@
 import { Image } from 'expo-image';
 import React, { useCallback, useEffect, useState } from 'react';
-import { ActivityIndicator, FlatList, Modal, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
+import { ActivityIndicator, Modal, StyleSheet, TextInput, TouchableOpacity, View } from 'react-native';
 
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { IconSymbol } from '@/components/ui/IconSymbol';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
 import { useToast } from '@/contexts/ToastContext';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -16,6 +17,8 @@ type GifPickerProps = {
   onClose: () => void;
   onSelectGif: (gif: { uri: string; alt: string; mimeType: string; tenorId?: string }) => void;
 };
+
+const ESTIMATED_GIF_ITEM_SIZE = 140;
 
 export function GifPicker({ visible, onClose, onSelectGif }: GifPickerProps) {
   const { t } = useTranslation();
@@ -244,7 +247,7 @@ export function GifPicker({ visible, onClose, onSelectGif }: GifPickerProps) {
           </View>
 
           {/* GIF Grid */}
-          <FlatList
+          <VirtualizedList
             data={gifs}
             renderItem={renderGifItem}
             keyExtractor={(item) => item.id}
@@ -255,6 +258,7 @@ export function GifPicker({ visible, onClose, onSelectGif }: GifPickerProps) {
             onEndReachedThreshold={0.5}
             ListFooterComponent={renderFooter}
             ListEmptyComponent={renderEmpty}
+            estimatedItemSize={ESTIMATED_GIF_ITEM_SIZE}
           />
         </ThemedView>
       </ThemedView>

--- a/apps/akari/test-utils/flash-list.tsx
+++ b/apps/akari/test-utils/flash-list.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { View } from 'react-native';
+
+export const mockScrollToOffset = jest.fn();
+
+type SupplementalComponent =
+  | React.ReactElement
+  | React.ComponentType
+  | (() => React.ReactNode)
+  | null
+  | undefined;
+
+function renderSupplemental(component: SupplementalComponent) {
+  if (!component) {
+    return null;
+  }
+
+  if (typeof component === 'function') {
+    const Component = component as () => React.ReactNode;
+    return <React.Fragment>{Component()}</React.Fragment>;
+  }
+
+  if (React.isValidElement(component)) {
+    return component;
+  }
+
+  const Component = component as React.ComponentType;
+  return <Component />;
+}
+
+export const FlashList = React.forwardRef<any, any>((props, ref) => {
+  const {
+    data = [],
+    renderItem,
+    ListEmptyComponent,
+    ListFooterComponent,
+    ListHeaderComponent,
+    keyExtractor,
+    style,
+  } = props;
+
+  React.useImperativeHandle(ref, () => ({
+    scrollToOffset: mockScrollToOffset,
+  }));
+
+  const typedData = Array.isArray(data) ? data : [];
+
+  const items =
+    renderItem && typedData.length > 0
+      ? typedData.map((item: any, index: number) => {
+          const rendered = renderItem({ item, index });
+          const key = keyExtractor ? keyExtractor(item, index) : index;
+
+          return <React.Fragment key={key}>{rendered}</React.Fragment>;
+        })
+      : null;
+
+  const shouldShowEmpty = typedData.length === 0 && ListEmptyComponent;
+
+  return (
+    <View style={style}>
+      {renderSupplemental(ListHeaderComponent)}
+      {shouldShowEmpty ? renderSupplemental(ListEmptyComponent) : items}
+      {renderSupplemental(ListFooterComponent)}
+    </View>
+  );
+});
+
+FlashList.displayName = 'FlashList';

--- a/virtualized-list-migration.md
+++ b/virtualized-list-migration.md
@@ -44,7 +44,7 @@ The FlashList-backed `VirtualizedList` component in `apps/akari/components/ui/Vi
   - Confirm pagination, footer, and empty state behaviour after the migration.
 
 ## Shared components
-- [ ] `apps/akari/components/GifPicker.tsx`
+- [x] `apps/akari/components/GifPicker.tsx`
   - Swap the GIF grid to `VirtualizedList`, keeping `numColumns`, `ListFooterComponent`, and `ListEmptyComponent` working.
   - FlashList needs an `estimatedItemSize` for grid tiles—base it on the GIF thumbnail height.
   - Re-run the infinite scroll logic to ensure `onEndReached` continues to request additional Tenor pages.
@@ -55,27 +55,27 @@ The FlashList-backed `VirtualizedList` component in `apps/akari/components/ui/Vi
 ## Tests
 - [x] `apps/akari/__tests__/app/tabs/messages-index.test.tsx`
   - Update the test to render and inspect `VirtualizedList` instead of `FlatList`, including scroll-to-top assertions.
-- [ ] `apps/akari/__tests__/app/tabs/messages-handle.test.tsx`
+- [x] `apps/akari/__tests__/app/tabs/messages-handle.test.tsx`
   - Adjust imports and `UNSAFE_getByType` calls to point at `VirtualizedList`, and confirm inverted pagination continues to trigger `onEndReached`.
-- [ ] `apps/akari/__tests__/app/tabs/messages-pending.test.tsx`
+- [x] `apps/akari/__tests__/app/tabs/messages-pending.test.tsx`
   - Point list queries at `VirtualizedList` and make sure pending state footers still render via the wrapper.
-- [ ] `apps/akari/__tests__/app/tabs/search.test.tsx`
+- [x] `apps/akari/__tests__/app/tabs/search.test.tsx`
   - Update mocks and queries to use `VirtualizedList`, and adapt refresh assertions to the new `refreshing`/`onRefresh` API.
-- [ ] `apps/akari/__tests__/components/profile/PostsTab.test.tsx`
+- [x] `apps/akari/__tests__/components/profile/PostsTab.test.tsx`
   - Replace the `FlatList` import, update `UNSAFE_getByType` references, and keep pagination tests working with FlashList.
-- [ ] `apps/akari/__tests__/components/profile/MediaTab.test.tsx`
+- [x] `apps/akari/__tests__/components/profile/MediaTab.test.tsx`
   - Point assertions at `VirtualizedList` and verify loading footer expectations.
-- [ ] `apps/akari/__tests__/components/profile/LikesTab.test.tsx`
+- [x] `apps/akari/__tests__/components/profile/LikesTab.test.tsx`
   - Update the list component under test to `VirtualizedList` and adjust any scroll/pagination mocks.
-- [ ] `apps/akari/__tests__/components/profile/VideosTab.test.tsx`
+- [x] `apps/akari/__tests__/components/profile/VideosTab.test.tsx`
   - Swap to `VirtualizedList` assertions and ensure pagination events still fire.
-- [ ] `apps/akari/__tests__/components/profile/StarterpacksTab.test.tsx`
+- [x] `apps/akari/__tests__/components/profile/StarterpacksTab.test.tsx`
   - Update imports and `UNSAFE_getByType` usage, keeping footer expectations intact.
-- [ ] `apps/akari/__tests__/components/profile/FeedsTab.test.tsx`
+- [x] `apps/akari/__tests__/components/profile/FeedsTab.test.tsx`
   - Point the test at `VirtualizedList` so end-reached assertions continue to pass.
-- [ ] `apps/akari/__tests__/components/FeedsTab.test.tsx`
+- [x] `apps/akari/__tests__/components/FeedsTab.test.tsx`
   - Update component queries to account for `VirtualizedList` and confirm `onEndReached` firing.
-- [ ] `apps/akari/__tests__/components/GifPicker.test.tsx`
+- [x] `apps/akari/__tests__/components/GifPicker.test.tsx`
   - Use `VirtualizedList` in place of `FlatList`, adjust grid assertions, and keep `onEndReached` events wired up.
 
 Once each item is migrated, re-run the relevant Jest suites to confirm FlashList behaves the same as the legacy `FlatList` implementations.


### PR DESCRIPTION
## Summary
- add a shared FlashList-based VirtualizedList test utility
- migrate GifPicker to use the VirtualizedList component with an estimated tile size
- update messaging and profile test suites (and checklist) to rely on the shared mock

## Testing
- npm run lint -- --filter=akari
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d1eefb8ff0832b8a5bbf44f6df9438