### PR TITLE
test: add coverage for bluesky-api modules

### DIFF
--- a/packages/bluesky-api/src/api.test.ts
+++ b/packages/bluesky-api/src/api.test.ts
@@ -1,0 +1,227 @@
+import { BlueskyApi } from './api';
+import type {
+  BlueskyBookmarksResponse,
+  BlueskyConvosResponse,
+  BlueskyFeedGeneratorsResponse,
+  BlueskyFeedResponse,
+  BlueskyFeedsResponse,
+  BlueskyMessagesResponse,
+  BlueskyNotificationsResponse,
+  BlueskyPreferencesResponse,
+  BlueskyProfileResponse,
+  BlueskySearchActorsResponse,
+  BlueskySearchPostsResponse,
+  BlueskySendMessageInput,
+  BlueskySendMessageResponse,
+  BlueskySession,
+  BlueskyStarterPacksResponse,
+  BlueskyThreadResponse,
+  BlueskyTrendingTopicsResponse,
+  BlueskyUnreadNotificationCount,
+  BlueskyUploadBlobResponse,
+  BlueskyPostView,
+  BlueskyCreatePostInput,
+  BlueskyCreatePostResponse,
+} from './types';
+
+describe('BlueskyApi', () => {
+  const setupApi = () => {
+    const api = new BlueskyApi('https://pds.example');
+    const internal = api as unknown as {
+      auth: Record<string, jest.Mock>;
+      actors: Record<string, jest.Mock>;
+      feeds: Record<string, jest.Mock>;
+      conversations: Record<string, jest.Mock>;
+      graph: Record<string, jest.Mock>;
+      search: Record<string, jest.Mock>;
+      notifications: Record<string, jest.Mock>;
+    };
+
+    return { api, internal };
+  };
+
+  it('delegates authentication operations to the auth client', async () => {
+    const { api, internal } = setupApi();
+    const session: BlueskySession = {
+      did: 'did:example:alice',
+      handle: 'alice.test',
+      active: true,
+      accessJwt: 'access',
+      refreshJwt: 'refresh',
+    };
+    const refreshed: BlueskySession = {
+      ...session,
+      accessJwt: 'new-access',
+    };
+
+    internal.auth = {
+      createSession: jest.fn().mockResolvedValue(session),
+      refreshSession: jest.fn().mockResolvedValue(refreshed),
+    };
+
+    await expect(api.createSession('alice.test', 'password')).resolves.toBe(session);
+    await expect(api.refreshSession('refresh')).resolves.toBe(refreshed);
+
+    expect(internal.auth.createSession).toHaveBeenCalledWith('alice.test', 'password');
+    expect(internal.auth.refreshSession).toHaveBeenCalledWith('refresh');
+  });
+
+  it('forwards actor requests to the actors client', async () => {
+    const { api, internal } = setupApi();
+    const profile = { handle: 'alice.test' } as unknown as BlueskyProfileResponse;
+    const preferences = { preferences: [] } as BlueskyPreferencesResponse;
+
+    internal.actors = {
+      getProfile: jest.fn().mockResolvedValue(profile),
+      updateProfile: jest.fn().mockResolvedValue(profile),
+      getPreferences: jest.fn().mockResolvedValue(preferences),
+    };
+
+    await expect(api.getProfile('jwt', 'did:example:alice')).resolves.toBe(profile);
+    await expect(api.updateProfile('jwt', { displayName: 'Alice' })).resolves.toBe(profile);
+    await expect(api.getPreferences('jwt')).resolves.toBe(preferences);
+
+    expect(internal.actors.getProfile).toHaveBeenCalledWith('jwt', 'did:example:alice');
+    expect(internal.actors.updateProfile).toHaveBeenCalledWith('jwt', { displayName: 'Alice' });
+    expect(internal.actors.getPreferences).toHaveBeenCalledWith('jwt');
+  });
+
+  it('routes feed operations to the feeds client', async () => {
+    const { api, internal } = setupApi();
+    const feed = { feed: [] } as unknown as BlueskyFeedResponse;
+    const trending = { topics: [] } as unknown as BlueskyTrendingTopicsResponse;
+    const feedsResponse = { feeds: [] } as unknown as BlueskyFeedsResponse;
+    const feedGenerators = { feeds: [] } as unknown as BlueskyFeedGeneratorsResponse;
+    const bookmarks = { bookmarks: [] } as unknown as BlueskyBookmarksResponse;
+    const post = { uri: 'at://post/1' } as unknown as BlueskyPostView;
+    const thread = { thread: {} } as unknown as BlueskyThreadResponse;
+    const starterpacks = { starterPacks: [] } as unknown as BlueskyStarterPacksResponse;
+    const blob = { blob: { ref: { $link: 'ref' }, mimeType: 'image/png', size: 1 } } as BlueskyUploadBlobResponse;
+    const postInput: BlueskyCreatePostInput = { text: 'Hello' };
+    const postResponse = { uri: 'at://post/1', cid: 'cid', commit: { cid: 'cid', rev: 'rev' }, validationStatus: 'valid' } as BlueskyCreatePostResponse;
+
+    internal.feeds = {
+      getTimeline: jest.fn().mockResolvedValue(feed),
+      getTrendingTopics: jest.fn().mockResolvedValue(trending),
+      getFeeds: jest.fn().mockResolvedValue(feedsResponse),
+      getFeed: jest.fn().mockResolvedValue(feed),
+      getFeedGenerators: jest.fn().mockResolvedValue(feedGenerators),
+      getBookmarks: jest.fn().mockResolvedValue(bookmarks),
+      getPost: jest.fn().mockResolvedValue(post),
+      getPostThread: jest.fn().mockResolvedValue(thread),
+      getAuthorFeed: jest.fn().mockResolvedValue(feed),
+      getAuthorVideos: jest.fn().mockResolvedValue(feed),
+      getAuthorFeeds: jest.fn().mockResolvedValue(feedsResponse),
+      getAuthorStarterpacks: jest.fn().mockResolvedValue(starterpacks),
+      createPost: jest.fn().mockResolvedValue(postResponse),
+      uploadImage: jest.fn().mockResolvedValue(blob),
+      likePost: jest.fn().mockResolvedValue({ uri: 'like' }),
+      unlikePost: jest.fn().mockResolvedValue({ success: true }),
+    };
+
+    await expect(api.getTimeline('jwt', 10)).resolves.toBe(feed);
+    await expect(api.getTrendingTopics(5)).resolves.toBe(trending);
+    await expect(api.getFeeds('jwt', 'did:example', 25)).resolves.toBe(feedsResponse);
+    await expect(api.getFeed('jwt', 'at://feed/1', 30)).resolves.toBe(feed);
+    await expect(api.getFeedGenerators('jwt', ['at://feed/a'])).resolves.toBe(feedGenerators);
+    await expect(api.getBookmarks('jwt', 40)).resolves.toBe(bookmarks);
+    await expect(api.getPost('jwt', 'at://post/1')).resolves.toBe(post);
+    await expect(api.getPostThread('jwt', 'at://post/1')).resolves.toBe(thread);
+    await expect(api.getAuthorFeed('jwt', 'did:example', 15)).resolves.toBe(feed);
+    await expect(api.getAuthorVideos('jwt', 'did:example', 15)).resolves.toBe(feed);
+    await expect(api.getAuthorFeeds('jwt', 'did:example', 15)).resolves.toBe(feedsResponse);
+    await expect(api.getAuthorStarterpacks('jwt', 'did:example', 15)).resolves.toBe(starterpacks);
+    await expect(api.createPost('jwt', 'did:example', postInput)).resolves.toBe(postResponse);
+    await expect(api.uploadImage('jwt', 'file://image.png', 'image/png')).resolves.toBe(blob);
+    await expect(api.likePost('jwt', 'at://post/1', 'cid', 'did:example')).resolves.toEqual({ uri: 'like' });
+    await expect(api.unlikePost('jwt', 'at://like/1', 'did:example')).resolves.toEqual({ success: true });
+
+    expect(internal.feeds.getTimeline).toHaveBeenCalledWith('jwt', 10);
+    expect(internal.feeds.getTrendingTopics).toHaveBeenCalledWith(5);
+    expect(internal.feeds.getFeeds).toHaveBeenCalledWith('jwt', 'did:example', 25, undefined);
+    expect(internal.feeds.getFeed).toHaveBeenCalledWith('jwt', 'at://feed/1', 30, undefined);
+    expect(internal.feeds.getFeedGenerators).toHaveBeenCalledWith('jwt', ['at://feed/a']);
+    expect(internal.feeds.createPost).toHaveBeenCalledWith('jwt', 'did:example', postInput);
+  });
+
+  it('delegates conversation operations to the conversations client', async () => {
+    const { api, internal } = setupApi();
+    const convos = { convos: [] } as unknown as BlueskyConvosResponse;
+    const messages = { messages: [] } as unknown as BlueskyMessagesResponse;
+    const messageInput: BlueskySendMessageInput = { text: 'hi' };
+    const sendResponse = { conversation: { id: '1' } } as unknown as BlueskySendMessageResponse;
+
+    internal.conversations = {
+      listConversations: jest.fn().mockResolvedValue(convos),
+      getMessages: jest.fn().mockResolvedValue(messages),
+      sendMessage: jest.fn().mockResolvedValue(sendResponse),
+    };
+
+    await expect(api.listConversations('jwt', 5)).resolves.toBe(convos);
+    await expect(api.getMessages('jwt', 'convo', 10)).resolves.toBe(messages);
+    await expect(api.sendMessage('jwt', 'convo', messageInput)).resolves.toBe(sendResponse);
+
+    expect(internal.conversations.listConversations).toHaveBeenCalledWith('jwt', 5, undefined, undefined, undefined);
+    expect(internal.conversations.getMessages).toHaveBeenCalledWith('jwt', 'convo', 10, undefined);
+    expect(internal.conversations.sendMessage).toHaveBeenCalledWith('jwt', 'convo', messageInput);
+  });
+
+  it('delegates graph, search, and notification helpers to their respective clients', async () => {
+    const { api, internal } = setupApi();
+    const notifications = { notifications: [] } as unknown as BlueskyNotificationsResponse;
+    const unread = { count: 5 } as BlueskyUnreadNotificationCount;
+    const actorResults = { actors: [] } as unknown as BlueskySearchActorsResponse;
+    const postResults = { posts: [] } as unknown as BlueskySearchPostsResponse;
+
+    internal.graph = {
+      followUser: jest.fn().mockResolvedValue({}),
+      unfollowUser: jest.fn().mockResolvedValue({}),
+      blockUser: jest.fn().mockResolvedValue({}),
+      unblockUser: jest.fn().mockResolvedValue({}),
+      muteUser: jest.fn().mockResolvedValue({}),
+      unmuteUser: jest.fn().mockResolvedValue({}),
+      muteActorList: jest.fn().mockResolvedValue({}),
+      muteThread: jest.fn().mockResolvedValue({}),
+    };
+
+    internal.search = {
+      searchProfiles: jest.fn().mockResolvedValue(actorResults),
+      searchPosts: jest.fn().mockResolvedValue(postResults),
+    };
+
+    internal.notifications = {
+      listNotifications: jest.fn().mockResolvedValue(notifications),
+      getUnreadCount: jest.fn().mockResolvedValue(unread),
+    };
+
+    await api.followUser('jwt', 'did:example');
+    await api.unfollowUser('jwt', 'at://follow/1');
+    await api.blockUser('jwt', 'did:example');
+    await api.unblockUser('jwt', 'at://block/1');
+    await api.muteUser('jwt', 'did:example');
+    await api.unmuteUser('jwt', 'did:example');
+    await api.muteActorList('jwt', 'at://list/1');
+    await api.muteThread('jwt', 'at://post/1');
+    await expect(api.searchProfiles('jwt', 'query', 10)).resolves.toBe(actorResults);
+    await expect(api.searchPosts('jwt', 'query', 10)).resolves.toBe(postResults);
+    await expect(api.listNotifications('jwt', 20)).resolves.toBe(notifications);
+    await expect(api.getUnreadNotificationsCount('jwt')).resolves.toBe(unread);
+
+    expect(internal.graph.followUser).toHaveBeenCalledWith('jwt', 'did:example');
+    expect(internal.search.searchProfiles).toHaveBeenCalledWith('jwt', 'query', 10, undefined);
+    expect(internal.notifications.listNotifications).toHaveBeenCalledWith(
+      'jwt',
+      20,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+    expect(internal.notifications.getUnreadCount).toHaveBeenCalledWith('jwt');
+  });
+
+  it('creates instances using the static helper', () => {
+    const api = BlueskyApi.createWithPDS('https://pds.example');
+    expect(api).toBeInstanceOf(BlueskyApi);
+  });
+});

--- a/packages/bluesky-api/src/auth.test.ts
+++ b/packages/bluesky-api/src/auth.test.ts
@@ -1,0 +1,84 @@
+import { BlueskyAuth } from './auth';
+import type { BlueskySession } from './types';
+
+describe('BlueskyAuth', () => {
+  class TestAuth extends BlueskyAuth {
+    public lastCall?: {
+      endpoint: string;
+      options: {
+        method?: 'GET' | 'POST';
+        headers?: Record<string, string>;
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string>;
+      };
+    };
+
+    public response: unknown;
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeRequest<T>(
+      endpoint: string,
+      options: {
+        method?: 'GET' | 'POST';
+        headers?: Record<string, string>;
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      this.lastCall = { endpoint, options };
+      return this.response as T;
+    }
+  }
+
+  it('creates a session with the provided credentials', async () => {
+    const auth = new TestAuth();
+    const session: BlueskySession = {
+      did: 'did:example:alice',
+      handle: 'alice.test',
+      active: true,
+      accessJwt: 'access-token',
+      refreshJwt: 'refresh-token',
+    };
+    auth.response = session;
+
+    const result = await auth.createSession('alice.test', 'password-123');
+
+    expect(result).toEqual(session);
+    expect(auth.lastCall).toEqual({
+      endpoint: '/com.atproto.server.createSession',
+      options: {
+        method: 'POST',
+        body: {
+          identifier: 'alice.test',
+          password: 'password-123',
+        },
+      },
+    });
+  });
+
+  it('refreshes a session using the refresh token', async () => {
+    const auth = new TestAuth();
+    const session: BlueskySession = {
+      did: 'did:example:alice',
+      handle: 'alice.test',
+      active: true,
+      accessJwt: 'access-token',
+      refreshJwt: 'new-refresh',
+    };
+    auth.response = session;
+
+    const result = await auth.refreshSession('refresh-token');
+
+    expect(result).toEqual(session);
+    expect(auth.lastCall).toEqual({
+      endpoint: '/com.atproto.server.refreshSession',
+      options: {
+        method: 'POST',
+        headers: { Authorization: 'Bearer refresh-token' },
+      },
+    });
+  });
+});

--- a/packages/bluesky-api/src/conversations.test.ts
+++ b/packages/bluesky-api/src/conversations.test.ts
@@ -1,0 +1,128 @@
+import { BlueskyConversations } from './conversations';
+import type {
+  BlueskyConvosResponse,
+  BlueskyMessagesResponse,
+  BlueskySendMessageInput,
+  BlueskySendMessageResponse,
+} from './types';
+
+describe('BlueskyConversations', () => {
+  class TestConversations extends BlueskyConversations {
+    public lastCall?: {
+      endpoint: string;
+      accessJwt: string;
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string>;
+        headers?: Record<string, string>;
+      };
+    };
+
+    public response: unknown;
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string>;
+        headers?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      this.lastCall = { endpoint, accessJwt, options };
+      return this.response as T;
+    }
+  }
+
+  it('lists conversations with optional filters', async () => {
+    const convoResponse: BlueskyConvosResponse = {
+      cursor: 'next',
+      convos: [],
+    };
+    const conversations = new TestConversations();
+    conversations.response = convoResponse;
+
+    const result = await conversations.listConversations('jwt', 10, 'cursor-1', 'unread', 'accepted');
+
+    expect(result).toEqual(convoResponse);
+    expect(conversations.lastCall).toEqual({
+      endpoint: '/chat.bsky.convo.listConvos',
+      accessJwt: 'jwt',
+      options: {
+        params: {
+          limit: '10',
+          cursor: 'cursor-1',
+          readState: 'unread',
+          status: 'accepted',
+        },
+        headers: {
+          'atproto-proxy': 'did:web:api.bsky.chat#bsky_chat',
+        },
+      },
+    });
+  });
+
+  it('fetches messages for a conversation', async () => {
+    const messageResponse: BlueskyMessagesResponse = {
+      cursor: 'next',
+      messages: [],
+    };
+    const conversations = new TestConversations();
+    conversations.response = messageResponse;
+
+    const result = await conversations.getMessages('jwt', 'convo-1', 25, 'cursor-2');
+
+    expect(result).toEqual(messageResponse);
+    expect(conversations.lastCall).toEqual({
+      endpoint: '/chat.bsky.convo.getMessages',
+      accessJwt: 'jwt',
+      options: {
+        params: {
+          convoId: 'convo-1',
+          limit: '25',
+          cursor: 'cursor-2',
+        },
+        headers: {
+          'atproto-proxy': 'did:web:api.bsky.chat#bsky_chat',
+        },
+      },
+    });
+  });
+
+  it('sends a message to a conversation', async () => {
+    const sendResponse: BlueskySendMessageResponse = {
+      id: 'msg-1',
+      rev: '1',
+      text: 'Hello there',
+      sender: { did: 'did:example:alice' },
+      sentAt: '2024-01-01T00:00:00.000Z',
+    };
+    const conversations = new TestConversations();
+    conversations.response = sendResponse;
+    const message: BlueskySendMessageInput = { text: 'Hello there' };
+
+    const result = await conversations.sendMessage('jwt', 'convo-1', message);
+
+    expect(result).toEqual(sendResponse);
+    expect(conversations.lastCall).toEqual({
+      endpoint: '/chat.bsky.convo.sendMessage',
+      accessJwt: 'jwt',
+      options: {
+        method: 'POST',
+        headers: {
+          'atproto-proxy': 'did:web:api.bsky.chat#bsky_chat',
+        },
+        body: {
+          convoId: 'convo-1',
+          message,
+        },
+      },
+    });
+  });
+});

--- a/packages/bluesky-api/src/feeds.test.ts
+++ b/packages/bluesky-api/src/feeds.test.ts
@@ -1,0 +1,356 @@
+import { BlueskyFeeds } from './feeds';
+import type {
+  BlueskyBookmarksResponse,
+  BlueskyFeedGeneratorsResponse,
+  BlueskyFeedResponse,
+  BlueskyFeedsResponse,
+  BlueskyLikeResponse,
+  BlueskyPostView,
+  BlueskyStarterPacksResponse,
+  BlueskyThreadResponse,
+  BlueskyTrendingTopicsResponse,
+  BlueskyUnlikeResponse,
+} from './types';
+
+describe('BlueskyFeeds', () => {
+  class TestFeeds extends BlueskyFeeds {
+    public authCalls: {
+      endpoint: string;
+      accessJwt: string;
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string>;
+        headers?: Record<string, string>;
+      };
+    }[] = [];
+
+    public requestCalls: {
+      endpoint: string;
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string>;
+        headers?: Record<string, string>;
+      };
+    }[] = [];
+
+    public responses: unknown[] = [];
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string>;
+        headers?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      this.authCalls.push({ endpoint, accessJwt, options });
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+
+    protected async makeRequest<T>(
+      endpoint: string,
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string>;
+        headers?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      this.requestCalls.push({ endpoint, options });
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+  }
+
+  it('requests the timeline with default limit and labeler headers', async () => {
+    const feeds = new TestFeeds();
+    const feedResponse = { feed: [] } as unknown as BlueskyFeedResponse;
+    feeds.responses = [feedResponse];
+
+    const result = await feeds.getTimeline('jwt');
+
+    expect(result).toBe(feedResponse);
+    expect(feeds.authCalls).toHaveLength(1);
+    const call = feeds.authCalls[0];
+    expect(call).toMatchObject({
+      endpoint: '/app.bsky.feed.getTimeline',
+      accessJwt: 'jwt',
+      options: { params: { limit: '20' } },
+    });
+    expect(call.options.headers?.['atproto-accept-labelers']).toContain(
+      'did:plc:ar7c4by46qjdydhdevvrndac;redact',
+    );
+  });
+
+  it('fetches trending topics without authentication', async () => {
+    const feeds = new TestFeeds();
+    const topicsResponse = { topics: [] } as unknown as BlueskyTrendingTopicsResponse;
+    feeds.responses = [topicsResponse];
+
+    const result = await feeds.getTrendingTopics();
+
+    expect(result).toBe(topicsResponse);
+    expect(feeds.requestCalls).toEqual([
+      {
+        endpoint: '/app.bsky.unspecced.getTrendingTopics',
+        options: { params: { limit: '10' } },
+      },
+    ]);
+  });
+
+  it('loads actor feeds with pagination cursor', async () => {
+    const feeds = new TestFeeds();
+    const response = { feeds: [] } as unknown as BlueskyFeedsResponse;
+    feeds.responses = [response];
+
+    const result = await feeds.getFeeds('jwt', 'did:example:alice', 25, 'cursor-123');
+
+    expect(result).toBe(response);
+    expect(feeds.authCalls[0]).toEqual({
+      endpoint: '/app.bsky.feed.getActorFeeds',
+      accessJwt: 'jwt',
+      options: {
+        params: {
+          actor: 'did:example:alice',
+          limit: '25',
+          cursor: 'cursor-123',
+        },
+      },
+    });
+  });
+
+  it('requests posts from a feed generator', async () => {
+    const feeds = new TestFeeds();
+    const response = { feed: [] } as unknown as BlueskyFeedResponse;
+    feeds.responses = [response];
+
+    const result = await feeds.getFeed('jwt', 'at://feed/123', 30);
+
+    expect(result).toBe(response);
+    expect(feeds.authCalls[0]).toEqual({
+      endpoint: '/app.bsky.feed.getFeed',
+      accessJwt: 'jwt',
+      options: {
+        params: {
+          feed: 'at://feed/123',
+          limit: '30',
+        },
+      },
+    });
+  });
+
+  it('fetches feed generator metadata', async () => {
+    const feeds = new TestFeeds();
+    const response = { feeds: [] } as unknown as BlueskyFeedGeneratorsResponse;
+    feeds.responses = [response];
+
+    const result = await feeds.getFeedGenerators('jwt', ['at://feed/a', 'at://feed/b']);
+
+    expect(result).toBe(response);
+    expect(feeds.authCalls[0]).toEqual({
+      endpoint: '/app.bsky.feed.getFeedGenerators',
+      accessJwt: 'jwt',
+      options: {
+        params: {
+          feeds: 'at://feed/a,at://feed/b',
+        },
+      },
+    });
+  });
+
+  it('lists bookmarks and forwards the cursor parameter when provided', async () => {
+    const feeds = new TestFeeds();
+    const response = { bookmarks: [] } as unknown as BlueskyBookmarksResponse;
+    feeds.responses = [response];
+
+    const result = await feeds.getBookmarks('jwt', 40, 'cursor-abc');
+
+    expect(result).toBe(response);
+    expect(feeds.authCalls[0]).toEqual({
+      endpoint: '/app.bsky.bookmark.getBookmarks',
+      accessJwt: 'jwt',
+      options: {
+        params: {
+          limit: '40',
+          cursor: 'cursor-abc',
+        },
+      },
+    });
+  });
+
+  it('returns a post from getPost when the thread is present', async () => {
+    const feeds = new TestFeeds();
+    const post = { uri: 'at://post/1' } as unknown as BlueskyPostView;
+    feeds.responses = [
+      {
+        thread: { post },
+      },
+    ];
+
+    const result = await feeds.getPost('jwt', 'at://post/1');
+
+    expect(result).toBe(post);
+    expect(feeds.authCalls[0]).toMatchObject({
+      endpoint: '/app.bsky.feed.getPostThread',
+      accessJwt: 'jwt',
+      options: { params: { uri: 'at://post/1' } },
+    });
+  });
+
+  it('throws an error when getPost cannot find the post in the thread', async () => {
+    const feeds = new TestFeeds();
+    feeds.responses = [{}];
+
+    await expect(feeds.getPost('jwt', 'at://post/2')).rejects.toThrow('Post not found');
+  });
+
+  it('retrieves a thread without extra processing', async () => {
+    const feeds = new TestFeeds();
+    const threadResponse = { thread: {} } as unknown as BlueskyThreadResponse;
+    feeds.responses = [threadResponse];
+
+    const result = await feeds.getPostThread('jwt', 'at://post/3');
+
+    expect(result).toBe(threadResponse);
+    expect(feeds.authCalls[0]).toEqual({
+      endpoint: '/app.bsky.feed.getPostThread',
+      accessJwt: 'jwt',
+      options: { params: { uri: 'at://post/3' } },
+    });
+  });
+
+  it('requests the author feed with filter and cursor', async () => {
+    const feeds = new TestFeeds();
+    const response = { feed: [] } as unknown as BlueskyFeedResponse;
+    feeds.responses = [response];
+
+    const result = await feeds.getAuthorFeed(
+      'jwt',
+      'did:example:alice',
+      10,
+      'cursor-1',
+      'posts_with_media',
+    );
+
+    expect(result).toBe(response);
+    expect(feeds.authCalls[0]).toEqual({
+      endpoint: '/app.bsky.feed.getAuthorFeed',
+      accessJwt: 'jwt',
+      options: {
+        params: {
+          actor: 'did:example:alice',
+          limit: '10',
+          cursor: 'cursor-1',
+          filter: 'posts_with_media',
+        },
+      },
+    });
+  });
+
+  it('requests the author video feed and forces the video filter', async () => {
+    const feeds = new TestFeeds();
+    const response = { feed: [] } as unknown as BlueskyFeedResponse;
+    feeds.responses = [response];
+
+    const result = await feeds.getAuthorVideos('jwt', 'did:example:bob', 5, 'cursor-2');
+
+    expect(result).toBe(response);
+    expect(feeds.authCalls[0]).toEqual({
+      endpoint: '/app.bsky.feed.getAuthorFeed',
+      accessJwt: 'jwt',
+      options: {
+        params: {
+          actor: 'did:example:bob',
+          limit: '5',
+          cursor: 'cursor-2',
+          filter: 'posts_with_video',
+        },
+      },
+    });
+  });
+
+  it('requests author feeds and starterpacks', async () => {
+    const feeds = new TestFeeds();
+    const feedResponse = { feeds: [] } as unknown as BlueskyFeedsResponse;
+    const starterpacksResponse = {
+      starterPacks: [],
+    } as unknown as BlueskyStarterPacksResponse;
+    feeds.responses = [feedResponse, starterpacksResponse];
+
+    const feedsResult = await feeds.getAuthorFeeds('jwt', 'did:example:carol', 15);
+    const starterpacksResult = await feeds.getAuthorStarterpacks('jwt', 'did:example:carol', 15);
+
+    expect(feedsResult).toBe(feedResponse);
+    expect(starterpacksResult).toBe(starterpacksResponse);
+    expect(feeds.authCalls[0]).toEqual({
+      endpoint: '/app.bsky.feed.getActorFeeds',
+      accessJwt: 'jwt',
+      options: { params: { actor: 'did:example:carol', limit: '15' } },
+    });
+    expect(feeds.authCalls[1]).toEqual({
+      endpoint: '/app.bsky.graph.getActorStarterPacks',
+      accessJwt: 'jwt',
+      options: { params: { actor: 'did:example:carol', limit: '15' } },
+    });
+  });
+
+  it('likes a post using the repo createRecord endpoint', async () => {
+    const feeds = new TestFeeds();
+    const response = { uri: 'at://like/1' } as unknown as BlueskyLikeResponse;
+    feeds.responses = [response];
+
+    const result = await feeds.likePost('jwt', 'at://post/5', 'cid123', 'did:example:me');
+
+    expect(result).toBe(response);
+    expect(feeds.authCalls[0].endpoint).toBe('/com.atproto.repo.createRecord');
+    expect(feeds.authCalls[0].options.method).toBe('POST');
+    expect(feeds.authCalls[0].options.body).toMatchObject({
+      repo: 'did:example:me',
+      collection: 'app.bsky.feed.like',
+      record: {
+        subject: { uri: 'at://post/5', cid: 'cid123' },
+        $type: 'app.bsky.feed.like',
+      },
+    });
+    const createdAt = (feeds.authCalls[0].options.body as Record<string, unknown>).record as Record<string, unknown>;
+    expect(typeof createdAt.createdAt).toBe('string');
+  });
+
+  it('unlikes a post using the deleteRecord endpoint', async () => {
+    const feeds = new TestFeeds();
+    const response = { success: true } as unknown as BlueskyUnlikeResponse;
+    feeds.responses = [response];
+
+    const result = await feeds.unlikePost('jwt', 'at://did:example/app.bsky.feed.like/123', 'did:example:me');
+
+    expect(result).toBe(response);
+    expect(feeds.authCalls[0]).toEqual({
+      endpoint: '/com.atproto.repo.deleteRecord',
+      accessJwt: 'jwt',
+      options: {
+        method: 'POST',
+        body: {
+          collection: 'app.bsky.feed.like',
+          repo: 'did:example:me',
+          rkey: '123',
+        },
+      },
+    });
+  });
+
+  it('throws an error when the like URI does not include an rkey', async () => {
+    const feeds = new TestFeeds();
+
+    await expect(feeds.unlikePost('jwt', 'at://did:example/', 'did:example:me')).rejects.toThrow(
+      'Invalid like URI: could not extract rkey',
+    );
+    expect(feeds.authCalls).toHaveLength(0);
+  });
+});

--- a/packages/bluesky-api/src/graph.test.ts
+++ b/packages/bluesky-api/src/graph.test.ts
@@ -1,0 +1,154 @@
+import { BlueskyGraph } from './graph';
+
+describe('BlueskyGraph', () => {
+  class TestGraph extends BlueskyGraph {
+    public calls: {
+      endpoint: string;
+      accessJwt: string;
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string>;
+        headers?: Record<string, string>;
+      };
+    }[] = [];
+
+    public responses: unknown[] = [];
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string>;
+        headers?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      this.calls.push({ endpoint, accessJwt, options });
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+  }
+
+  it('follows and unfollows users through repo record endpoints', async () => {
+    const graph = new TestGraph();
+    graph.responses = [{ uri: 'follow-record' }, { success: true }];
+
+    const followResult = await graph.followUser('jwt', 'did:example:alice');
+    const unfollowResult = await graph.unfollowUser('jwt', 'at://follow/123');
+
+    expect(followResult).toEqual({ uri: 'follow-record' });
+    expect(unfollowResult).toEqual({ success: true });
+
+    expect(graph.calls[0]).toMatchObject({
+      endpoint: '/com.atproto.repo.createRecord',
+      accessJwt: 'jwt',
+      options: {
+        method: 'POST',
+        body: {
+          repo: 'self',
+          collection: 'app.bsky.graph.follow',
+          record: expect.objectContaining({ subject: 'did:example:alice' }),
+        },
+      },
+    });
+    const followRecord = graph.calls[0].options.body as { record: Record<string, unknown> };
+    expect(typeof followRecord.record.createdAt).toBe('string');
+
+    expect(graph.calls[1]).toEqual({
+      endpoint: '/com.atproto.repo.deleteRecord',
+      accessJwt: 'jwt',
+      options: {
+        method: 'POST',
+        body: {
+          uri: 'at://follow/123',
+        },
+      },
+    });
+  });
+
+  it('blocks and unblocks actors', async () => {
+    const graph = new TestGraph();
+    graph.responses = [{ block: true }, { success: true }];
+
+    const blockResult = await graph.blockUser('jwt', 'did:example:bob');
+    const unblockResult = await graph.unblockUser('jwt', 'at://block/1');
+
+    expect(blockResult).toEqual({ block: true });
+    expect(unblockResult).toEqual({ success: true });
+
+    expect(graph.calls[0].endpoint).toBe('/com.atproto.repo.createRecord');
+    expect(graph.calls[0].options.body).toMatchObject({
+      repo: 'self',
+      collection: 'app.bsky.graph.block',
+      record: expect.objectContaining({ subject: 'did:example:bob' }),
+    });
+    expect(graph.calls[1]).toEqual({
+      endpoint: '/com.atproto.repo.deleteRecord',
+      accessJwt: 'jwt',
+      options: {
+        method: 'POST',
+        body: {
+          uri: 'at://block/1',
+        },
+      },
+    });
+  });
+
+  it('mutes users, lists, and threads via dedicated endpoints', async () => {
+    const graph = new TestGraph();
+    graph.responses = [{}, {}, {}];
+
+    await graph.muteUser('jwt', 'did:example:carol');
+    await graph.muteActorList('jwt', 'at://list/1');
+    await graph.muteThread('jwt', 'at://post/thread');
+
+    expect(graph.calls).toHaveLength(3);
+    expect(graph.calls[0]).toEqual({
+      endpoint: '/app.bsky.graph.muteActor',
+      accessJwt: 'jwt',
+      options: {
+        method: 'POST',
+        body: { actor: 'did:example:carol' },
+      },
+    });
+    expect(graph.calls[1]).toEqual({
+      endpoint: '/app.bsky.graph.muteActorList',
+      accessJwt: 'jwt',
+      options: {
+        method: 'POST',
+        body: { list: 'at://list/1' },
+      },
+    });
+    expect(graph.calls[2]).toEqual({
+      endpoint: '/app.bsky.graph.muteThread',
+      accessJwt: 'jwt',
+      options: {
+        method: 'POST',
+        body: { root: 'at://post/thread' },
+      },
+    });
+  });
+
+  it('unmutes users using the unmute endpoint', async () => {
+    const graph = new TestGraph();
+    graph.responses = [{}];
+
+    await graph.unmuteUser('jwt', 'did:example:dan');
+
+    expect(graph.calls).toEqual([
+      {
+        endpoint: '/app.bsky.graph.unmuteActor',
+        accessJwt: 'jwt',
+        options: {
+          method: 'POST',
+          body: { actor: 'did:example:dan' },
+        },
+      },
+    ]);
+  });
+});

--- a/packages/bluesky-api/src/index.test.ts
+++ b/packages/bluesky-api/src/index.test.ts
@@ -1,0 +1,17 @@
+import * as Bluesky from './index';
+
+describe('index exports', () => {
+  it('exposes the main API surface', () => {
+    expect(Bluesky.BlueskyApi).toBeDefined();
+    expect(Bluesky.BlueskyAuth).toBeDefined();
+    expect(Bluesky.BlueskyActors).toBeDefined();
+    expect(Bluesky.BlueskyFeeds).toBeDefined();
+    expect(Bluesky.BlueskyConversations).toBeDefined();
+    expect(Bluesky.BlueskyGraph).toBeDefined();
+    expect(Bluesky.BlueskySearch).toBeDefined();
+    expect(Bluesky.BlueskyNotifications).toBeDefined();
+    expect(typeof Bluesky.resolveBlueskyVideoUrl).toBe('function');
+    expect(typeof Bluesky.getPdsUrlFromDid).toBe('function');
+    expect(typeof Bluesky.getPdsUrlFromHandle).toBe('function');
+  });
+});

--- a/packages/bluesky-api/src/search.test.ts
+++ b/packages/bluesky-api/src/search.test.ts
@@ -1,0 +1,85 @@
+import { BlueskySearch } from './search';
+import type {
+  BlueskySearchActorsResponse,
+  BlueskySearchPostsResponse,
+} from './types';
+
+describe('BlueskySearch', () => {
+  class TestSearch extends BlueskySearch {
+    public calls: {
+      endpoint: string;
+      accessJwt: string;
+      options: {
+        method?: 'GET' | 'POST';
+        params?: Record<string, string>;
+        headers?: Record<string, string>;
+        body?: Record<string, unknown> | FormData | Blob;
+      };
+    }[] = [];
+
+    public responses: unknown[] = [];
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: {
+        method?: 'GET' | 'POST';
+        params?: Record<string, string>;
+        headers?: Record<string, string>;
+        body?: Record<string, unknown> | FormData | Blob;
+      } = {},
+    ): Promise<T> {
+      this.calls.push({ endpoint, accessJwt, options });
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+  }
+
+  it('searches profiles and forwards pagination cursor', async () => {
+    const search = new TestSearch();
+    const response = { actors: [] } as unknown as BlueskySearchActorsResponse;
+    search.responses = [response];
+
+    const result = await search.searchProfiles('jwt', 'carol', 15, 'cursor-abc');
+
+    expect(result).toBe(response);
+    expect(search.calls).toEqual([
+      {
+        endpoint: '/app.bsky.actor.searchActors',
+        accessJwt: 'jwt',
+        options: {
+          params: {
+            q: 'carol',
+            limit: '15',
+            cursor: 'cursor-abc',
+          },
+        },
+      },
+    ]);
+  });
+
+  it('searches posts without a cursor and uses the default limit', async () => {
+    const search = new TestSearch();
+    const response = { posts: [] } as unknown as BlueskySearchPostsResponse;
+    search.responses = [response];
+
+    const result = await search.searchPosts('jwt', 'hello world');
+
+    expect(result).toBe(response);
+    expect(search.calls).toEqual([
+      {
+        endpoint: '/app.bsky.feed.searchPosts',
+        accessJwt: 'jwt',
+        options: {
+          params: {
+            q: 'hello world',
+            limit: '20',
+          },
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit coverage for BlueskyAuth, BlueskyConversations, BlueskyFeeds, BlueskyGraph, and BlueskySearch request helpers
- verify BlueskyApi delegates to domain clients and ensure package index re-exports expected utilities

## Testing
- npm run lint -- --filter=bluesky-api
- cd packages/bluesky-api && npm run test -- --runTestsByPath src/auth.test.ts src/api.test.ts src/conversations.test.ts src/feeds.test.ts src/graph.test.ts src/index.test.ts src/search.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d7c3a9f474832bae374ed913b89a70