### PR TITLE
test: expand playwright coverage for app pages

### DIFF
--- a/apps/akari-e2e/debug.spec.ts
+++ b/apps/akari-e2e/debug.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Debug screen', () => {
+  test('shows query cache controls and empty state', async ({ page }) => {
+    await page.goto('/debug');
+
+    await expect(page.getByText('Query Cache Debug')).toBeVisible();
+    await expect(page.getByText('Invalidate All')).toBeVisible();
+    await expect(page.getByText('Clear All')).toBeVisible();
+    await expect(page.getByText(/Total Queries:/)).toBeVisible();
+    await expect(page.getByText('No queries in cache')).toBeVisible();
+  });
+});

--- a/apps/akari-e2e/not-found.spec.ts
+++ b/apps/akari-e2e/not-found.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Not found screen', () => {
+  test('provides navigation back to the home screen', async ({ page }) => {
+    await page.goto('/this-route-does-not-exist');
+
+    await expect(page.getByText('This screen does not exist.')).toBeVisible();
+    const backLink = page.getByRole('link', { name: 'Go to home screen!' });
+    await expect(backLink).toBeVisible();
+
+    await backLink.click();
+
+    await expect(page.getByText('Sign in to Bluesky')).toBeVisible();
+  });
+});

--- a/apps/akari-e2e/protected-routes.spec.ts
+++ b/apps/akari-e2e/protected-routes.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@playwright/test';
+
+const signInHeading = 'Sign in to Bluesky';
+const handlePlaceholder = 'username.bsky.social or @username';
+
+const protectedRoutes = [
+  '/',
+  '/bookmarks',
+  '/messages',
+  '/messages/pending',
+  '/messages/example-user',
+  '/notifications',
+  '/post/example-post',
+  '/profile',
+  '/profile/example-user',
+  '/search',
+  '/settings',
+] as const;
+
+test.describe('Protected routes require authentication', () => {
+  for (const path of protectedRoutes) {
+    test(`redirects ${path} to the sign in screen`, async ({ page }) => {
+      await page.goto(path);
+
+      await expect(page.getByText(signInHeading)).toBeVisible();
+      await expect(page.getByPlaceholder(handlePlaceholder)).toBeVisible();
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add end-to-end coverage for the debug screen and 404 flow
- verify unauthenticated visitors are redirected from each tab route to the sign-in screen

## Testing
- npx playwright test
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d32f900ed4832b96cf9258ff113469