### PR TITLE
refactor: split profile block handler

### DIFF
--- a/apps/akari/__tests__/hooks/useBlockUserHandler.test.tsx
+++ b/apps/akari/__tests__/hooks/useBlockUserHandler.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import { useBlockUserHandler } from '@/hooks/useBlockUserHandler';
+import { useBlockUser } from '@/hooks/mutations/useBlockUser';
+import { useToast } from '@/contexts/ToastContext';
+import { useTranslation } from '@/hooks/useTranslation';
+import { showAlert } from '@/utils/alert';
+
+jest.mock('@/hooks/mutations/useBlockUser');
+jest.mock('@/contexts/ToastContext');
+jest.mock('@/hooks/useTranslation');
+jest.mock('@/utils/alert');
+
+describe('useBlockUserHandler', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useBlockUser as jest.Mock).mockReturnValue({ mutateAsync: jest.fn().mockResolvedValue(undefined) });
+    (useToast as jest.Mock).mockReturnValue({ showToast: jest.fn(), hideToast: jest.fn() });
+    (useTranslation as jest.Mock).mockReturnValue({
+      t: (key: string, params?: Record<string, string>) =>
+        params?.handle ? `${key}:${params.handle}` : key,
+    });
+    (showAlert as jest.Mock).mockImplementation(({ buttons }) => {
+      const confirmButton = buttons?.find((button: any) => button.style === 'destructive');
+      confirmButton?.onPress?.();
+    });
+  });
+
+  it('blocks a user and invalidates profile queries', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const onSuccess = jest.fn();
+    const { result } = renderHook(() => useBlockUserHandler(), { wrapper });
+    const blockUserMockResults = (useBlockUser as jest.Mock).mock.results;
+    const blockUserInstance = blockUserMockResults[blockUserMockResults.length - 1]?.value as {
+      mutateAsync: jest.Mock;
+    } | undefined;
+    if (!blockUserInstance) {
+      throw new Error('useBlockUser mock was not invoked');
+    }
+    const mutateAsync = blockUserInstance.mutateAsync;
+
+    await act(async () => {
+      result.current.handleBlockPress({
+        did: 'did:example:123',
+        handle: 'alice',
+        onSuccess,
+      });
+    });
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        did: 'did:example:123',
+        blockUri: undefined,
+        action: 'block',
+      });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(expect.objectContaining({ queryKey: ['profile', 'alice'] }));
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['profile', 'did:example:123'] }),
+    );
+    expect(onSuccess).toHaveBeenCalled();
+    expect(showAlert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'common.block',
+        message: 'profile.blockConfirmation:alice',
+      }),
+    );
+  });
+
+  it('unblocks a user and shows error toast when mutation fails', async () => {
+    const { wrapper } = createWrapper();
+    const error = new Error('nope');
+    const mutateAsync = jest.fn().mockRejectedValue(error);
+    (useBlockUser as jest.Mock).mockReturnValueOnce({ mutateAsync });
+    const showToastMock = jest.fn();
+    (useToast as jest.Mock).mockReturnValueOnce({ showToast: showToastMock, hideToast: jest.fn() });
+    const { result } = renderHook(() => useBlockUserHandler(), { wrapper });
+
+    await act(async () => {
+      result.current.handleBlockPress({
+        did: 'did:example:999',
+        handle: 'bob',
+        blockingUri: 'at://block/123',
+      });
+    });
+
+    await waitFor(() => {
+      expect(mutateAsync).toHaveBeenCalledWith({
+        did: 'did:example:999',
+        blockUri: 'at://block/123',
+        action: 'unblock',
+      });
+    });
+
+    expect(showToastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        title: 'common.unblock',
+        message: 'common.somethingWentWrong',
+      }),
+    );
+  });
+});
+

--- a/apps/akari/app/(tabs)/profile/[handle].tsx
+++ b/apps/akari/app/(tabs)/profile/[handle].tsx
@@ -20,6 +20,7 @@ import { useToast } from '@/contexts/ToastContext';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useProfile } from '@/hooks/queries/useProfile';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useBlockUserHandler } from '@/hooks/useBlockUserHandler';
 import type { ProfileTabType } from '@/types/profile';
 import { showAlert } from '@/utils/alert';
 
@@ -32,6 +33,7 @@ export default function ProfileScreen() {
   const { t } = useTranslation();
   const { data: currentUser } = useCurrentAccount();
   const { showToast } = useToast();
+  const { handleBlockPress: showBlockConfirmation } = useBlockUserHandler();
 
   const { data: profile, isLoading, error } = useProfile(handle);
 
@@ -116,9 +118,16 @@ export default function ProfileScreen() {
   };
 
   const handleBlockPress = () => {
-    // TODO: Implement block functionality
-    console.log('Block account');
-    setShowDropdown(false);
+    if (!profile?.did) {
+      return;
+    }
+
+    showBlockConfirmation({
+      did: profile.did,
+      handle: profile.handle,
+      blockingUri: profile.viewer?.blocking,
+      onSuccess: () => setShowDropdown(false),
+    });
   };
 
   const handleReportAccount = () => {

--- a/apps/akari/app/(tabs)/profile/index.tsx
+++ b/apps/akari/app/(tabs)/profile/index.tsx
@@ -18,6 +18,7 @@ import { useToast } from '@/contexts/ToastContext';
 import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
 import { useProfile } from '@/hooks/queries/useProfile';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useBlockUserHandler } from '@/hooks/useBlockUserHandler';
 import { tabScrollRegistry } from '@/utils/tabScrollRegistry';
 import { showAlert } from '@/utils/alert';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -33,6 +34,7 @@ export default function ProfileScreen() {
   const scrollViewRef = useRef<ScrollView>(null);
   const { t } = useTranslation();
   const { showToast } = useToast();
+  const { handleBlockPress: showBlockConfirmation } = useBlockUserHandler();
 
   // Create scroll to top function
   const scrollToTop = () => {
@@ -181,8 +183,16 @@ export default function ProfileScreen() {
           setShowDropdown(false);
         }}
         onBlockPress={() => {
-          // TODO: Implement block account functionality
-          setShowDropdown(false);
+          if (!profile?.did || !profile?.handle) {
+            return;
+          }
+
+          showBlockConfirmation({
+            did: profile.did,
+            handle: profile.handle,
+            blockingUri: profile.viewer?.blocking,
+            onSuccess: () => setShowDropdown(false),
+          });
         }}
         onReportAccount={() => {
           // TODO: Implement report account functionality

--- a/apps/akari/hooks/useBlockUserHandler.ts
+++ b/apps/akari/hooks/useBlockUserHandler.ts
@@ -1,0 +1,77 @@
+import { useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { useBlockUser } from '@/hooks/mutations/useBlockUser';
+import { useToast } from '@/contexts/ToastContext';
+import { useTranslation } from '@/hooks/useTranslation';
+import { showAlert } from '@/utils/alert';
+
+type HandleBlockPressParams = {
+  did?: string;
+  handle: string;
+  blockingUri?: string;
+  onSuccess?: () => void;
+};
+
+export function useBlockUserHandler() {
+  const queryClient = useQueryClient();
+  const blockMutation = useBlockUser();
+  const { showToast } = useToast();
+  const { t } = useTranslation();
+
+  const handleBlockPress = useCallback(
+    ({ did, handle, blockingUri, onSuccess }: HandleBlockPressParams) => {
+      if (!did) {
+        return;
+      }
+
+      const isBlocking = Boolean(blockingUri);
+      const action = isBlocking ? 'unblock' : 'block';
+      const titleKey = isBlocking ? 'common.unblock' : 'common.block';
+      const messageKey = isBlocking ? 'profile.unblockConfirmation' : 'profile.blockConfirmation';
+
+      const runMutation = async () => {
+        try {
+          await blockMutation.mutateAsync({
+            did,
+            blockUri: blockingUri,
+            action,
+          });
+
+          if (handle) {
+            queryClient.invalidateQueries({ queryKey: ['profile', handle] });
+          }
+
+          queryClient.invalidateQueries({ queryKey: ['profile', did] });
+          onSuccess?.();
+        } catch (error) {
+          console.error('Block error:', error);
+          showToast({
+            type: 'error',
+            title: t(titleKey),
+            message: t('common.somethingWentWrong'),
+          });
+        }
+      };
+
+      showAlert({
+        title: t(titleKey),
+        message: t(messageKey, { handle }),
+        buttons: [
+          { text: t('common.cancel'), style: 'cancel' },
+          {
+            text: t(titleKey),
+            style: 'destructive',
+            onPress: runMutation,
+          },
+        ],
+      });
+    },
+    [blockMutation, queryClient, showToast, t],
+  );
+
+  return {
+    handleBlockPress,
+  };
+}
+


### PR DESCRIPTION
## Summary
- replace the generic profile actions helper with a block-specific handler hook
- point profile header and tabbed screens at the new block helper for consistent confirmation UX
- update the associated tests to mock the new hook and add coverage for its behaviour

## Testing
- npm run lint -- --filter=akari
- npx turbo run test --filter=akari -- --runTestsByPath __tests__/hooks/useBlockUserHandler.test.tsx __tests__/app/tabs-profile.test.tsx __tests__/app/profile/[handle].test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68d7b7d525bc832bb33e198018d11948