### PR TITLE
fix: use react query caching for saved feeds

### DIFF
--- a/apps/akari/__tests__/hooks/queries/useSavedFeeds.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useSavedFeeds.test.tsx
@@ -5,9 +5,10 @@ import { renderHook, waitFor } from '@testing-library/react-native';
 import { useSavedFeeds } from '@/hooks/queries/usePreferences';
 import { useJwtToken } from '@/hooks/queries/useJwtToken';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
-import { useFeedGenerators } from '@/hooks/queries/useFeedGenerators';
+import type { SavedFeedWithMetadata } from '@/types/savedFeed';
 
 const mockGetPreferences = jest.fn();
+const mockGetFeedGenerators = jest.fn();
 
 jest.mock('@/hooks/queries/useJwtToken', () => ({
   useJwtToken: jest.fn(),
@@ -17,17 +18,14 @@ jest.mock('@/hooks/queries/useCurrentAccount', () => ({
   useCurrentAccount: jest.fn(),
 }));
 
-jest.mock('@/hooks/queries/useFeedGenerators', () => ({
-  useFeedGenerators: jest.fn(),
-}));
-
 jest.mock('@/bluesky-api', () => ({
   BlueskyApi: jest.fn(() => ({
     getPreferences: mockGetPreferences,
+    getFeedGenerators: mockGetFeedGenerators,
   })),
 }));
 
-describe('useSavedFeeds hook', () => {
+describe('useSavedFeeds query', () => {
   const createWrapper = () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -35,16 +33,18 @@ describe('useSavedFeeds hook', () => {
     const wrapper = ({ children }: { children: React.ReactNode }) => (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     );
-    return { wrapper };
+    return { queryClient, wrapper };
   };
 
   beforeEach(() => {
     jest.clearAllMocks();
     (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
-    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:example:123' },
+    });
   });
 
-  it('returns saved feeds with metadata', async () => {
+  it('fetches saved feeds with metadata and caches result', async () => {
     mockGetPreferences.mockResolvedValue({
       preferences: [
         {
@@ -57,49 +57,81 @@ describe('useSavedFeeds hook', () => {
       ],
     });
 
-    (useFeedGenerators as jest.Mock).mockReturnValue({
-      data: { feeds: [{ uri: 'at://feed1', displayName: 'Feed 1' }] },
-      isLoading: false,
+    mockGetFeedGenerators.mockResolvedValue({
+      feeds: [{ uri: 'at://feed1', displayName: 'Feed 1' }],
     });
 
-    const { wrapper } = createWrapper();
+    const { queryClient, wrapper } = createWrapper();
     const { result } = renderHook(() => useSavedFeeds(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(result.current).toEqual({
-      data: [
-        { type: 'timeline', value: 'timeline', pinned: false, id: '1', metadata: null },
-        {
-          type: 'feed',
-          value: 'at://feed1',
-          pinned: true,
-          id: '2',
-          metadata: { uri: 'at://feed1', displayName: 'Feed 1' },
-        },
-      ],
-      isLoading: false,
-      error: null,
-    });
+    const expectedData: SavedFeedWithMetadata[] = [
+      { type: 'timeline', value: 'timeline', pinned: false, id: '1', metadata: null },
+      {
+        type: 'feed',
+        value: 'at://feed1',
+        pinned: true,
+        id: '2',
+        metadata: { uri: 'at://feed1', displayName: 'Feed 1' },
+      },
+    ];
+
+    expect(result.current.data).toEqual(expectedData);
+    expect(queryClient.getQueryData(['savedFeeds', 'did:example:123'])).toEqual(expectedData);
+    expect(mockGetPreferences).toHaveBeenCalledTimes(1);
+    expect(mockGetFeedGenerators).toHaveBeenCalledWith('token', ['at://feed1']);
   });
 
-  it('returns empty list when preferences missing', async () => {
+  it('returns empty array when no saved feeds are configured', async () => {
     mockGetPreferences.mockResolvedValue({ preferences: [] });
-    (useFeedGenerators as jest.Mock).mockReturnValue({
-      data: { feeds: [] },
-      isLoading: false,
-    });
 
     const { wrapper } = createWrapper();
     const { result } = renderHook(() => useSavedFeeds(), { wrapper });
 
     await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
+      expect(result.current.isSuccess).toBe(true);
     });
 
-    expect(result.current).toEqual({ data: [], isLoading: false, error: null });
+    expect(result.current.data).toEqual([]);
+    expect(mockGetFeedGenerators).not.toHaveBeenCalled();
+  });
+
+  it('retains cached data when refetch fails', async () => {
+    mockGetPreferences.mockResolvedValue({
+      preferences: [
+        {
+          $type: 'app.bsky.actor.defs#savedFeedsPrefV2',
+          items: [{ type: 'feed', value: 'at://feed1', pinned: false, id: 'cached' }],
+        },
+      ],
+    });
+
+    mockGetFeedGenerators.mockResolvedValue({
+      feeds: [{ uri: 'at://feed1', displayName: 'Feed 1' }],
+    });
+
+    const { queryClient, wrapper } = createWrapper();
+    const { result } = renderHook(() => useSavedFeeds(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const cachedData = result.current.data;
+
+    mockGetPreferences.mockRejectedValueOnce(new Error('Network error'));
+    mockGetFeedGenerators.mockRejectedValueOnce(new Error('Network error'));
+
+    await queryClient.removeQueries({ queryKey: ['preferences'] });
+    await queryClient.removeQueries({ queryKey: ['feedGenerators'] });
+
+    const refetchResult = await result.current.refetch();
+
+    expect(refetchResult.error).toBeInstanceOf(Error);
+    expect(result.current.data).toEqual(cachedData);
   });
 });
 

--- a/apps/akari/types/savedFeed.ts
+++ b/apps/akari/types/savedFeed.ts
@@ -1,0 +1,5 @@
+import type { BlueskyFeed, BlueskySavedFeedItem } from '@/bluesky-api';
+
+export type SavedFeedWithMetadata = BlueskySavedFeedItem & {
+  metadata: BlueskyFeed | null;
+};


### PR DESCRIPTION
## Summary
- reuse React Query query options for preferences and feed generators and drop manual secure storage fallback
- expose a saved feeds query that uses the query client cache to hydrate metadata when network calls succeed
- update saved feed tests to validate cached data reuse when refetch attempts fail

## Testing
- npm run lint -- --filter=akari
- npm run test -- -- --runTestsByPath __tests__/hooks/queries/useSavedFeeds.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d1f3dada60832bbc97f21e64952cc6