### PR TITLE
chore: add expo insights dependency

### DIFF
--- a/apps/akari/package.json
+++ b/apps/akari/package.json
@@ -63,6 +63,7 @@
     "expo-haptics": "~15.0.7",
     "expo-image": "~3.0.8",
     "expo-image-picker": "~17.0.8",
+    "expo-insights": "~0.9.3",
     "expo-linking": "~8.0.8",
     "expo-localization": "~17.0.7",
     "expo-notifications": "~0.32.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,7 @@
         "expo-haptics": "~15.0.7",
         "expo-image": "~3.0.8",
         "expo-image-picker": "~17.0.8",
+        "expo-insights": "~0.9.3",
         "expo-linking": "~8.0.8",
         "expo-localization": "~17.0.7",
         "expo-notifications": "~0.32.11",
@@ -10016,6 +10017,24 @@
       "peerDependencies": {
         "expo": "*"
       }
+    },
+    "node_modules/expo-insights": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/expo-insights/-/expo-insights-0.9.3.tgz",
+      "integrity": "sha512-ictylDUdERHPXUM4suEYLJGGvlSOB7btDSA0FtlZeVWWOcyTWQlSF5t1Wj3lCCljzjMm/pIj8k9hp8CXCl0gsg==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-eas-client": "~0.14.3"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-insights/node_modules/expo-eas-client": {
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/expo-eas-client/-/expo-eas-client-0.14.4.tgz",
+      "integrity": "sha512-TSL1BbBFIuXchJmPgbPnB7cGpOOuSGJcQ/L7gij/+zPjExwvKm5ckA5dlSulwoFhH8zQt4vb7bfISPSAWQVWBw==",
+      "license": "MIT"
     },
     "node_modules/expo-json-utils": {
       "version": "0.15.0",


### PR DESCRIPTION
## Summary
- add expo-insights to the Expo app dependencies so the package is available in the project

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68d87117bfa8832b9e9bcb1a96c3a09e