### PR TITLE
fix: prevent PostCard language selection loop

### DIFF
--- a/apps/akari/components/PostCard.tsx
+++ b/apps/akari/components/PostCard.tsx
@@ -317,16 +317,20 @@ export function PostCard({ post, onPress }: PostCardProps) {
   const languages = languagesQuery.data?.languages ?? DEFAULT_LIBRETRANSLATE_LANGUAGES;
 
   useEffect(() => {
-    if (!hasUserSelectedLanguage) {
-      setSelectedLanguage(resolveLanguageCode(currentLocale, languages));
-    }
-  }, [currentLocale, hasUserSelectedLanguage, languages]);
+    const resolvedLanguage = resolveLanguageCode(currentLocale, languages);
 
-  useEffect(() => {
     if (!languages.some((language) => language.code === selectedLanguage)) {
-      setSelectedLanguage(resolveLanguageCode(currentLocale, languages));
+      if (selectedLanguage !== resolvedLanguage) {
+        setSelectedLanguage(resolvedLanguage);
+      }
+
+      return;
     }
-  }, [languages, selectedLanguage, currentLocale]);
+
+    if (!hasUserSelectedLanguage && selectedLanguage !== resolvedLanguage) {
+      setSelectedLanguage(resolvedLanguage);
+    }
+  }, [currentLocale, hasUserSelectedLanguage, languages, selectedLanguage]);
 
   const languageNameMap = useMemo(
     () => new Map(languages.map((language) => [language.code, language.name])),


### PR DESCRIPTION
## Summary
- guard PostCard language selection against repeatedly setting the same value
- consolidate the auto-selection and validation effects to avoid infinite update loops

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d32681f914832b86e63b0e9127f089