### PR TITLE
feat: surface Whitewind posts on profiles

### DIFF
--- a/apps/akari/__tests__/app/profile/[handle].test.tsx
+++ b/apps/akari/__tests__/app/profile/[handle].test.tsx
@@ -43,13 +43,15 @@ jest.mock('@/components/ProfileTabs', () => {
   return {
     ProfileTabs: ({ onTabChange }: any) => (
       <>
-        {['posts', 'replies', 'likes', 'media', 'videos', 'feeds', 'repos', 'starterpacks', 'unknown'].map(
-          (tab) => (
-            <Text key={tab} accessibilityRole="button" onPress={() => onTabChange(tab as any)}>
-              {tab}
-            </Text>
-          ),
-        )}
+        {
+          ['posts', 'whitewind', 'replies', 'likes', 'media', 'videos', 'feeds', 'repos', 'starterpacks', 'unknown'].map(
+            (tab) => (
+              <Text key={tab} accessibilityRole="button" onPress={() => onTabChange(tab as any)}>
+                {tab}
+              </Text>
+            ),
+          )
+        }
       </>
     ),
   };
@@ -135,6 +137,11 @@ jest.mock('@/components/profile/StarterpacksTab', () => {
 jest.mock('@/components/profile/ReposTab', () => {
   const { Text } = require('react-native');
   return { ReposTab: ({ handle }: any) => <Text>{`repos ${handle}`}</Text> };
+});
+
+jest.mock('@/components/profile/WhitewindTab', () => {
+  const { Text } = require('react-native');
+  return { WhitewindTab: ({ handle }: any) => <Text>{`whitewind ${handle}`}</Text> };
 });
 
 const { ProfileHeader: ProfileHeaderMock } = require('@/components/ProfileHeader');

--- a/apps/akari/__tests__/app/tabs-profile.test.tsx
+++ b/apps/akari/__tests__/app/tabs-profile.test.tsx
@@ -136,6 +136,9 @@ jest.mock('@/components/ProfileTabs', () => {
         <TouchableOpacity onPress={() => onTabChange('posts')}>
           <Text>posts tab</Text>
         </TouchableOpacity>
+        <TouchableOpacity onPress={() => onTabChange('whitewind')}>
+          <Text>whitewind tab</Text>
+        </TouchableOpacity>
         <TouchableOpacity onPress={() => onTabChange('replies')}>
           <Text>replies tab</Text>
         </TouchableOpacity>
@@ -211,6 +214,12 @@ jest.mock('@/components/profile/ReposTab', () => {
   const React = require('react');
   const { Text } = require('react-native');
   return { ReposTab: ({ handle }: any) => <Text>repos {handle}</Text> };
+});
+
+jest.mock('@/components/profile/WhitewindTab', () => {
+  const React = require('react');
+  const { Text } = require('react-native');
+  return { WhitewindTab: ({ handle }: any) => <Text>whitewind {handle}</Text> };
 });
 
 jest.mock('@/components/ThemedView', () => {

--- a/apps/akari/__tests__/components/ProfileTabs.test.tsx
+++ b/apps/akari/__tests__/components/ProfileTabs.test.tsx
@@ -25,6 +25,7 @@ describe('ProfileTabs', () => {
       t: (key: string) => {
         const map: Record<string, string> = {
           'common.posts': 'Posts',
+          'profile.whitewind': 'Whitewind',
           'common.replies': 'Replies',
           'profile.media': 'Media',
           'common.likes': 'Likes',
@@ -51,6 +52,7 @@ describe('ProfileTabs', () => {
 
     const labels = [
       'Posts',
+      'Whitewind',
       'Replies',
       'Media',
       'Likes',
@@ -76,7 +78,7 @@ describe('ProfileTabs', () => {
       />,
     );
 
-    const labels = ['Posts', 'Replies', 'Media', 'Videos', 'Feeds', 'Repos', 'Starterpacks'];
+    const labels = ['Posts', 'Whitewind', 'Replies', 'Media', 'Videos', 'Feeds', 'Repos', 'Starterpacks'];
 
     for (const label of labels) {
       expect(getByText(label)).toBeTruthy();

--- a/apps/akari/__tests__/components/profile/WhitewindTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/WhitewindTab.test.tsx
@@ -1,0 +1,184 @@
+import { act, render } from '@testing-library/react-native';
+
+import { WhitewindTab } from '@/components/profile/WhitewindTab';
+import { useAuthorWhtwndPosts } from '@/hooks/queries/useAuthorWhtwndPosts';
+import { useThemeColor } from '@/hooks/useThemeColor';
+import { useTranslation } from '@/hooks/useTranslation';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
+
+jest.mock('@/hooks/queries/useAuthorWhtwndPosts');
+jest.mock('@/hooks/useThemeColor');
+jest.mock('@/hooks/useTranslation');
+jest.mock('@/components/skeletons', () => {
+  const { Text } = require('react-native');
+  return {
+    FeedSkeleton: () => <Text>feed skeleton</Text>,
+  };
+});
+jest.mock('@shopify/flash-list', () => require('../../../test-utils/flash-list'));
+
+const mockUseAuthorWhtwndPosts = useAuthorWhtwndPosts as jest.Mock;
+const mockUseThemeColor = useThemeColor as jest.Mock;
+const mockUseTranslation = useTranslation as jest.Mock;
+
+describe('WhitewindTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseThemeColor.mockImplementation((colors: { light?: string }) => colors.light ?? '#000');
+    mockUseTranslation.mockReturnValue({ t: (key: string) => key });
+  });
+
+  it('shows loading skeleton while fetching data', () => {
+    mockUseAuthorWhtwndPosts.mockReturnValue({
+      data: [],
+      isLoading: true,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    const { getByText } = render(<WhitewindTab handle="alice" isOwnProfile />);
+    expect(getByText('feed skeleton')).toBeTruthy();
+  });
+
+  it('renders empty state when no posts exist', () => {
+    mockUseAuthorWhtwndPosts.mockReturnValue({
+      data: [],
+      isLoading: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    const { getByText } = render(<WhitewindTab handle="alice" isOwnProfile={false} />);
+    expect(getByText('profile.noPosts')).toBeTruthy();
+  });
+
+  it('filters private posts for visitors', () => {
+    mockUseAuthorWhtwndPosts.mockReturnValue({
+      data: [
+        {
+          uri: 'at://post/1',
+          value: {
+            $type: 'com.whtwnd.blog.entry',
+            title: 'Private note',
+            content: 'secret',
+            createdAt: new Date().toISOString(),
+            visibility: 'author',
+          },
+        },
+        {
+          uri: 'at://post/2',
+          value: {
+            $type: 'com.whtwnd.blog.entry',
+            title: 'Public note',
+            content: 'hello world',
+            createdAt: new Date().toISOString(),
+            visibility: 'public',
+          },
+        },
+      ],
+      isLoading: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    const { getByText, queryByText } = render(
+      <WhitewindTab handle="alice" isOwnProfile={false} />,
+    );
+
+    expect(getByText('Public note')).toBeTruthy();
+    expect(queryByText('Private note')).toBeNull();
+  });
+
+  it('renders posts and loads more on end reach', () => {
+    const fetchNextPage = jest.fn();
+    const posts = [
+      {
+        uri: 'at://post/1',
+        value: {
+          $type: 'com.whtwnd.blog.entry',
+          title: 'Hello',
+          content: 'welcome to whitewind',
+          createdAt: new Date().toISOString(),
+          visibility: 'public',
+        },
+      },
+    ];
+
+    mockUseAuthorWhtwndPosts.mockReturnValue({
+      data: posts,
+      isLoading: false,
+      fetchNextPage,
+      hasNextPage: true,
+      isFetchingNextPage: false,
+    });
+
+    const { getByText, UNSAFE_getByType, queryByText } = render(
+      <WhitewindTab handle="alice" isOwnProfile />,
+    );
+
+    expect(getByText('Hello')).toBeTruthy();
+    expect(queryByText('common.loading')).toBeNull();
+
+    act(() => {
+      UNSAFE_getByType(VirtualizedList).props.onEndReached();
+    });
+
+    expect(fetchNextPage).toHaveBeenCalled();
+  });
+
+  it('shows loading footer when fetching next page', () => {
+    mockUseAuthorWhtwndPosts.mockReturnValue({
+      data: [
+        {
+          uri: 'at://post/1',
+          value: {
+            $type: 'com.whtwnd.blog.entry',
+            title: 'Hello',
+            content: 'welcome',
+            createdAt: new Date().toISOString(),
+            visibility: 'public',
+          },
+        },
+      ],
+      isLoading: false,
+      fetchNextPage: jest.fn(),
+      hasNextPage: true,
+      isFetchingNextPage: true,
+    });
+
+    const { getByText } = render(<WhitewindTab handle="alice" isOwnProfile />);
+    expect(getByText('common.loading')).toBeTruthy();
+  });
+
+  it('does not fetch when no more posts are available', () => {
+    const fetchNextPage = jest.fn();
+    mockUseAuthorWhtwndPosts.mockReturnValue({
+      data: [
+        {
+          uri: 'at://post/1',
+          value: {
+            $type: 'com.whtwnd.blog.entry',
+            title: 'Hello',
+            content: 'welcome',
+            createdAt: new Date().toISOString(),
+            visibility: 'public',
+          },
+        },
+      ],
+      isLoading: false,
+      fetchNextPage,
+      hasNextPage: false,
+      isFetchingNextPage: false,
+    });
+
+    const { UNSAFE_getByType } = render(<WhitewindTab handle="alice" isOwnProfile />);
+    act(() => {
+      UNSAFE_getByType(VirtualizedList).props.onEndReached();
+    });
+
+    expect(fetchNextPage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useAuthorWhtwndPosts.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useAuthorWhtwndPosts.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor, act } from '@testing-library/react-native';
+
+import { useAuthorWhtwndPosts } from '@/hooks/queries/useAuthorWhtwndPosts';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetAuthorWhtwndPosts = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getAuthorWhtwndPosts: mockGetAuthorWhtwndPosts,
+  })),
+}));
+
+describe('useAuthorWhtwndPosts query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+  });
+
+  it('fetches and paginates Whtwnd posts', async () => {
+    mockGetAuthorWhtwndPosts
+      .mockResolvedValueOnce({ records: [{ uri: 'at://post/1' }], cursor: 'cursor1' })
+      .mockResolvedValueOnce({ records: [{ uri: 'at://post/2' }], cursor: undefined });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAuthorWhtwndPosts('did', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual([{ uri: 'at://post/1' }]);
+    expect(mockGetAuthorWhtwndPosts).toHaveBeenCalledWith('token', 'did', 5, undefined);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ uri: 'at://post/1' }, { uri: 'at://post/2' }]);
+    });
+    expect(mockGetAuthorWhtwndPosts).toHaveBeenCalledWith('token', 'did', 5, 'cursor1');
+  });
+
+  it('errors when token is missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAuthorWhtwndPosts('did'), { wrapper });
+
+    await expect(result.current.refetch({ throwOnError: true })).rejects.toThrow('No access token');
+  });
+
+  it('errors when identifier is missing', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAuthorWhtwndPosts(undefined), { wrapper });
+
+    await expect(result.current.refetch({ throwOnError: true })).rejects.toThrow('No identifier provided');
+  });
+
+  it('errors when PDS URL is missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: {} });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAuthorWhtwndPosts('did'), { wrapper });
+
+    await expect(result.current.refetch({ throwOnError: true })).rejects.toThrow('No PDS URL available');
+  });
+});

--- a/apps/akari/app/(tabs)/profile/[handle].tsx
+++ b/apps/akari/app/(tabs)/profile/[handle].tsx
@@ -16,6 +16,7 @@ import { RepliesTab } from '@/components/profile/RepliesTab';
 import { StarterpacksTab } from '@/components/profile/StarterpacksTab';
 import { ReposTab } from '@/components/profile/ReposTab';
 import { VideosTab } from '@/components/profile/VideosTab';
+import { WhitewindTab } from '@/components/profile/WhitewindTab';
 import { searchProfilePosts } from '@/components/profile/profileActions';
 import { ProfileHeaderSkeleton } from '@/components/skeletons';
 import { useToast } from '@/contexts/ToastContext';
@@ -144,6 +145,8 @@ export default function ProfileScreen() {
         return <MediaTab handle={handle} />;
       case 'videos':
         return <VideosTab handle={handle} />;
+      case 'whitewind':
+        return <WhitewindTab handle={handle} isOwnProfile={isOwnProfile} />;
       case 'feeds':
         return <FeedsTab handle={handle} />;
       case 'repos':

--- a/apps/akari/components/ProfileTabs.tsx
+++ b/apps/akari/components/ProfileTabs.tsx
@@ -17,6 +17,7 @@ export function ProfileTabs({ activeTab, onTabChange, profileHandle }: ProfileTa
 
   const tabs = [
     { key: 'posts' as const, label: t('common.posts') },
+    { key: 'whitewind' as const, label: t('profile.whitewind') },
     { key: 'replies' as const, label: t('common.replies') },
     { key: 'media' as const, label: t('profile.media') },
     ...(isOwnProfile ? [{ key: 'likes' as const, label: t('common.likes') }] : []),

--- a/apps/akari/components/profile/WhitewindTab.tsx
+++ b/apps/akari/components/profile/WhitewindTab.tsx
@@ -1,0 +1,135 @@
+import { StyleSheet } from 'react-native';
+
+import { FeedSkeleton } from '@/components/skeletons';
+import { ThemedCard } from '@/components/ThemedCard';
+import { ThemedText } from '@/components/ThemedText';
+import { ThemedView } from '@/components/ThemedView';
+import { VirtualizedList } from '@/components/ui/VirtualizedList';
+import { useAuthorWhtwndPosts } from '@/hooks/queries/useAuthorWhtwndPosts';
+import { useThemeColor } from '@/hooks/useThemeColor';
+import { useTranslation } from '@/hooks/useTranslation';
+import { formatRelativeTime } from '@/utils/timeUtils';
+import type { BlueskyWhtwndEntry } from '@/bluesky-api';
+
+const ESTIMATED_WHITEWIND_CARD_HEIGHT = 220;
+
+export type WhitewindTabProps = {
+  handle: string;
+  isOwnProfile: boolean;
+};
+
+type WhitewindPostItemProps = {
+  entry: BlueskyWhtwndEntry;
+};
+
+function WhitewindPostItem({ entry }: WhitewindPostItemProps) {
+  const titleColor = useThemeColor({ light: '#1b1b1f', dark: '#f2f2f7' }, 'text');
+  const metaColor = useThemeColor({ light: '#5f6368', dark: '#9ba1a6' }, 'text');
+  const contentColor = useThemeColor({ light: '#1f2023', dark: '#f1f5f9' }, 'text');
+
+  return (
+    <ThemedCard style={styles.entryCard}>
+      <ThemedText style={[styles.entryTitle, { color: titleColor }]} numberOfLines={2}>
+        {entry.value.title}
+      </ThemedText>
+      <ThemedText style={[styles.entryMeta, { color: metaColor }]} accessibilityRole="text">
+        {formatRelativeTime(entry.value.createdAt)}
+      </ThemedText>
+      <ThemedText style={[styles.entryContent, { color: contentColor }]} numberOfLines={6}>
+        {entry.value.content}
+      </ThemedText>
+    </ThemedCard>
+  );
+}
+
+export function WhitewindTab({ handle, isOwnProfile }: WhitewindTabProps) {
+  const { t } = useTranslation();
+  const {
+    data: posts,
+    isLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useAuthorWhtwndPosts(handle);
+
+  const handleLoadMore = () => {
+    if (hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  };
+
+  const visiblePosts = (posts ?? []).filter((entry) => isOwnProfile || entry.value.visibility !== 'author');
+
+  const renderItem = ({ item }: { item: BlueskyWhtwndEntry }) => <WhitewindPostItem entry={item} />;
+
+  const renderFooter = () => {
+    if (!isFetchingNextPage) return null;
+    return (
+      <ThemedView style={styles.loadingFooter}>
+        <ThemedText style={styles.loadingText}>{t('common.loading')}</ThemedText>
+      </ThemedView>
+    );
+  };
+
+  if (isLoading) {
+    return <FeedSkeleton count={3} />;
+  }
+
+  if (!visiblePosts.length) {
+    return (
+      <ThemedView style={styles.emptyContainer}>
+        <ThemedText style={styles.emptyText}>{t('profile.noPosts')}</ThemedText>
+      </ThemedView>
+    );
+  }
+
+  return (
+    <VirtualizedList
+      data={visiblePosts}
+      renderItem={renderItem}
+      keyExtractor={(item) => item.uri}
+      onEndReached={handleLoadMore}
+      onEndReachedThreshold={0.1}
+      ListFooterComponent={renderFooter}
+      showsVerticalScrollIndicator={false}
+      scrollEnabled={false}
+      estimatedItemSize={ESTIMATED_WHITEWIND_CARD_HEIGHT}
+    />
+  );
+}
+
+const styles = StyleSheet.create({
+  emptyContainer: {
+    paddingVertical: 60,
+    alignItems: 'center',
+  },
+  emptyText: {
+    fontSize: 16,
+    opacity: 0.6,
+  },
+  loadingFooter: {
+    paddingVertical: 20,
+    alignItems: 'center',
+  },
+  loadingText: {
+    fontSize: 14,
+    opacity: 0.6,
+  },
+  entryCard: {
+    marginHorizontal: 16,
+    marginVertical: 8,
+    gap: 8,
+  },
+  entryTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+  },
+  entryMeta: {
+    fontSize: 13,
+    letterSpacing: 0.2,
+  },
+  entryContent: {
+    fontSize: 15,
+    lineHeight: 22,
+  },
+});

--- a/apps/akari/hooks/queries/useAuthorWhtwndPosts.ts
+++ b/apps/akari/hooks/queries/useAuthorWhtwndPosts.ts
@@ -1,0 +1,38 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { CursorPageParam } from '@/hooks/queries/types';
+import { BlueskyApi } from '@/bluesky-api';
+
+/**
+ * Infinite query hook for fetching Whtwnd blog posts authored by a user
+ * @param identifier - The user's handle or DID
+ * @param limit - Number of posts to fetch per page (default: 25)
+ */
+export function useAuthorWhtwndPosts(identifier: string | undefined, limit: number = 25) {
+  const { data: token } = useJwtToken();
+  const { data: currentAccount } = useCurrentAccount();
+
+  return useInfiniteQuery({
+    queryKey: ['authorWhtwndPosts', identifier, limit, currentAccount?.pdsUrl],
+    queryFn: async ({ pageParam }: CursorPageParam) => {
+      if (!token) throw new Error('No access token');
+      if (!identifier) throw new Error('No identifier provided');
+      if (!currentAccount?.pdsUrl) throw new Error('No PDS URL available');
+
+      const api = new BlueskyApi(currentAccount.pdsUrl);
+      const entries = await api.getAuthorWhtwndPosts(token, identifier, limit, pageParam);
+
+      return {
+        posts: entries.records,
+        cursor: entries.cursor,
+      };
+    },
+    select: (data) => data.pages.flatMap((page) => page.posts),
+    enabled: !!identifier && !!token,
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.cursor,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/apps/akari/translations/ar.json
+++ b/apps/akari/translations/ar.json
@@ -171,6 +171,7 @@
       "media": "الوسائط",
       "videos": "فيديوهات",
       "feeds": "التدفقات",
+      "whitewind": "Whitewind",
       "repos": "المستودعات",
       "starterpacks": "حزم البداية",
       "posts": "المنشورات {{count}}",

--- a/apps/akari/translations/az.json
+++ b/apps/akari/translations/az.json
@@ -171,6 +171,7 @@
       "media": "Media",
       "videos": "Videonlar",
       "feeds": "Yem",
+      "whitewind": "Whitewind",
       "repos": "Depozitlər",
       "starterpacks": "Başselerpacks",
       "posts": "Yazılar {{count}}",

--- a/apps/akari/translations/bg.json
+++ b/apps/akari/translations/bg.json
@@ -171,6 +171,7 @@
       "media": "Медия",
       "videos": "Видеоклипове",
       "feeds": "Емисии",
+      "whitewind": "Whitewind",
       "repos": "Хранилища",
       "starterpacks": "Стартерпи",
       "posts": "Публикации {{count}}",

--- a/apps/akari/translations/cs.json
+++ b/apps/akari/translations/cs.json
@@ -171,6 +171,7 @@
       "media": "Média",
       "videos": "Videa",
       "feeds": "Krmiva",
+      "whitewind": "Whitewind",
       "repos": "Úložiště",
       "starterpacks": "Starterpacks",
       "posts": "Příspěvky {{count}}",

--- a/apps/akari/translations/cy.json
+++ b/apps/akari/translations/cy.json
@@ -171,6 +171,7 @@
       "media": "Cyfryngau",
       "videos": "Fideos",
       "feeds": "Porthiant",
+      "whitewind": "Whitewind",
       "repos": "Gadwrfeydd",
       "starterpacks": "Pecynnau Cychwyn",
       "posts": "Swyddi {{count}}",

--- a/apps/akari/translations/da.json
+++ b/apps/akari/translations/da.json
@@ -171,6 +171,7 @@
       "media": "Medier",
       "videos": "Videoer",
       "feeds": "Feeds",
+      "whitewind": "Whitewind",
       "repos": "Repositorier",
       "starterpacks": "Starterpacks",
       "posts": "Indlæg {{count}}",

--- a/apps/akari/translations/de.json
+++ b/apps/akari/translations/de.json
@@ -171,6 +171,7 @@
       "media": "Medien",
       "videos": "Videos",
       "feeds": "Feeds",
+      "whitewind": "Whitewind",
       "repos": "Repositorien",
       "starterpacks": "Starterpacks",
       "posts": "Beiträge {{count}}",

--- a/apps/akari/translations/el.json
+++ b/apps/akari/translations/el.json
@@ -171,6 +171,7 @@
       "media": "Μέσα ενημέρωσης",
       "videos": "Βίντεο",
       "feeds": "Ζωοτροφές",
+      "whitewind": "Whitewind",
       "repos": "Αποθετήρια",
       "starterpacks": "Εκκινητής",
       "posts": "Δημοσιεύσεις {{count}}",

--- a/apps/akari/translations/en-US.json
+++ b/apps/akari/translations/en-US.json
@@ -185,6 +185,7 @@
       "following": "Following {{count}}",
       "videos": "Videos",
       "feeds": "Feeds",
+      "whitewind": "Whitewind",
       "repos": "Repos",
       "starterpacks": "Starterpacks",
       "noVideos": "No videos yet",

--- a/apps/akari/translations/en.json
+++ b/apps/akari/translations/en.json
@@ -171,6 +171,7 @@
       "media": "Media",
       "videos": "Videos",
       "feeds": "Feeds",
+      "whitewind": "Whitewind",
       "repos": "Repos",
       "starterpacks": "Starterpacks",
       "posts": "Posts {{count}}",

--- a/apps/akari/translations/es.json
+++ b/apps/akari/translations/es.json
@@ -171,6 +171,7 @@
       "media": "Medios",
       "videos": "Videos",
       "feeds": "Feeds",
+      "whitewind": "Whitewind",
       "repos": "Repositorios",
       "starterpacks": "Starterpacks",
       "posts": "Publicaciones {{count}}",

--- a/apps/akari/translations/fa.json
+++ b/apps/akari/translations/fa.json
@@ -171,6 +171,7 @@
       "media": "رسانه ها",
       "videos": "فیلم",
       "feeds": "فید",
+      "whitewind": "Whitewind",
       "repos": "مخازن",
       "starterpacks": "پله",
       "posts": "پست های {{count}}",

--- a/apps/akari/translations/fi.json
+++ b/apps/akari/translations/fi.json
@@ -171,6 +171,7 @@
       "media": "Media",
       "videos": "Video",
       "feeds": "Syöttö",
+      "whitewind": "Whitewind",
       "repos": "Arkistot",
       "starterpacks": "Starterpacks",
       "posts": "Viestit {{count}}",

--- a/apps/akari/translations/fr.json
+++ b/apps/akari/translations/fr.json
@@ -171,6 +171,7 @@
       "media": "Médias",
       "videos": "Vidéos",
       "feeds": "Flux",
+      "whitewind": "Whitewind",
       "repos": "Référentiels",
       "starterpacks": "Starterpacks",
       "posts": "Publications {{count}}",

--- a/apps/akari/translations/he.json
+++ b/apps/akari/translations/he.json
@@ -171,6 +171,7 @@
       "media": "כְּלֵי תִקְשׁוֹרֶת",
       "videos": "סרטונים",
       "feeds": "עדכונים",
+      "whitewind": "Whitewind",
       "repos": "מאגרים",
       "starterpacks": "StarterPacks",
       "posts": "פוסטים {{count}}",

--- a/apps/akari/translations/hi.json
+++ b/apps/akari/translations/hi.json
@@ -171,6 +171,7 @@
       "media": "मीडिया",
       "videos": "वीडियो",
       "feeds": "फीड्स",
+      "whitewind": "Whitewind",
       "repos": "रिपॉज़िटरीज़",
       "starterpacks": "स्टार्टरपैक्स",
       "posts": "पोस्ट {{count}}",

--- a/apps/akari/translations/hu.json
+++ b/apps/akari/translations/hu.json
@@ -171,6 +171,7 @@
       "media": "Média",
       "videos": "Videó",
       "feeds": "Takarmányozás",
+      "whitewind": "Whitewind",
       "repos": "Tárolók",
       "starterpacks": "Indítópacks",
       "posts": "Bejegyzések {{count}}",

--- a/apps/akari/translations/id.json
+++ b/apps/akari/translations/id.json
@@ -171,6 +171,7 @@
       "media": "Media",
       "videos": "Video",
       "feeds": "Feed",
+      "whitewind": "Whitewind",
       "repos": "Repositori",
       "starterpacks": "Starterpacks",
       "posts": "Postingan {{count}}",

--- a/apps/akari/translations/it.json
+++ b/apps/akari/translations/it.json
@@ -171,6 +171,7 @@
       "media": "Media",
       "videos": "Video",
       "feeds": "Feed",
+      "whitewind": "Whitewind",
       "repos": "Repository",
       "starterpacks": "Starterpacks",
       "posts": "Post {{count}}",

--- a/apps/akari/translations/ja.json
+++ b/apps/akari/translations/ja.json
@@ -171,6 +171,7 @@
       "media": "メディア",
       "videos": "動画",
       "feeds": "フィード",
+      "whitewind": "Whitewind",
       "repos": "リポジトリ",
       "starterpacks": "スターターパック",
       "posts": "投稿 {{count}}",

--- a/apps/akari/translations/ko.json
+++ b/apps/akari/translations/ko.json
@@ -171,6 +171,7 @@
       "media": "미디어",
       "videos": "동영상",
       "feeds": "피드",
+      "whitewind": "Whitewind",
       "repos": "저장소",
       "starterpacks": "스타터팩",
       "posts": "게시물 {{count}}",

--- a/apps/akari/translations/nl.json
+++ b/apps/akari/translations/nl.json
@@ -171,6 +171,7 @@
       "media": "Media",
       "videos": "Video's",
       "feeds": "Feeds",
+      "whitewind": "Whitewind",
       "repos": "Repositories",
       "starterpacks": "Starterpacks",
       "posts": "Berichten {{count}}",

--- a/apps/akari/translations/pl.json
+++ b/apps/akari/translations/pl.json
@@ -171,6 +171,7 @@
       "media": "Media",
       "videos": "Filmy",
       "feeds": "Kanały",
+      "whitewind": "Whitewind",
       "repos": "Repozytoria",
       "starterpacks": "Starterpacks",
       "posts": "Posty {{count}}",

--- a/apps/akari/translations/pt.json
+++ b/apps/akari/translations/pt.json
@@ -171,6 +171,7 @@
       "media": "Mídia",
       "videos": "Vídeos",
       "feeds": "Feeds",
+      "whitewind": "Whitewind",
       "repos": "Repositórios",
       "starterpacks": "Starterpacks",
       "posts": "Publicações {{count}}",

--- a/apps/akari/translations/ro.json
+++ b/apps/akari/translations/ro.json
@@ -171,6 +171,7 @@
       "media": "Media",
       "videos": "Videoclipuri",
       "feeds": "Feed -uri",
+      "whitewind": "Whitewind",
       "repos": "Depozite",
       "starterpacks": "Starterpacks",
       "posts": "Postări {{count}}",

--- a/apps/akari/translations/ru.json
+++ b/apps/akari/translations/ru.json
@@ -171,6 +171,7 @@
       "media": "Медиа",
       "videos": "Видео",
       "feeds": "Ленты",
+      "whitewind": "Whitewind",
       "repos": "Репозитории",
       "starterpacks": "Стартерпаки",
       "posts": "Посты {{count}}",

--- a/apps/akari/translations/sk.json
+++ b/apps/akari/translations/sk.json
@@ -171,6 +171,7 @@
       "media": "Médium",
       "videos": "Videá",
       "feeds": "Krmivo",
+      "whitewind": "Whitewind",
       "repos": "Úložiská",
       "starterpacks": "Štartovacie batoh",
       "posts": "Príspevky {{count}}",

--- a/apps/akari/translations/sl.json
+++ b/apps/akari/translations/sl.json
@@ -171,6 +171,7 @@
       "media": "Mediji",
       "videos": "Videoposnetki",
       "feeds": "Krmi",
+      "whitewind": "Whitewind",
       "repos": "Repozitoriji",
       "starterpacks": "Starterpacks",
       "posts": "Objave {{count}}",

--- a/apps/akari/translations/sv.json
+++ b/apps/akari/translations/sv.json
@@ -171,6 +171,7 @@
       "media": "Media",
       "videos": "Videor",
       "feeds": "Foder",
+      "whitewind": "Whitewind",
       "repos": "Arkiv",
       "starterpacks": "Starterpacks",
       "posts": "Inlägg {{count}}",

--- a/apps/akari/translations/th.json
+++ b/apps/akari/translations/th.json
@@ -171,6 +171,7 @@
       "media": "สื่อ",
       "videos": "วิดีโอ",
       "feeds": "ฟีด",
+      "whitewind": "Whitewind",
       "repos": "ที่เก็บ",
       "starterpacks": "สตาร์เตอร์แพ็ค",
       "posts": "โพสต์ {{count}}",

--- a/apps/akari/translations/tr.json
+++ b/apps/akari/translations/tr.json
@@ -171,6 +171,7 @@
       "media": "Medya",
       "videos": "Videolar",
       "feeds": "Akışlar",
+      "whitewind": "Whitewind",
       "repos": "Depolar",
       "starterpacks": "Başlangıç Paketleri",
       "posts": "Gönderiler {{count}}",

--- a/apps/akari/translations/uk.json
+++ b/apps/akari/translations/uk.json
@@ -171,6 +171,7 @@
       "media": "ЗМІ",
       "videos": "Відеоролики",
       "feeds": "Корми",
+      "whitewind": "Whitewind",
       "repos": "Сховища",
       "starterpacks": "Стартерпак",
       "posts": "Повідомлення {{count}}",

--- a/apps/akari/translations/vi.json
+++ b/apps/akari/translations/vi.json
@@ -171,6 +171,7 @@
       "media": "Phương tiện",
       "videos": "Video",
       "feeds": "Nguồn cấp",
+      "whitewind": "Whitewind",
       "repos": "Kho lưu trữ",
       "starterpacks": "Gói khởi đầu",
       "posts": "Bài viết {{count}}",

--- a/apps/akari/translations/zh-CN.json
+++ b/apps/akari/translations/zh-CN.json
@@ -171,6 +171,7 @@
       "media": "媒体",
       "videos": "视频",
       "feeds": "信息流",
+      "whitewind": "Whitewind",
       "repos": "存储库",
       "starterpacks": "入门包",
       "posts": "帖子 {{count}}",

--- a/apps/akari/translations/zh-TW.json
+++ b/apps/akari/translations/zh-TW.json
@@ -171,6 +171,7 @@
       "media": "媒體",
       "videos": "影片",
       "feeds": "動態",
+      "whitewind": "Whitewind",
       "repos": "存儲庫",
       "starterpacks": "入門包",
       "posts": "貼文 {{count}}",

--- a/apps/akari/translations/zh.json
+++ b/apps/akari/translations/zh.json
@@ -171,6 +171,7 @@
       "media": "媒体",
       "videos": "视频",
       "feeds": "饲料",
+      "whitewind": "Whitewind",
       "repos": "存储库",
       "starterpacks": "启动背包",
       "posts": "帖子{{count}}",

--- a/apps/akari/types/profile.ts
+++ b/apps/akari/types/profile.ts
@@ -1,1 +1,10 @@
-export type ProfileTabType = 'posts' | 'replies' | 'likes' | 'media' | 'videos' | 'feeds' | 'repos' | 'starterpacks';
+export type ProfileTabType =
+  | 'posts'
+  | 'whitewind'
+  | 'replies'
+  | 'likes'
+  | 'media'
+  | 'videos'
+  | 'feeds'
+  | 'repos'
+  | 'starterpacks';

--- a/packages/bluesky-api/src/api.test.ts
+++ b/packages/bluesky-api/src/api.test.ts
@@ -16,6 +16,7 @@ import type {
   BlueskySession,
   BlueskyStarterPacksResponse,
   BlueskyTangledReposResponse,
+  BlueskyWhtwndEntriesResponse,
   BlueskyThreadResponse,
   BlueskyTrendingTopicsResponse,
   BlueskyUnreadNotificationCount,
@@ -99,6 +100,7 @@ describe('BlueskyApi', () => {
     const thread = { thread: {} } as unknown as BlueskyThreadResponse;
     const starterpacks = { starterPacks: [] } as unknown as BlueskyStarterPacksResponse;
     const reposResponse = { records: [] } as unknown as BlueskyTangledReposResponse;
+    const whtwndResponse = { records: [] } as unknown as BlueskyWhtwndEntriesResponse;
     const blob = { blob: { ref: { $link: 'ref' }, mimeType: 'image/png', size: 1 } } as BlueskyUploadBlobResponse;
     const postInput: BlueskyCreatePostInput = { text: 'Hello' };
     const postResponse = { uri: 'at://post/1', cid: 'cid', commit: { cid: 'cid', rev: 'rev' }, validationStatus: 'valid' } as BlueskyCreatePostResponse;
@@ -123,6 +125,7 @@ describe('BlueskyApi', () => {
     };
     internal.repos = {
       getActorRepos: jest.fn().mockResolvedValue(reposResponse),
+      getAuthorWhtwndPosts: jest.fn().mockResolvedValue(whtwndResponse),
     };
 
     await expect(api.getTimeline('jwt', 10)).resolves.toBe(feed);
@@ -138,6 +141,7 @@ describe('BlueskyApi', () => {
     await expect(api.getAuthorFeeds('jwt', 'did:example', 15)).resolves.toBe(feedsResponse);
     await expect(api.getAuthorStarterpacks('jwt', 'did:example', 15)).resolves.toBe(starterpacks);
     await expect(api.getActorRepos('jwt', 'did:example', 15)).resolves.toBe(reposResponse);
+    await expect(api.getAuthorWhtwndPosts('jwt', 'did:example', 30)).resolves.toBe(whtwndResponse);
     await expect(api.createPost('jwt', 'did:example', postInput)).resolves.toBe(postResponse);
     await expect(api.uploadImage('jwt', 'file://image.png', 'image/png')).resolves.toBe(blob);
     await expect(api.likePost('jwt', 'at://post/1', 'cid', 'did:example')).resolves.toEqual({ uri: 'like' });
@@ -150,6 +154,7 @@ describe('BlueskyApi', () => {
     expect(internal.feeds.getFeedGenerators).toHaveBeenCalledWith('jwt', ['at://feed/a']);
     expect(internal.feeds.createPost).toHaveBeenCalledWith('jwt', 'did:example', postInput);
     expect(internal.repos.getActorRepos).toHaveBeenCalledWith('jwt', 'did:example', 15, undefined);
+    expect(internal.repos.getAuthorWhtwndPosts).toHaveBeenCalledWith('jwt', 'did:example', 30, undefined);
   });
 
   it('delegates conversation operations to the conversations client', async () => {

--- a/packages/bluesky-api/src/api.ts
+++ b/packages/bluesky-api/src/api.ts
@@ -27,6 +27,7 @@ import type {
   BlueskySession,
   BlueskyStarterPacksResponse,
   BlueskyTangledReposResponse,
+  BlueskyWhtwndEntriesResponse,
   BlueskyThreadResponse,
   BlueskyTrendingTopicsResponse,
   BlueskyProfileUpdateInput,
@@ -126,6 +127,23 @@ export class BlueskyApi extends BlueskyApiClient {
     cursor?: string,
   ): Promise<BlueskyTangledReposResponse> {
     return this.repos.getActorRepos(accessJwt, actor, limit, cursor);
+  }
+
+  /**
+   * Lists Whtwnd blog entries authored by the requested actor.
+   * @param accessJwt - Valid session token authorised to query the actor's records.
+   * @param actor - DID or handle identifying the actor whose Whtwnd posts should be loaded.
+   * @param limit - Maximum number of posts to fetch per page, defaults to 25.
+   * @param cursor - Pagination cursor from previous responses, if any.
+   * @returns Whtwnd blog entries created by the actor.
+   */
+  async getAuthorWhtwndPosts(
+    accessJwt: string,
+    actor: string,
+    limit: number = 25,
+    cursor?: string,
+  ): Promise<BlueskyWhtwndEntriesResponse> {
+    return this.repos.getAuthorWhtwndPosts(accessJwt, actor, limit, cursor);
   }
 
   /**

--- a/packages/bluesky-api/src/repos.test.ts
+++ b/packages/bluesky-api/src/repos.test.ts
@@ -84,4 +84,55 @@ describe('BlueskyRepos', () => {
       },
     });
   });
+
+  it('fetches Whtwnd posts with reverse pagination ordering', async () => {
+    const repos = new TestRepos();
+    repos.responses = [
+      {
+        cursor: 'cursor-2',
+        records: [],
+      },
+    ];
+
+    const result = await repos.getAuthorWhtwndPosts('jwt', 'did:example:bob', 10, 'cursor-1');
+
+    expect(result).toEqual({ cursor: 'cursor-2', records: [] });
+    expect(repos.calls.at(-1)).toEqual({
+      endpoint: '/com.atproto.repo.listRecords',
+      accessJwt: 'jwt',
+      options: {
+        params: {
+          repo: 'did:example:bob',
+          collection: 'com.whtwnd.blog.entry',
+          limit: '10',
+          reverse: 'true',
+          cursor: 'cursor-1',
+        },
+      },
+    });
+  });
+
+  it('defaults Whtwnd limit to 25 and omits cursor when absent', async () => {
+    const repos = new TestRepos();
+    repos.responses = [
+      {
+        records: [],
+      },
+    ];
+
+    await repos.getAuthorWhtwndPosts('jwt', 'carol.test');
+
+    expect(repos.calls.at(-1)).toEqual({
+      endpoint: '/com.atproto.repo.listRecords',
+      accessJwt: 'jwt',
+      options: {
+        params: {
+          repo: 'carol.test',
+          collection: 'com.whtwnd.blog.entry',
+          limit: '25',
+          reverse: 'true',
+        },
+      },
+    });
+  });
 });

--- a/packages/bluesky-api/src/repos.ts
+++ b/packages/bluesky-api/src/repos.ts
@@ -1,5 +1,5 @@
 import { BlueskyApiClient } from './client';
-import type { BlueskyTangledReposResponse } from './types';
+import type { BlueskyTangledReposResponse, BlueskyWhtwndEntriesResponse } from './types';
 
 /**
  * Bluesky API methods for interacting with Tangled repo records.
@@ -30,6 +30,36 @@ export class BlueskyRepos extends BlueskyApiClient {
     }
 
     return this.makeAuthenticatedRequest<BlueskyTangledReposResponse>('/com.atproto.repo.listRecords', accessJwt, {
+      params,
+    });
+  }
+
+  /**
+   * Lists Whtwnd blog entries created by the specified actor.
+   * @param accessJwt - Valid access JWT token for the authenticated user.
+   * @param repo - DID or handle identifying the actor whose blog entries should be loaded.
+   * @param limit - Number of entries to fetch per page (default: 25).
+   * @param cursor - Optional pagination cursor returned by previous calls.
+   * @returns Promise resolving to Whtwnd blog entries for the actor.
+   */
+  async getAuthorWhtwndPosts(
+    accessJwt: string,
+    repo: string,
+    limit: number = 25,
+    cursor?: string,
+  ): Promise<BlueskyWhtwndEntriesResponse> {
+    const params: Record<string, string> = {
+      repo,
+      collection: 'com.whtwnd.blog.entry',
+      limit: limit.toString(),
+      reverse: 'true',
+    };
+
+    if (cursor) {
+      params.cursor = cursor;
+    }
+
+    return this.makeAuthenticatedRequest<BlueskyWhtwndEntriesResponse>('/com.atproto.repo.listRecords', accessJwt, {
       params,
     });
   }

--- a/packages/bluesky-api/src/types.ts
+++ b/packages/bluesky-api/src/types.ts
@@ -884,6 +884,43 @@ export type BlueskyTangledReposResponse = {
 };
 
 /**
+ * Whtwnd blog entry stored in the com.whtwnd.blog.entry collection
+ */
+export type BlueskyWhtwndEntry = {
+  /** AT URI of the Whtwnd blog entry */
+  uri: string;
+  /** CID of the Whtwnd blog entry */
+  cid: string;
+  /** Blog entry record value */
+  value: {
+    /** Lexicon type identifier */
+    $type: 'com.whtwnd.blog.entry';
+    /** Theme identifier used by Whitewind */
+    theme?: string;
+    /** Title of the blog entry */
+    title: string;
+    /** Markdown or plain text content of the entry */
+    content: string;
+    /** When the entry was created */
+    createdAt: string;
+    /** Visibility level for the entry */
+    visibility?: 'public' | 'unlisted' | 'author' | 'followers';
+  };
+  /** When the record was indexed */
+  indexedAt?: string;
+};
+
+/**
+ * Response from the com.atproto.repo.listRecords endpoint for Whtwnd entries
+ */
+export type BlueskyWhtwndEntriesResponse = {
+  /** Cursor for pagination */
+  cursor?: string;
+  /** Array of Whtwnd blog entries */
+  records: BlueskyWhtwndEntry[];
+};
+
+/**
  * Error response from Bluesky API endpoints
  */
 export type BlueskyError = {


### PR DESCRIPTION
## Summary
- add Whtwnd entry types and client helpers to the Bluesky API package
- add a React Query hook and profile tab for rendering Whitewind blog posts
- cover the new behavior with component and hook tests and expose the tab label across locales

## Testing
- npm run lint -- --filter=akari
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68e16fd3a39c832ba0c1c79b3423c194