### PR TITLE
fix: stretch feed tab bar to full width

### DIFF
--- a/apps/akari/app/(tabs)/index.tsx
+++ b/apps/akari/app/(tabs)/index.tsx
@@ -337,7 +337,8 @@ const styles = StyleSheet.create({
     paddingBottom: 12,
   },
   listHeaderContent: {
-    paddingHorizontal: 16,
+    width: '100%',
+    alignSelf: 'stretch',
   },
   header: {
     alignItems: 'center',


### PR DESCRIPTION
## Summary
- ensure the feed screen tab bar header stretches across the available width by removing the constraining padding

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68e064633dd8832b8390c8a455d3546f