### PR TITLE
fix: serve docs assets correctly on GitHub Pages

### DIFF
--- a/apps/docs/vite.config.mts
+++ b/apps/docs/vite.config.mts
@@ -3,6 +3,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 
 export default defineConfig({
+  base: './',
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- configure the docs Vite build to emit relative asset URLs so GitHub Pages can load bundled files

## Testing
- npm run lint -- --filter=akari
- npm run lint -- --filter=docs

------
https://chatgpt.com/codex/tasks/task_e_68d48f7e6c54832b96b061cc2b12a6a1