### PR TITLE
feat: highlight live streams on post card

### DIFF
--- a/apps/akari/__tests__/components/PostCard.test.tsx
+++ b/apps/akari/__tests__/components/PostCard.test.tsx
@@ -18,6 +18,7 @@ import { PostCard } from '@/components/PostCard';
 import { useLikePost } from '@/hooks/mutations/useLikePost';
 import { usePostTranslation } from '@/hooks/mutations/usePostTranslation';
 import { useLibreTranslateLanguages } from '@/hooks/queries/useLibreTranslateLanguages';
+import { useLiveNow } from '@/hooks/queries/useLiveNow';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
 import { router } from 'expo-router';
@@ -25,6 +26,7 @@ import { router } from 'expo-router';
 jest.mock('@/hooks/mutations/useLikePost');
 jest.mock('@/hooks/mutations/usePostTranslation');
 jest.mock('@/hooks/queries/useLibreTranslateLanguages');
+jest.mock('@/hooks/queries/useLiveNow');
 jest.mock('@/hooks/useThemeColor');
 jest.mock('@/hooks/useTranslation');
 jest.mock('expo-router', () => ({ router: { push: jest.fn() } }));
@@ -66,7 +68,7 @@ const YouTubeEmbedMock = require('@/components/YouTubeEmbed').YouTubeEmbed as je
 type Post = {
   id: string;
   text?: string;
-  author: { handle: string; displayName?: string; avatar?: string };
+  author: { did: string; handle: string; displayName?: string; avatar?: string };
   createdAt: string;
   likeCount?: number;
   commentCount?: number;
@@ -84,6 +86,7 @@ describe('PostCard', () => {
   const mockUseLikePost = useLikePost as jest.Mock;
   const mockUsePostTranslation = usePostTranslation as jest.Mock;
   const mockUseLibreTranslateLanguages = useLibreTranslateLanguages as jest.Mock;
+  const mockUseLiveNow = useLiveNow as jest.Mock;
   const mockUseThemeColor = useThemeColor as jest.Mock;
   const mockUseTranslation = useTranslation as jest.Mock;
   let mutateAsyncMock: jest.Mock;
@@ -91,7 +94,7 @@ describe('PostCard', () => {
   const basePost: Post = {
     id: '1',
     text: 'Hello world',
-    author: { handle: 'alice', displayName: 'Alice' },
+    author: { did: 'did:plc:alice', handle: 'alice', displayName: 'Alice' },
     createdAt: '2024-01-01',
     likeCount: 0,
     commentCount: 0,
@@ -109,6 +112,7 @@ describe('PostCard', () => {
       changeLanguage: jest.fn(),
       availableLocales: ['en'],
     });
+    mockUseLiveNow.mockReturnValue({ data: [], isLoading: false });
     mutateAsyncMock = jest
       .fn()
       .mockImplementation(async ({ targetLanguage }: { targetLanguage: string }) => ({

--- a/apps/akari/app/(tabs)/bookmarks.tsx
+++ b/apps/akari/app/(tabs)/bookmarks.tsx
@@ -72,6 +72,7 @@ export default function BookmarksScreen() {
             id: post.uri,
             text: (post.record as { text?: string } | undefined)?.text,
             author: {
+              did: post.author.did,
               handle: post.author.handle,
               displayName: post.author.displayName,
               avatar: post.author.avatar,

--- a/apps/akari/app/(tabs)/index.tsx
+++ b/apps/akari/app/(tabs)/index.tsx
@@ -233,6 +233,7 @@ export default function HomeScreen() {
             id: post.uri,
             text: post.record?.text as string,
             author: {
+              did: post.author.did,
               handle: post.author.handle,
               displayName: post.author.displayName,
               avatar: post.author.avatar,

--- a/apps/akari/app/(tabs)/post/[id].tsx
+++ b/apps/akari/app/(tabs)/post/[id].tsx
@@ -60,6 +60,7 @@ export const renderComment = (
               ? (post.record as { text: string }).text
               : undefined,
           author: {
+            did: post.author.did,
             handle: post.author.handle,
             displayName: post.author.displayName,
             avatar: post.author.avatar,
@@ -97,6 +98,7 @@ export const renderComment = (
             ? (postItem.record as { text: string }).text
             : undefined,
         author: {
+          did: postItem.author.did,
           handle: postItem.author.handle,
           displayName: postItem.author.displayName,
           avatar: postItem.author.avatar,
@@ -200,6 +202,7 @@ export default function PostDetailScreen() {
               ? (parentPost.record as { text: string }).text
               : undefined,
           author: {
+            did: parentPost.author.did,
             handle: parentPost.author.handle,
             displayName: parentPost.author.displayName,
             avatar: parentPost.author.avatar,
@@ -233,6 +236,7 @@ export default function PostDetailScreen() {
               ? (rootPost.record as { text: string }).text
               : undefined,
           author: {
+            did: rootPost.author.did,
             handle: rootPost.author.handle,
             displayName: rootPost.author.displayName,
             avatar: rootPost.author.avatar,
@@ -324,6 +328,7 @@ export default function PostDetailScreen() {
                     ? (mainPost.record as { text: string }).text
                     : undefined,
                 author: {
+                  did: mainPost?.author?.did || '',
                   handle: mainPost?.author?.handle || '',
                   displayName: mainPost?.author?.displayName,
                   avatar: mainPost?.author?.avatar,

--- a/apps/akari/app/(tabs)/search.tsx
+++ b/apps/akari/app/(tabs)/search.tsx
@@ -184,6 +184,7 @@ export default function SearchScreen() {
           id: post.uri,
           text: post.record?.text,
           author: {
+            did: post.author.did,
             handle: post.author.handle,
             displayName: post.author.displayName,
             avatar: post.author.avatar,

--- a/apps/akari/components/profile/LikesTab.tsx
+++ b/apps/akari/components/profile/LikesTab.tsx
@@ -43,6 +43,7 @@ export function LikesTab({ handle }: LikesTabProps) {
           id: item.uri,
           text: item.record?.text as string | undefined,
           author: {
+            did: item.author.did,
             handle: item.author.handle,
             displayName: item.author.displayName,
             avatar: item.author.avatar,

--- a/apps/akari/components/profile/MediaTab.tsx
+++ b/apps/akari/components/profile/MediaTab.tsx
@@ -49,6 +49,7 @@ export function MediaTab({ handle }: MediaTabProps) {
           id: item.uri,
           text: item.record?.text as string | undefined,
           author: {
+            did: item.author.did,
             handle: item.author.handle,
             displayName: item.author.displayName,
             avatar: item.author.avatar,

--- a/apps/akari/components/profile/PostsTab.tsx
+++ b/apps/akari/components/profile/PostsTab.tsx
@@ -43,6 +43,7 @@ export function PostsTab({ handle }: PostsTabProps) {
           id: item.uri,
           text: item.record?.text as string | undefined,
           author: {
+            did: item.author.did,
             handle: item.author.handle,
             displayName: item.author.displayName,
             avatar: item.author.avatar,

--- a/apps/akari/components/profile/RepliesTab.tsx
+++ b/apps/akari/components/profile/RepliesTab.tsx
@@ -43,6 +43,7 @@ export function RepliesTab({ handle }: RepliesTabProps) {
           id: item.uri,
           text: item.record?.text as string | undefined,
           author: {
+            did: item.author.did,
             handle: item.author.handle,
             displayName: item.author.displayName,
             avatar: item.author.avatar,

--- a/apps/akari/components/profile/VideosTab.tsx
+++ b/apps/akari/components/profile/VideosTab.tsx
@@ -43,6 +43,7 @@ export function VideosTab({ handle }: VideosTabProps) {
           id: item.uri,
           text: item.record?.text as string | undefined,
           author: {
+            did: item.author.did,
             handle: item.author.handle,
             displayName: item.author.displayName,
             avatar: item.author.avatar,

--- a/apps/akari/hooks/queries/useLiveNow.ts
+++ b/apps/akari/hooks/queries/useLiveNow.ts
@@ -1,0 +1,46 @@
+import { useQuery } from '@tanstack/react-query';
+
+const LIVE_CONFIG_URL = 'https://api.bsky.app/xrpc/app.bsky.unspecced.getConfig';
+const LIVE_CONFIG_QUERY_KEY = ['liveNowConfig'];
+
+type LiveNowEntry = {
+  did: string;
+  domains: string[];
+};
+
+type LiveConfigResponse = {
+  liveNow?: LiveNowEntry[];
+};
+
+export const useLiveNow = () => {
+  return useQuery<LiveNowEntry[]>({
+    queryKey: LIVE_CONFIG_QUERY_KEY,
+    queryFn: async () => {
+      try {
+        const response = await fetch(LIVE_CONFIG_URL, {
+          headers: {
+            'atproto-proxy': 'did:web:api.bsky.app#bsky_appview',
+          },
+        });
+
+        if (!response.ok) {
+          return [];
+        }
+
+        const data = (await response.json()) as LiveConfigResponse;
+        return data.liveNow ?? [];
+      } catch (error) {
+        if (__DEV__) {
+          console.warn('Failed to fetch Bluesky live config', error);
+        }
+
+        return [];
+      }
+    },
+    staleTime: 60 * 1000,
+    gcTime: 5 * 60 * 1000,
+    refetchInterval: 60 * 1000,
+  });
+};
+
+export type { LiveNowEntry };

--- a/apps/akari/translations/ar.json
+++ b/apps/akari/translations/ar.json
@@ -59,7 +59,10 @@
       "mute": "كتم الصوت",
       "unmute": "إلغاء كتم الصوت",
       "pendingChats": "الدردشات المعلقة",
-      "viewPendingChats": "عرض الدردشات المعلقة"
+      "viewPendingChats": "عرض الدردشات المعلقة",
+      "live": "مباشر",
+      "watchNow": "شاهد الآن",
+      "openProfile": "افتح الملف الشخصي"
     },
     "auth": {
       "fillAllFields": "يرجى ملء جميع الحقول",

--- a/apps/akari/translations/cy.json
+++ b/apps/akari/translations/cy.json
@@ -59,7 +59,10 @@
       "mute": "Tewi",
       "unmute": "Ailgychwyn Sain",
       "pendingChats": "Sgyrsiau ar y gweill",
-      "viewPendingChats": "Gweld sgyrsiau ar y gweill"
+      "viewPendingChats": "Gweld sgyrsiau ar y gweill",
+      "live": "Byw",
+      "watchNow": "Gwyliwch nawr",
+      "openProfile": "Agor proffil"
     },
     "auth": {
       "fillAllFields": "Llenwch bob maes",

--- a/apps/akari/translations/de.json
+++ b/apps/akari/translations/de.json
@@ -59,7 +59,10 @@
       "mute": "Stumm",
       "unmute": "Stummschaltung aufheben",
       "pendingChats": "Ausstehende Chats",
-      "viewPendingChats": "Ausstehende Chats anzeigen"
+      "viewPendingChats": "Ausstehende Chats anzeigen",
+      "live": "LIVE",
+      "watchNow": "Jetzt ansehen",
+      "openProfile": "Profil öffnen"
     },
     "auth": {
       "fillAllFields": "Bitte fülle alle Felder aus",

--- a/apps/akari/translations/en-US.json
+++ b/apps/akari/translations/en-US.json
@@ -59,7 +59,10 @@
       "unmute": "Unmute",
       "pendingChats": "Pending chats",
       "viewPendingChats": "View pending chats",
-      "bookmarks": "Bookmarks"
+      "bookmarks": "Bookmarks",
+      "live": "LIVE",
+      "watchNow": "Watch now",
+      "openProfile": "Open profile"
     },
     "auth": {
       "fillAllFields": "Please fill in all fields",

--- a/apps/akari/translations/en.json
+++ b/apps/akari/translations/en.json
@@ -59,7 +59,10 @@
       "checkOutImage": "Check out this image!",
       "pendingChats": "Pending chats",
       "viewPendingChats": "View pending chats",
-      "bookmarks": "Bookmarks"
+      "bookmarks": "Bookmarks",
+      "live": "LIVE",
+      "watchNow": "Watch now",
+      "openProfile": "Open profile"
     },
     "auth": {
       "fillAllFields": "Please fill in all fields",

--- a/apps/akari/translations/es.json
+++ b/apps/akari/translations/es.json
@@ -59,7 +59,10 @@
       "mute": "Silenciar",
       "unmute": "Activar sonido",
       "pendingChats": "Chats pendientes",
-      "viewPendingChats": "Ver chats pendientes"
+      "viewPendingChats": "Ver chats pendientes",
+      "live": "EN VIVO",
+      "watchNow": "Ver ahora",
+      "openProfile": "Abrir perfil"
     },
     "auth": {
       "fillAllFields": "Por favor completa todos los campos",

--- a/apps/akari/translations/fr.json
+++ b/apps/akari/translations/fr.json
@@ -59,7 +59,10 @@
       "mute": "Muet",
       "unmute": "Activer le son",
       "pendingChats": "Discussions en attente",
-      "viewPendingChats": "Voir les discussions en attente"
+      "viewPendingChats": "Voir les discussions en attente",
+      "live": "EN DIRECT",
+      "watchNow": "Regarder maintenant",
+      "openProfile": "Ouvrir le profil"
     },
     "auth": {
       "fillAllFields": "Veuillez remplir tous les champs",

--- a/apps/akari/translations/hi.json
+++ b/apps/akari/translations/hi.json
@@ -59,7 +59,10 @@
       "mute": "म्यूट",
       "unmute": "म्यूट हटाएं",
       "pendingChats": "लंबित चैट्स",
-      "viewPendingChats": "लंबित चैट्स देखें"
+      "viewPendingChats": "लंबित चैट्स देखें",
+      "live": "लाइव",
+      "watchNow": "अभी देखें",
+      "openProfile": "प्रोफ़ाइल खोलें"
     },
     "auth": {
       "fillAllFields": "कृपया सभी फ़ील्ड भरें",

--- a/apps/akari/translations/id.json
+++ b/apps/akari/translations/id.json
@@ -59,7 +59,10 @@
       "mute": "Bisukan",
       "unmute": "Aktifkan Suara",
       "pendingChats": "Obrolan tertunda",
-      "viewPendingChats": "Lihat obrolan tertunda"
+      "viewPendingChats": "Lihat obrolan tertunda",
+      "live": "Langsung",
+      "watchNow": "Tonton sekarang",
+      "openProfile": "Buka profil"
     },
     "auth": {
       "fillAllFields": "Silakan isi semua kolom",

--- a/apps/akari/translations/it.json
+++ b/apps/akari/translations/it.json
@@ -59,7 +59,10 @@
       "mute": "Silenzia",
       "unmute": "Riattiva audio",
       "pendingChats": "Chat in sospeso",
-      "viewPendingChats": "Vedi le chat in sospeso"
+      "viewPendingChats": "Vedi le chat in sospeso",
+      "live": "IN DIRETTA",
+      "watchNow": "Guarda ora",
+      "openProfile": "Apri profilo"
     },
     "auth": {
       "fillAllFields": "Compila tutti i campi",

--- a/apps/akari/translations/ja.json
+++ b/apps/akari/translations/ja.json
@@ -59,7 +59,10 @@
       "mute": "ミュート",
       "unmute": "ミュート解除",
       "pendingChats": "保留中のチャット",
-      "viewPendingChats": "保留中のチャットを表示"
+      "viewPendingChats": "保留中のチャットを表示",
+      "live": "ライブ",
+      "watchNow": "今すぐ視聴",
+      "openProfile": "プロフィールを開く"
     },
     "auth": {
       "fillAllFields": "すべてのフィールドを入力してください",

--- a/apps/akari/translations/ko.json
+++ b/apps/akari/translations/ko.json
@@ -59,7 +59,10 @@
       "mute": "음소거",
       "unmute": "음소거 해제",
       "pendingChats": "보류 중인 채팅",
-      "viewPendingChats": "보류 중인 채팅 보기"
+      "viewPendingChats": "보류 중인 채팅 보기",
+      "live": "라이브",
+      "watchNow": "지금 시청하기",
+      "openProfile": "프로필 열기"
     },
     "auth": {
       "fillAllFields": "모든 필드를 입력해주세요",

--- a/apps/akari/translations/nl.json
+++ b/apps/akari/translations/nl.json
@@ -59,7 +59,10 @@
       "mute": "Dempen",
       "unmute": "Dempen opheffen",
       "pendingChats": "Openstaande chats",
-      "viewPendingChats": "Openstaande chats bekijken"
+      "viewPendingChats": "Openstaande chats bekijken",
+      "live": "LIVE",
+      "watchNow": "Bekijk nu",
+      "openProfile": "Profiel openen"
     },
     "auth": {
       "fillAllFields": "Vul alle velden in",

--- a/apps/akari/translations/pl.json
+++ b/apps/akari/translations/pl.json
@@ -59,7 +59,10 @@
       "mute": "Wycisz",
       "unmute": "Włącz dźwięk",
       "pendingChats": "Oczekujące czaty",
-      "viewPendingChats": "Zobacz oczekujące czaty"
+      "viewPendingChats": "Zobacz oczekujące czaty",
+      "live": "NA ŻYWO",
+      "watchNow": "Obejrzyj teraz",
+      "openProfile": "Otwórz profil"
     },
     "auth": {
       "fillAllFields": "Wypełnij wszystkie pola",

--- a/apps/akari/translations/pt.json
+++ b/apps/akari/translations/pt.json
@@ -59,7 +59,10 @@
       "mute": "Silenciar",
       "unmute": "Ativar som",
       "pendingChats": "Conversas pendentes",
-      "viewPendingChats": "Ver conversas pendentes"
+      "viewPendingChats": "Ver conversas pendentes",
+      "live": "AO VIVO",
+      "watchNow": "Assistir agora",
+      "openProfile": "Abrir perfil"
     },
     "auth": {
       "fillAllFields": "Preencha todos os campos",

--- a/apps/akari/translations/ru.json
+++ b/apps/akari/translations/ru.json
@@ -59,7 +59,10 @@
       "mute": "Отключить звук",
       "unmute": "Включить звук",
       "pendingChats": "Ожидающие чаты",
-      "viewPendingChats": "Просмотреть ожидающие чаты"
+      "viewPendingChats": "Просмотреть ожидающие чаты",
+      "live": "В ЭФИРЕ",
+      "watchNow": "Смотреть сейчас",
+      "openProfile": "Открыть профиль"
     },
     "auth": {
       "fillAllFields": "Заполните все поля",

--- a/apps/akari/translations/th.json
+++ b/apps/akari/translations/th.json
@@ -59,7 +59,10 @@
       "mute": "ปิดเสียง",
       "unmute": "เปิดเสียง",
       "pendingChats": "แชทที่รอดำเนินการ",
-      "viewPendingChats": "ดูแชทที่รอดำเนินการ"
+      "viewPendingChats": "ดูแชทที่รอดำเนินการ",
+      "live": "ไลฟ์สด",
+      "watchNow": "ดูตอนนี้",
+      "openProfile": "เปิดโปรไฟล์"
     },
     "auth": {
       "fillAllFields": "กรุณากรอกทุกช่อง",

--- a/apps/akari/translations/tr.json
+++ b/apps/akari/translations/tr.json
@@ -59,7 +59,10 @@
       "mute": "Sessiz",
       "unmute": "Sesi Aç",
       "pendingChats": "Bekleyen sohbetler",
-      "viewPendingChats": "Bekleyen sohbetleri görüntüle"
+      "viewPendingChats": "Bekleyen sohbetleri görüntüle",
+      "live": "CANLI",
+      "watchNow": "Şimdi izle",
+      "openProfile": "Profili aç"
     },
     "auth": {
       "fillAllFields": "Lütfen tüm alanları doldurun",

--- a/apps/akari/translations/vi.json
+++ b/apps/akari/translations/vi.json
@@ -59,7 +59,10 @@
       "mute": "Tắt tiếng",
       "unmute": "Bật tiếng",
       "pendingChats": "Cuộc trò chuyện đang chờ",
-      "viewPendingChats": "Xem các cuộc trò chuyện đang chờ"
+      "viewPendingChats": "Xem các cuộc trò chuyện đang chờ",
+      "live": "TRỰC TIẾP",
+      "watchNow": "Xem ngay",
+      "openProfile": "Mở hồ sơ"
     },
     "auth": {
       "fillAllFields": "Vui lòng điền tất cả các trường",

--- a/apps/akari/translations/zh-CN.json
+++ b/apps/akari/translations/zh-CN.json
@@ -59,7 +59,10 @@
       "mute": "静音",
       "unmute": "取消静音",
       "pendingChats": "待处理聊天",
-      "viewPendingChats": "查看待处理聊天"
+      "viewPendingChats": "查看待处理聊天",
+      "live": "直播",
+      "watchNow": "立即观看",
+      "openProfile": "打开个人资料"
     },
     "auth": {
       "fillAllFields": "请填写所有字段",

--- a/apps/akari/translations/zh-TW.json
+++ b/apps/akari/translations/zh-TW.json
@@ -59,7 +59,10 @@
       "mute": "靜音",
       "unmute": "取消靜音",
       "pendingChats": "待處理聊天",
-      "viewPendingChats": "查看待處理聊天"
+      "viewPendingChats": "查看待處理聊天",
+      "live": "直播",
+      "watchNow": "立即觀看",
+      "openProfile": "開啟個人檔案"
     },
     "auth": {
       "fillAllFields": "請填寫所有欄位",


### PR DESCRIPTION
## Summary
- show a live badge around post avatars and preview the stream when available
- fetch live stream configuration with a dedicated query hook and ensure author DIDs are passed through
- localize the new live UI strings across all translations and update unit tests

## Testing
- `npm run lint -- --filter=akari`
- `cd apps/akari && npm run test -- __tests__/components/PostCard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68d3141b9f6c832bb474992989824cf6