### PR TITLE
refactor: document package apis and extract shared types

### DIFF
--- a/packages/bluesky-api/src/actors.ts
+++ b/packages/bluesky-api/src/actors.ts
@@ -1,5 +1,9 @@
 import { BlueskyApiClient } from './client';
-import type { BlueskyPreferencesResponse, BlueskyProfileResponse } from './types';
+import type {
+  BlueskyPreferencesResponse,
+  BlueskyProfileResponse,
+  BlueskyProfileUpdateInput,
+} from './types';
 
 /**
  * Bluesky API actor/profile methods
@@ -25,12 +29,7 @@ export class BlueskyActors extends BlueskyApiClient {
    */
   async updateProfile(
     accessJwt: string,
-    profileData: {
-      displayName?: string;
-      description?: string;
-      avatar?: string;
-      banner?: string;
-    },
+    profileData: BlueskyProfileUpdateInput,
   ): Promise<BlueskyProfileResponse> {
     return this.makeAuthenticatedRequest<BlueskyProfileResponse>('/app.bsky.actor.updateProfile', accessJwt, {
       method: 'POST',

--- a/packages/bluesky-api/src/api.ts
+++ b/packages/bluesky-api/src/api.ts
@@ -9,10 +9,12 @@ import { BlueskySearch } from './search';
 import type {
   BlueskyBookmarksResponse,
   BlueskyConvosResponse,
-  BlueskyFeed,
   BlueskyFeedResponse,
   BlueskyFeedsResponse,
   BlueskyMessagesResponse,
+  BlueskyCreatePostInput,
+  BlueskyCreatePostResponse,
+  BlueskyFeedGeneratorsResponse,
   BlueskyNotificationsResponse,
   BlueskyPostView,
   BlueskyPreferencesResponse,
@@ -20,10 +22,14 @@ import type {
   BlueskySearchActorsResponse,
   BlueskySearchPostsResponse,
   BlueskySendMessageResponse,
+  BlueskySendMessageInput,
   BlueskySession,
   BlueskyStarterPacksResponse,
   BlueskyThreadResponse,
   BlueskyTrendingTopicsResponse,
+  BlueskyProfileUpdateInput,
+  BlueskyUnreadNotificationCount,
+  BlueskyUploadBlobResponse,
 } from './types';
 
 /**
@@ -38,6 +44,10 @@ export class BlueskyApi extends BlueskyApiClient {
   private notifications: BlueskyNotifications;
   private search: BlueskySearch;
 
+  /**
+   * Creates a convenience wrapper around the various Bluesky domain clients while sharing the base PDS URL.
+   * @param pdsUrl - Personal data server URL that hosts the AT Protocol endpoints.
+   */
   constructor(pdsUrl: string) {
     super(pdsUrl);
     this.actors = new BlueskyActors(pdsUrl);
@@ -49,56 +59,114 @@ export class BlueskyApi extends BlueskyApiClient {
     this.search = new BlueskySearch(pdsUrl);
   }
 
-  // Auth methods
+  /**
+   * Creates an authenticated session for the supplied handle or DID using the user's password.
+   * @param identifier - Handle or DID that should be authenticated.
+   * @param password - Account password used to obtain the session tokens.
+   * @returns Newly created session tokens for the account.
+   */
   async createSession(identifier: string, password: string): Promise<BlueskySession> {
     return this.auth.createSession(identifier, password);
   }
 
+  /**
+   * Exchanges a refresh token for a new authenticated session.
+   * @param refreshJwt - Refresh JWT provided by Bluesky during the original session creation.
+   * @returns Fresh access and refresh token pair from the PDS.
+   */
   async refreshSession(refreshJwt: string): Promise<BlueskySession> {
     return this.auth.refreshSession(refreshJwt);
   }
 
-  // Feed methods
+  /**
+   * Loads profile metadata and viewer state for the requested DID.
+   * @param accessJwt - Valid session token used to authorise the profile lookup.
+   * @param did - DID of the actor whose profile information should be retrieved.
+   * @returns Profile record and viewer relationship metadata.
+   */
   async getProfile(accessJwt: string, did: string): Promise<BlueskyProfileResponse> {
     return this.actors.getProfile(accessJwt, did);
   }
 
-  async updateProfile(
-    accessJwt: string,
-    profileData: {
-      displayName?: string;
-      description?: string;
-      avatar?: string;
-      banner?: string;
-    },
-  ): Promise<BlueskyProfileResponse> {
+  /**
+   * Updates profile metadata such as display name, description, avatar or banner in the actor record.
+   * @param accessJwt - Valid session token authorised to modify the actor profile.
+   * @param profileData - Partial profile fields that should be persisted for the actor.
+   * @returns Updated profile record returned by Bluesky after the mutation.
+   */
+  async updateProfile(accessJwt: string, profileData: BlueskyProfileUpdateInput): Promise<BlueskyProfileResponse> {
     return this.actors.updateProfile(accessJwt, profileData);
   }
 
+  /**
+   * Retrieves the authenticated user's current preference records, including saved feeds and content filters.
+   * @param accessJwt - Valid session token for the actor whose preferences are requested.
+   * @returns Preference collection describing feed pinning and label settings.
+   */
   async getPreferences(accessJwt: string): Promise<BlueskyPreferencesResponse> {
     return this.actors.getPreferences(accessJwt);
   }
 
+  /**
+   * Fetches the home timeline feed for the authenticated user.
+   * @param accessJwt - Valid session token for the requesting user.
+   * @param limit - Maximum number of feed items to return, defaults to 20.
+   * @returns Feed page that mirrors the app.bsky.feed.getTimeline endpoint.
+   */
   async getTimeline(accessJwt: string, limit: number = 20): Promise<BlueskyFeedResponse> {
     return this.feeds.getTimeline(accessJwt, limit);
   }
 
+  /**
+   * Retrieves the curated trending topics list exposed by Bluesky.
+   * @param limit - Maximum number of topics to fetch, defaults to 10.
+   * @returns List of trending topic descriptors sourced from the unspecced API.
+   */
   async getTrendingTopics(limit: number = 10): Promise<BlueskyTrendingTopicsResponse> {
     return this.feeds.getTrendingTopics(limit);
   }
 
+  /**
+   * Lists feed generators created by a particular actor.
+   * @param accessJwt - Valid session token to access the feed generator listing.
+   * @param actor - DID or handle identifying the actor whose feeds should be loaded.
+   * @param limit - Maximum number of feeds to fetch per page, defaults to 50.
+   * @param cursor - Pagination cursor returned from previous requests.
+   * @returns Feed generator metadata for the provided actor.
+   */
   async getFeeds(accessJwt: string, actor: string, limit: number = 50, cursor?: string): Promise<BlueskyFeedsResponse> {
     return this.feeds.getFeeds(accessJwt, actor, limit, cursor);
   }
 
+  /**
+   * Fetches posts produced by a feed generator.
+   * @param accessJwt - Valid session token to authorise the feed request.
+   * @param feed - AT URI of the feed generator to read.
+   * @param limit - Maximum number of posts to request, defaults to 50.
+   * @param cursor - Pagination cursor returned by the API, if available.
+   * @returns Feed slice containing posts created by the generator.
+   */
   async getFeed(accessJwt: string, feed: string, limit: number = 50, cursor?: string): Promise<BlueskyFeedResponse> {
     return this.feeds.getFeed(accessJwt, feed, limit, cursor);
   }
 
-  async getFeedGenerators(accessJwt: string, feeds: string[]): Promise<{ feeds: BlueskyFeed[] }> {
+  /**
+   * Resolves metadata for an array of feed generator URIs.
+   * @param accessJwt - Valid session token to authorise the metadata request.
+   * @param feeds - List of feed generator URIs that should be described.
+   * @returns Collection of feed generator descriptions keyed by Bluesky.
+   */
+  async getFeedGenerators(accessJwt: string, feeds: string[]): Promise<BlueskyFeedGeneratorsResponse> {
     return this.feeds.getFeedGenerators(accessJwt, feeds);
   }
 
+  /**
+   * Lists the authenticated user's bookmarked posts.
+   * @param accessJwt - Valid session token for the requesting user.
+   * @param limit - Maximum number of bookmarks to fetch per page, defaults to 50.
+   * @param cursor - Pagination cursor from the previous response, if any.
+   * @returns Paginated bookmark feed from the app.bsky.bookmark namespace.
+   */
   async getBookmarks(
     accessJwt: string,
     limit: number = 50,
@@ -107,14 +175,35 @@ export class BlueskyApi extends BlueskyApiClient {
     return this.feeds.getBookmarks(accessJwt, limit, cursor);
   }
 
+  /**
+   * Loads a single post view by its AT URI, guaranteeing the post exists before returning it.
+   * @param accessJwt - Valid session token used to look up the post.
+   * @param uri - AT URI of the post to fetch.
+   * @returns Post view containing record data, embeds and viewer state.
+   */
   async getPost(accessJwt: string, uri: string): Promise<BlueskyPostView> {
     return this.feeds.getPost(accessJwt, uri);
   }
 
+  /**
+   * Fetches a full thread for a given post including replies and parent context.
+   * @param accessJwt - Valid session token used to authorise the request.
+   * @param uri - AT URI of the root post to expand.
+   * @returns Thread response mirroring the feed.getPostThread endpoint.
+   */
   async getPostThread(accessJwt: string, uri: string): Promise<BlueskyThreadResponse> {
     return this.feeds.getPostThread(accessJwt, uri);
   }
 
+  /**
+   * Retrieves an author's posts with optional filtering for replies, media or thread starters.
+   * @param accessJwt - Valid session token to authorise the author feed lookup.
+   * @param actor - DID or handle identifying the author.
+   * @param limit - Maximum number of posts to fetch per page, defaults to 20.
+   * @param cursor - Pagination cursor from the previous author feed response.
+   * @param filter - Optional server-side filter for replies, media, or author threads.
+   * @returns Paginated feed slice scoped to the author's posts.
+   */
   async getAuthorFeed(
     accessJwt: string,
     actor: string,
@@ -125,6 +214,14 @@ export class BlueskyApi extends BlueskyApiClient {
     return this.feeds.getAuthorFeed(accessJwt, actor, limit, cursor, filter);
   }
 
+  /**
+   * Retrieves an author's posts filtered to entries containing uploaded video.
+   * @param accessJwt - Valid session token to authorise the request.
+   * @param actor - DID or handle representing the author.
+   * @param limit - Maximum number of posts to request, defaults to 20.
+   * @param cursor - Optional pagination cursor from the API.
+   * @returns Feed page containing only posts with video embeds.
+   */
   async getAuthorVideos(
     accessJwt: string,
     actor: string,
@@ -134,6 +231,14 @@ export class BlueskyApi extends BlueskyApiClient {
     return this.feeds.getAuthorVideos(accessJwt, actor, limit, cursor);
   }
 
+  /**
+   * Lists feed generators owned by an actor, mirroring getFeeds but scoped to author-owned resources.
+   * @param accessJwt - Valid session token to authorise the listing.
+   * @param actor - DID or handle representing the author.
+   * @param limit - Maximum number of feed generators per page, defaults to 50.
+   * @param cursor - Pagination cursor from the previous response, if present.
+   * @returns Feed generator list for the supplied actor.
+   */
   async getAuthorFeeds(
     accessJwt: string,
     actor: string,
@@ -143,6 +248,14 @@ export class BlueskyApi extends BlueskyApiClient {
     return this.feeds.getAuthorFeeds(accessJwt, actor, limit, cursor);
   }
 
+  /**
+   * Retrieves starter packs curated by an author that bundle suggested follows and feeds.
+   * @param accessJwt - Valid session token to authorise the starter pack lookup.
+   * @param actor - DID or handle whose starter packs should be returned.
+   * @param limit - Maximum number of starter packs per page, defaults to 50.
+   * @param cursor - Pagination cursor from previous starter pack responses.
+   * @returns Paginated list of starter packs authored by the given actor.
+   */
   async getAuthorStarterpacks(
     accessJwt: string,
     actor: string,
@@ -152,39 +265,60 @@ export class BlueskyApi extends BlueskyApiClient {
     return this.feeds.getAuthorStarterpacks(accessJwt, actor, limit, cursor);
   }
 
-  async createPost(
-    accessJwt: string,
-    userDid: string,
-    post: {
-      text: string;
-      replyTo?: {
-        root: string;
-        parent: string;
-      };
-      images?: {
-        uri: string;
-        alt: string;
-        mimeType: string;
-      }[];
-    },
-  ) {
+  /**
+   * Creates a new post on behalf of the authenticated user including optional reply context and media embeds.
+   * @param accessJwt - Valid session token authorised to create posts for the provided DID.
+   * @param userDid - DID of the repository where the post should be recorded.
+   * @param post - Text, reply references and media attachments to persist in the record.
+   * @returns Metadata for the created record including AT URI and commit details.
+   */
+  async createPost(accessJwt: string, userDid: string, post: BlueskyCreatePostInput): Promise<BlueskyCreatePostResponse> {
     return this.feeds.createPost(accessJwt, userDid, post);
   }
 
-  async uploadImage(accessJwt: string, imageUri: string, mimeType: string) {
+  /**
+   * Uploads a binary blob (image or GIF) to Bluesky and returns the blob reference for embedding.
+   * @param accessJwt - Valid session token authorised to upload media.
+   * @param imageUri - Local URI that should be fetched and uploaded as a blob.
+   * @param mimeType - MIME type associated with the uploaded media.
+   * @returns Blob reference structure compatible with Bluesky embed records.
+   */
+  async uploadImage(accessJwt: string, imageUri: string, mimeType: string): Promise<BlueskyUploadBlobResponse> {
     return this.feeds.uploadImage(accessJwt, imageUri, mimeType);
   }
 
-  // Like/Unlike methods
+  /**
+   * Creates a like record for the specified post in the authenticated user's repository.
+   * @param accessJwt - Valid session token authorised to mutate the repository.
+   * @param postUri - AT URI of the post that should be liked.
+   * @param postCid - CID of the post being liked, required by the repo mutation.
+   * @param userDid - DID of the repository owner creating the like record.
+   * @returns Response emitted by the repo.createRecord mutation.
+   */
   async likePost(accessJwt: string, postUri: string, postCid: string, userDid: string) {
     return this.feeds.likePost(accessJwt, postUri, postCid, userDid);
   }
 
+  /**
+   * Removes an existing like record from the authenticated user's repository.
+   * @param accessJwt - Valid session token authorised to mutate the repository.
+   * @param likeUri - URI of the like record to delete.
+   * @param userDid - DID of the repository owner removing the like record.
+   * @returns Response emitted by the repo.deleteRecord mutation.
+   */
   async unlikePost(accessJwt: string, likeUri: string, userDid: string) {
     return this.feeds.unlikePost(accessJwt, likeUri, userDid);
   }
 
-  // Conversation methods
+  /**
+   * Lists the user's conversations including the most recent message and participant metadata.
+   * @param accessJwt - Valid session token authorised to read conversation state.
+   * @param limit - Maximum number of conversations to fetch, defaults to 50.
+   * @param cursor - Pagination cursor returned from a previous list call.
+   * @param readState - Optional filter restricting results to unread conversations.
+   * @param status - Optional status filter for request vs accepted conversations.
+   * @returns Conversation listing including pagination metadata.
+   */
   async listConversations(
     accessJwt: string,
     limit: number = 50,
@@ -195,6 +329,14 @@ export class BlueskyApi extends BlueskyApiClient {
     return this.conversations.listConversations(accessJwt, limit, cursor, readState, status);
   }
 
+  /**
+   * Retrieves messages for a specific conversation.
+   * @param accessJwt - Valid session token authorised to read the conversation contents.
+   * @param convoId - Conversation identifier returned by the conversations list endpoint.
+   * @param limit - Maximum number of messages to fetch per page, defaults to 50.
+   * @param cursor - Pagination cursor used to continue from a previous response.
+   * @returns Conversation messages along with pagination metadata.
+   */
   async getMessages(
     accessJwt: string,
     convoId: string,
@@ -204,50 +346,109 @@ export class BlueskyApi extends BlueskyApiClient {
     return this.conversations.getMessages(accessJwt, convoId, limit, cursor);
   }
 
+  /**
+   * Sends a direct message in the specified conversation on behalf of the authenticated user.
+   * @param accessJwt - Valid session token authorised to post to the conversation.
+   * @param convoId - Identifier of the conversation where the message should be delivered.
+   * @param message - Message payload containing the textual body.
+   * @returns Server response describing the persisted message record.
+   */
   async sendMessage(
     accessJwt: string,
     convoId: string,
-    message: {
-      text: string;
-    },
+    message: BlueskySendMessageInput,
   ): Promise<BlueskySendMessageResponse> {
     return this.conversations.sendMessage(accessJwt, convoId, message);
   }
 
-  // Graph methods (follow/block/mute)
+  /**
+   * Creates a follow record pointing at the supplied DID.
+   * @param accessJwt - Valid session token for the actor initiating the follow.
+   * @param did - DID of the actor that should be followed.
+   * @returns Response emitted by the repo.createRecord mutation.
+   */
   async followUser(accessJwt: string, did: string) {
     return this.graph.followUser(accessJwt, did);
   }
 
+  /**
+   * Deletes an existing follow record, effectively unfollowing the target actor.
+   * @param accessJwt - Valid session token for the actor removing the follow.
+   * @param followUri - URI of the follow record to delete.
+   * @returns Response emitted by the repo.deleteRecord mutation.
+   */
   async unfollowUser(accessJwt: string, followUri: string) {
     return this.graph.unfollowUser(accessJwt, followUri);
   }
 
+  /**
+   * Creates a block record against the supplied DID.
+   * @param accessJwt - Valid session token for the actor initiating the block.
+   * @param did - DID of the actor that should be blocked.
+   * @returns Response emitted by the repo.createRecord mutation.
+   */
   async blockUser(accessJwt: string, did: string) {
     return this.graph.blockUser(accessJwt, did);
   }
 
+  /**
+   * Removes an existing block record, unblocking the target actor.
+   * @param accessJwt - Valid session token for the actor clearing the block.
+   * @param blockUri - URI of the block record to delete.
+   * @returns Response emitted by the repo.deleteRecord mutation.
+   */
   async unblockUser(accessJwt: string, blockUri: string) {
     return this.graph.unblockUser(accessJwt, blockUri);
   }
 
+  /**
+   * Mutes the supplied actor so their posts and notifications are hidden locally.
+   * @param accessJwt - Valid session token for the actor applying the mute.
+   * @param actor - DID or handle of the actor that should be muted.
+   * @returns Response payload from the graph.muteActor endpoint.
+   */
   async muteUser(accessJwt: string, actor: string) {
     return this.graph.muteUser(accessJwt, actor);
   }
 
+  /**
+   * Clears an existing mute on the supplied actor.
+   * @param accessJwt - Valid session token for the actor removing the mute.
+   * @param actor - DID or handle of the actor that should be unmuted.
+   * @returns Response payload from the graph.unmuteActor endpoint.
+   */
   async unmuteUser(accessJwt: string, actor: string) {
     return this.graph.unmuteUser(accessJwt, actor);
   }
 
+  /**
+   * Mutes all members of a Bluesky list for the authenticated user.
+   * @param accessJwt - Valid session token for the actor applying the mute list.
+   * @param list - AT URI of the list to mute.
+   * @returns Response payload from the graph.muteActorList endpoint.
+   */
   async muteActorList(accessJwt: string, list: string) {
     return this.graph.muteActorList(accessJwt, list);
   }
 
+  /**
+   * Mutes a thread so future replies no longer surface in the user's notifications.
+   * @param accessJwt - Valid session token for the actor muting the thread.
+   * @param root - AT URI of the thread root that should be muted.
+   * @returns Response payload from the graph.muteThread endpoint.
+   */
   async muteThread(accessJwt: string, root: string) {
     return this.graph.muteThread(accessJwt, root);
   }
 
-  // Search methods
+  /**
+   * Searches for actors matching the provided query string.
+   * @param accessJwt - Valid session token used to authorise the search request.
+   * @param query - Text query to match against actor handles and display names.
+   * @param limit - Maximum number of results to return per page, defaults to 20.
+   * @param cursor - Pagination cursor returned by previous search requests.
+   * @returns Actor search results with pagination metadata.
+   */
   async searchProfiles(
     accessJwt: string,
     query: string,
@@ -257,6 +458,14 @@ export class BlueskyApi extends BlueskyApiClient {
     return this.search.searchProfiles(accessJwt, query, limit, cursor);
   }
 
+  /**
+   * Searches public posts that match the provided query string.
+   * @param accessJwt - Valid session token used to authorise the search request.
+   * @param query - Text query applied to posts.
+   * @param limit - Maximum number of results to return per page, defaults to 20.
+   * @param cursor - Pagination cursor returned by previous search requests.
+   * @returns Post search results with pagination metadata.
+   */
   async searchPosts(
     accessJwt: string,
     query: string,
@@ -266,7 +475,16 @@ export class BlueskyApi extends BlueskyApiClient {
     return this.search.searchPosts(accessJwt, query, limit, cursor);
   }
 
-  // Notification methods
+  /**
+   * Lists notifications for the authenticated user with optional filtering.
+   * @param accessJwt - Valid session token authorised to read notifications.
+   * @param limit - Maximum number of notifications to fetch per page, defaults to 50.
+   * @param cursor - Pagination cursor returned from previous notification requests.
+   * @param reasons - Optional filter restricting notifications to specific reasons.
+   * @param priority - Optional filter to only return priority notifications.
+   * @param seenAt - Optional timestamp used to fetch notifications since a specific moment.
+   * @returns Notification listing including pagination metadata.
+   */
   async listNotifications(
     accessJwt: string,
     limit: number = 50,
@@ -278,11 +496,20 @@ export class BlueskyApi extends BlueskyApiClient {
     return this.notifications.listNotifications(accessJwt, limit, cursor, reasons, priority, seenAt);
   }
 
-  async getUnreadNotificationsCount(accessJwt: string): Promise<{ count: number }> {
+  /**
+   * Retrieves the total number of unread notifications for the authenticated user.
+   * @param accessJwt - Valid session token authorised to read the notification counts.
+   * @returns Unread notification counter sourced from the Bluesky API.
+   */
+  async getUnreadNotificationsCount(accessJwt: string): Promise<BlueskyUnreadNotificationCount> {
     return this.notifications.getUnreadCount(accessJwt);
   }
 
-  // Static factory method for custom PDS
+  /**
+   * Convenience constructor that mirrors the standard constructor for parity with previous usage.
+   * @param pdsUrl - Personal data server URL that hosts the AT Protocol endpoints.
+   * @returns Instantiated {@link BlueskyApi} for the supplied PDS.
+   */
   static createWithPDS(pdsUrl: string): BlueskyApi {
     return new BlueskyApi(pdsUrl);
   }

--- a/packages/bluesky-api/src/client.ts
+++ b/packages/bluesky-api/src/client.ts
@@ -1,4 +1,4 @@
-import type { BlueskyError } from './types';
+import type { BlueskyError, BlueskyUploadBlobResponse } from './types';
 
 /**
  * Bluesky API client for interacting with Bluesky Personal Data Servers (PDS)
@@ -103,34 +103,22 @@ export class BlueskyApiClient {
     accessJwt: string,
     blob: Blob,
     mimeType: string,
-  ): Promise<{
-    blob: {
-      ref: {
-        $link: string;
-      };
-      mimeType: string;
-      size: number;
-    };
-  }> {
+  ): Promise<BlueskyUploadBlobResponse> {
     // Get the blob data as array buffer and create a new blob with correct MIME type
     const arrayBuffer = await blob.arrayBuffer();
     const typedBlob = new Blob([arrayBuffer], { type: mimeType });
 
-    const result = await this.makeAuthenticatedRequest<{
-      blob: {
-        ref: {
-          $link: string;
-        };
-        mimeType: string;
-        size: number;
-      };
-    }>('/com.atproto.repo.uploadBlob', accessJwt, {
-      method: 'POST',
-      body: typedBlob,
-      headers: {
-        'Content-Type': mimeType,
+    const result = await this.makeAuthenticatedRequest<BlueskyUploadBlobResponse>(
+      '/com.atproto.repo.uploadBlob',
+      accessJwt,
+      {
+        method: 'POST',
+        body: typedBlob,
+        headers: {
+          'Content-Type': mimeType,
+        },
       },
-    });
+    );
 
     return result;
   }

--- a/packages/bluesky-api/src/conversations.ts
+++ b/packages/bluesky-api/src/conversations.ts
@@ -1,5 +1,10 @@
 import { BlueskyApiClient } from './client';
-import type { BlueskyConvosResponse, BlueskyMessagesResponse, BlueskySendMessageResponse } from './types';
+import type {
+  BlueskyConvosResponse,
+  BlueskyMessagesResponse,
+  BlueskySendMessageInput,
+  BlueskySendMessageResponse,
+} from './types';
 
 /**
  * Bluesky API conversation methods
@@ -70,9 +75,7 @@ export class BlueskyConversations extends BlueskyApiClient {
   async sendMessage(
     accessJwt: string,
     convoId: string,
-    message: {
-      text: string;
-    },
+    message: BlueskySendMessageInput,
   ): Promise<BlueskySendMessageResponse> {
     return this.makeAuthenticatedRequest<BlueskySendMessageResponse>('/chat.bsky.convo.sendMessage', accessJwt, {
       method: 'POST',

--- a/packages/bluesky-api/src/feeds.ts
+++ b/packages/bluesky-api/src/feeds.ts
@@ -1,7 +1,6 @@
 import { BlueskyApiClient } from './client';
 import type {
   BlueskyBookmarksResponse,
-  BlueskyFeed,
   BlueskyFeedResponse,
   BlueskyFeedsResponse,
   BlueskyLikeResponse,
@@ -10,6 +9,10 @@ import type {
   BlueskyThreadResponse,
   BlueskyUnlikeResponse,
   BlueskyTrendingTopicsResponse,
+  BlueskyCreatePostInput,
+  BlueskyCreatePostResponse,
+  BlueskyFeedGeneratorsResponse,
+  BlueskyUploadBlobResponse,
 } from './types';
 
 /**
@@ -91,12 +94,12 @@ export class BlueskyFeeds extends BlueskyApiClient {
    * @param feeds - Array of feed URIs to get metadata for
    * @returns Promise resolving to feed generators data
    */
-  async getFeedGenerators(accessJwt: string, feeds: string[]): Promise<{ feeds: BlueskyFeed[] }> {
+  async getFeedGenerators(accessJwt: string, feeds: string[]): Promise<BlueskyFeedGeneratorsResponse> {
     const params: Record<string, string> = {
       feeds: feeds.join(','),
     };
 
-    return this.makeAuthenticatedRequest<{ feeds: BlueskyFeed[] }>('/app.bsky.feed.getFeedGenerators', accessJwt, {
+    return this.makeAuthenticatedRequest<BlueskyFeedGeneratorsResponse>('/app.bsky.feed.getFeedGenerators', accessJwt, {
       params,
     });
   }
@@ -332,15 +335,7 @@ export class BlueskyFeeds extends BlueskyApiClient {
     accessJwt: string,
     imageUri: string,
     mimeType: string,
-  ): Promise<{
-    blob: {
-      ref: {
-        $link: string;
-      };
-      mimeType: string;
-      size: number;
-    };
-  }> {
+  ): Promise<BlueskyUploadBlobResponse> {
     // Convert image URI to blob
     const response = await fetch(imageUri);
     const blob = await response.blob();
@@ -361,20 +356,8 @@ export class BlueskyFeeds extends BlueskyApiClient {
   async createPost(
     accessJwt: string,
     userDid: string,
-    post: {
-      text: string;
-      replyTo?: {
-        root: string;
-        parent: string;
-      };
-      images?: {
-        uri: string;
-        alt: string;
-        mimeType: string;
-        tenorId?: string;
-      }[];
-    },
-  ) {
+    post: BlueskyCreatePostInput,
+  ): Promise<BlueskyCreatePostResponse> {
     const { text, replyTo, images } = post;
 
     let record: Record<string, unknown> = {
@@ -439,15 +422,7 @@ export class BlueskyFeeds extends BlueskyApiClient {
       }
     }
 
-    return this.makeAuthenticatedRequest<{
-      uri: string;
-      cid: string;
-      commit: {
-        cid: string;
-        rev: string;
-      };
-      validationStatus: string;
-    }>('/com.atproto.repo.createRecord', accessJwt, {
+    return this.makeAuthenticatedRequest<BlueskyCreatePostResponse>('/com.atproto.repo.createRecord', accessJwt, {
       method: 'POST',
       body: {
         repo: userDid,

--- a/packages/bluesky-api/src/notifications.ts
+++ b/packages/bluesky-api/src/notifications.ts
@@ -1,4 +1,4 @@
-import type { BlueskyNotificationsResponse } from './types';
+import type { BlueskyNotificationsResponse, BlueskyUnreadNotificationCount } from './types';
 
 /**
  * Bluesky notifications API client
@@ -56,11 +56,11 @@ export class BlueskyNotifications {
   }
 
   /**
-   * Get the count of unread notifications
-   * @param accessJwt - JWT access token
-   * @returns Promise resolving to unread count
+   * Retrieves the unread notification counter maintained by Bluesky.
+   * @param accessJwt - JWT access token authorised to read notifications.
+   * @returns Object containing the unread notification total.
    */
-  async getUnreadCount(accessJwt: string): Promise<{ count: number }> {
+  async getUnreadCount(accessJwt: string): Promise<BlueskyUnreadNotificationCount> {
     const url = `${this.pdsUrl}/xrpc/app.bsky.notification.getUnreadCount`;
 
     const response = await fetch(url, {

--- a/packages/bluesky-api/src/types.ts
+++ b/packages/bluesky-api/src/types.ts
@@ -3,7 +3,7 @@
  */
 
 // Common types used across multiple interfaces
-export interface BlueskyAssociated {
+export type BlueskyAssociated = {
   lists: number;
   feedgens: number;
   starterPacks: number;
@@ -11,9 +11,9 @@ export interface BlueskyAssociated {
   chat: {
     allowIncoming: string;
   };
-}
+};
 
-export interface BlueskyViewer {
+export type BlueskyViewer = {
   muted: boolean;
   mutedByList?: string;
   blockedBy: boolean;
@@ -25,23 +25,23 @@ export interface BlueskyViewer {
     count: number;
     followers: string[];
   };
-}
+};
 
-export interface BlueskyVerification {
+export type BlueskyVerification = {
   verifications: string[];
   verifiedStatus: string;
   trustedVerifierStatus: string;
-}
+};
 
-export interface BlueskyStatus {
+export type BlueskyStatus = {
   status: string;
   record: Record<string, unknown>;
   embed?: BlueskyEmbed;
   expiresAt: string;
   isActive: boolean;
-}
+};
 
-export interface BlueskyLabel {
+export type BlueskyLabel = {
   val: string;
   src: string;
   cts: string;
@@ -53,9 +53,9 @@ export interface BlueskyLabel {
   label?: string;
   ver?: number;
   exp?: string;
-}
+};
 
-export interface BlueskyImage {
+export type BlueskyImage = {
   alt: string;
   image?: {
     ref: {
@@ -70,9 +70,9 @@ export interface BlueskyImage {
     width: number;
     height: number;
   };
-}
+};
 
-export interface BlueskyVideo {
+export type BlueskyVideo = {
   alt: string;
   ref: {
     $link: string;
@@ -83,9 +83,9 @@ export interface BlueskyVideo {
     width: number;
     height: number;
   };
-}
+};
 
-export interface BlueskyExternal {
+export type BlueskyExternal = {
   uri: string;
   title: string;
   description: string;
@@ -96,7 +96,7 @@ export interface BlueskyExternal {
     mimeType: string;
     size: number;
   };
-}
+};
 
 export type BlueskyRecordAuthor = {
   did: string;
@@ -143,7 +143,64 @@ export type BlueskyNestedRecord = {
   labels?: BlueskyLabel[];
 };
 
-export interface BlueskyRecord {
+export type BlueskyProfileUpdateInput = {
+  displayName?: string;
+  description?: string;
+  avatar?: string;
+  banner?: string;
+};
+
+export type BlueskyFeedGeneratorsResponse = {
+  feeds: BlueskyFeed[];
+};
+
+export type BlueskyPostReplyReference = {
+  root: string;
+  parent: string;
+};
+
+export type BlueskyPostImageInput = {
+  uri: string;
+  alt: string;
+  mimeType: string;
+  tenorId?: string;
+};
+
+export type BlueskyCreatePostInput = {
+  text: string;
+  replyTo?: BlueskyPostReplyReference;
+  images?: BlueskyPostImageInput[];
+};
+
+export type BlueskyUploadBlobResponse = {
+  blob: {
+    ref: {
+      $link: string;
+    };
+    mimeType: string;
+    size: number;
+  };
+};
+
+export type BlueskyCreatePostResponse = {
+  uri: string;
+  cid: string;
+  commit: {
+    cid: string;
+    rev: string;
+  };
+  validationStatus: string;
+};
+
+export type BlueskySendMessageInput = {
+  text: string;
+};
+
+export type BlueskyUnreadNotificationCount = {
+  count: number;
+};
+
+export type BlueskyRecord = {
   uri: string;
   cid: string;
   $type?: string; // For blocked records like 'app.bsky.embed.record#viewBlocked'
@@ -167,15 +224,15 @@ export interface BlueskyRecord {
       byteStart: number;
       byteEnd: number;
     };
-    features: {
+  features: {
       $type: string;
       uri?: string;
       tag?: string;
     }[];
   }[];
-}
+};
 
-export interface BlueskyEmbed {
+export type BlueskyEmbed = {
   $type: string;
   images?: BlueskyImage[];
   video?: BlueskyVideo;
@@ -190,9 +247,9 @@ export interface BlueskyEmbed {
     width: number;
     height: number;
   };
-}
+};
 
-export interface BlueskyAuthor {
+export type BlueskyAuthor = {
   did: string;
   handle: string;
   displayName: string;
@@ -203,7 +260,7 @@ export interface BlueskyAuthor {
   createdAt: string;
   verification?: BlueskyVerification;
   status?: BlueskyStatus;
-}
+};
 
 export type BlueskyPostView = {
   /** The post's URI */
@@ -868,10 +925,10 @@ export type BlueskyAppStatePref = {
   /** Type identifier */
   $type: 'app.bsky.actor.defs#bskyAppStatePref';
   /** NUX completion status */
-  nuxs?: Array<{
+  nuxs?: {
     id: string;
     completed: boolean;
-  }>;
+  }[];
 };
 
 /**

--- a/packages/tenor-api/src/index.ts
+++ b/packages/tenor-api/src/index.ts
@@ -46,6 +46,13 @@ export type TenorTrendingResponse = {
   next: string;
 };
 
+export type TenorAttachedImage = {
+  uri: string;
+  alt: string;
+  mimeType: string;
+  tenorId?: string;
+};
+
 class TenorAPI {
   private apiKey: string;
 
@@ -147,16 +154,11 @@ class TenorAPI {
   }
 
   /**
-   * Convert Tenor GIF to AttachedImage format
-   * @param gif - Tenor GIF object
-   * @returns AttachedImage object
+   * Converts a Tenor GIF response into the attachment structure used by Bluesky posts.
+   * @param gif - Tenor GIF entry returned by the search or trending endpoints.
+   * @returns Attachment metadata capturing the GIF URL, alt text and Bluesky MIME requirements.
    */
-  convertGifToAttachedImage(gif: TenorGif): {
-    uri: string;
-    alt: string;
-    mimeType: string;
-    tenorId?: string;
-  } {
+  convertGifToAttachedImage(gif: TenorGif): TenorAttachedImage {
     // Try to get the best available format
     const gifUrl = gif.media_formats.gif?.url || gif.media_formats.tinygif?.url || gif.media_formats.nanogif?.url || gif.url;
 


### PR DESCRIPTION
## Summary
- add descriptive JSDoc to Bluesky API surface and reuse shared type aliases
- extract reusable types for post creation, feed generators, uploads and messaging to avoid inline object shapes
- document LibreTranslate and Tenor helpers while introducing named attachment type

## Testing
- npm run lint -- --filter=akari
- npm run lint -- --filter=bluesky-api

------
https://chatgpt.com/codex/tasks/task_e_68d4851cc228832bae726baeff611741