### PR TITLE
test: add Playwright e2e suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,14 @@ jobs:
           lcov-file: coverage/lcov.info
           name: akari-monorepo
           update-comment: true
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:e2e

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ app-example
 
 .turbo
 coverage
+playwright-report/
+test-results/

--- a/apps/akari-e2e/sign-in.spec.ts
+++ b/apps/akari-e2e/sign-in.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Authentication screen', () => {
+  test('shows the sign in form for new visitors', async ({ page }) => {
+    await page.goto('/');
+
+    await expect(page.getByText('Sign in to Bluesky')).toBeVisible();
+    await expect(page.getByPlaceholder('username.bsky.social or @username')).toBeVisible();
+    await expect(page.getByPlaceholder('Enter your app password')).toBeVisible();
+    await expect(page.getByText('Sign In', { exact: true })).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "react-native-webview": "13.13.5"
       },
       "devDependencies": {
+        "@playwright/test": "^1.55.1",
         "turbo": "^2.3.0"
       }
     },
@@ -4293,6 +4294,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -15479,6 +15496,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "lint": "turbo run lint",
     "test": "turbo run test --filter=akari",
     "test:coverage": "turbo run test:coverage --filter=akari && npm run merge-coverage",
+    "test:e2e": "playwright test",
     "merge-coverage": "node scripts/merge-coverage.cjs",
     "clean": "turbo run clean",
     "start:development": "turbo run start:development --filter=akari",
@@ -32,6 +33,7 @@
     "web:development": "turbo run web:development --filter=akari",
     "web:preview": "turbo run web:preview --filter=akari",
     "web:production": "turbo run web:production --filter=akari",
+    "web:test": "node ./scripts/start-expo-web.cjs",
     "reset-project": "node ./scripts/reset-project.js",
     "update-translations": "node ./scripts/update-translations.js",
     "validate-translations": "node ./scripts/validate-translations.js",
@@ -90,6 +92,7 @@
     "react-native-webview": "13.13.5"
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.1",
     "turbo": "^2.3.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const webPort = process.env.PLAYWRIGHT_WEB_PORT ?? '8081';
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${webPort}`;
+
+export default defineConfig({
+  testDir: './apps/akari-e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm run web:test',
+    url: `${baseURL}/`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 240_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
+  ],
+});

--- a/scripts/start-expo-web.cjs
+++ b/scripts/start-expo-web.cjs
@@ -1,0 +1,45 @@
+const { spawn, spawnSync } = require('node:child_process');
+
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const packagesToBuild = ['clearsky-api'];
+
+for (const workspace of packagesToBuild) {
+  const buildResult = spawnSync(
+    npmCommand,
+    ['run', 'build', '--workspace', workspace],
+    {
+      stdio: 'inherit',
+      env: {
+        ...process.env,
+        CI: process.env.CI ?? '1',
+      },
+    },
+  );
+
+  if (buildResult.status !== 0) {
+    process.exit(buildResult.status ?? 1);
+  }
+}
+
+const port = process.env.PLAYWRIGHT_WEB_PORT ?? '8081';
+
+const child = spawn(
+  npmCommand,
+  ['run', 'web', '--workspace', 'akari', '--', '--port', port],
+  {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      CI: process.env.CI ?? '1',
+    },
+  },
+);
+
+child.on('exit', (code) => {
+  process.exit(code ?? 0);
+});
+
+child.on('error', (error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- configure Playwright with a Chromium-only project and npm scripts to exercise the Expo web app
- add a basic sign-in smoke test plus a helper script that prebuilds required packages before starting the web server
- update the CI test workflow to install browsers and execute the new end-to-end suite on pull requests

## Testing
- npm run lint -- --filter=akari
- npm run test:e2e


------
https://chatgpt.com/codex/tasks/task_e_68d31eb1068c832b9f0c9a347dd59439