### PR TITLE
fix: align react-test-renderer with react 19.1

### DIFF
--- a/apps/akari/package.json
+++ b/apps/akari/package.json
@@ -105,7 +105,7 @@
     "jest": "~29.7.0",
     "jest-expo": "~54.0.12",
     "jsdom": "^27.0.0",
-    "react-test-renderer": "^19.1.0",
+    "react-test-renderer": "19.1.0",
     "ts-jest": "^29.4.1",
     "typescript": "~5.9.2",
     "vitest": "^2.1.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -145,7 +145,7 @@
         "jest": "~29.7.0",
         "jest-expo": "~54.0.12",
         "jsdom": "^27.0.0",
-        "react-test-renderer": "^19.1.0",
+        "react-test-renderer": "19.1.0",
         "ts-jest": "^29.4.1",
         "typescript": "~5.9.2",
         "vitest": "^2.1.9",


### PR DESCRIPTION
## Summary
- pin `react-test-renderer` to version 19.1.0 so its peer requirements match the Expo app's React version
- update the workspace lockfile to capture the pinned dependency

## Testing
- npm_config_progress=false npm install --no-save --no-package-lock
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68e0366c6824832b8ee1374b59f72450