### PR TITLE
feat: add microcosm links api client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15830,6 +15830,10 @@
         "node": ">=20.19.4"
       }
     },
+    "node_modules/microcosm-links-api": {
+      "resolved": "packages/microcosm-links-api",
+      "link": true
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -22165,6 +22169,90 @@
       }
     },
     "packages/libretranslate-api/node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "packages/microcosm-links-api": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@eslint/eslintrc": "^3.0.0",
+        "@eslint/js": "^9.25.0",
+        "@types/jest": "^30.0.0",
+        "eslint": "^9.25.0",
+        "eslint-config-expo": "~9.2.0",
+        "jest": "~29.7.0",
+        "msw": "^2.4.9",
+        "ts-jest": "^29.4.1",
+        "typescript": "~5.8.3"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-native": ">=0.70.0"
+      }
+    },
+    "packages/microcosm-links-api/node_modules/eslint-config-expo": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-expo/-/eslint-config-expo-9.2.0.tgz",
+      "integrity": "sha512-TQgmSx+2mRM7qUS0hB5kTDrHcSC35rA1UzOSgK5YRLmSkSMlKLmXkUrhwOpnyo9D/nHdf4ERRAySRYxgA6dlrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.18.2",
+        "@typescript-eslint/parser": "^8.18.2",
+        "eslint-import-resolver-typescript": "^3.6.3",
+        "eslint-plugin-expo": "^0.1.4",
+        "eslint-plugin-import": "^2.30.0",
+        "eslint-plugin-react": "^7.37.3",
+        "eslint-plugin-react-hooks": "^5.1.0",
+        "globals": "^16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.10"
+      }
+    },
+    "packages/microcosm-links-api/node_modules/eslint-plugin-expo": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-expo/-/eslint-plugin-expo-0.1.4.tgz",
+      "integrity": "sha512-YA7yiMacQbLJySuyJA0Eb5V65obqp6fVOWtw1JdYDRWC5MeToPrnNvhGDpk01Bv3Vm4ownuzUfvi89MXi1d6cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "^8.29.1",
+        "@typescript-eslint/utils": "^8.29.1",
+        "eslint": "^9.24.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.10"
+      }
+    },
+    "packages/microcosm-links-api/node_modules/globals": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+      "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/microcosm-links-api/node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",

--- a/packages/microcosm-links-api/AGENTS.md
+++ b/packages/microcosm-links-api/AGENTS.md
@@ -1,0 +1,5 @@
+# Microcosm Links API Package Guidelines
+
+- Keep HTTP utilities inside `MicrocosmApiClient` and let higher level APIs extend it.
+- Model request and response payloads as `type` aliases in `types.ts` and export them via `src/index.ts`.
+- Add Jest tests that cover success and failure flows using `msw`.

--- a/packages/microcosm-links-api/eslint.config.js
+++ b/packages/microcosm-links-api/eslint.config.js
@@ -1,0 +1,18 @@
+import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+});
+
+export default [
+  js.configs.recommended,
+  ...compat.extends('eslint-config-expo'),
+  {
+    rules: {},
+  },
+];

--- a/packages/microcosm-links-api/jest.config.cjs
+++ b/packages/microcosm-links-api/jest.config.cjs
@@ -1,0 +1,31 @@
+const isGithubActions = Boolean(process.env.GITHUB_ACTIONS);
+
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  transform: {
+    '^.+\\.m?tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: './tsconfig.json',
+      },
+    ],
+    'node_modules/until-async/.*\\.js$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          allowJs: true,
+          esModuleInterop: true,
+        },
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!until-async)'],
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.{ts,tsx}', '!**/*.d.ts'],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'html'],
+  ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
+};

--- a/packages/microcosm-links-api/package.json
+++ b/packages/microcosm-links-api/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "microcosm-links-api",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "API client for querying Microcosm Constellation backlink endpoints",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "scripts": {
+    "build": "tsc",
+    "test": "jest --config ./jest.config.cjs",
+    "test:run": "jest --config ./jest.config.cjs",
+    "test:coverage": "jest --config ./jest.config.cjs --coverage --passWithNoTests",
+    "lint": "eslint src --ext .ts"
+  },
+  "keywords": ["microcosm", "constellation", "atproto", "api", "client"],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {},
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.0.0",
+    "@eslint/js": "^9.25.0",
+    "@types/jest": "^30.0.0",
+    "eslint": "^9.25.0",
+    "eslint-config-expo": "~9.2.0",
+    "jest": "~29.7.0",
+    "msw": "^2.4.9",
+    "ts-jest": "^29.4.1",
+    "typescript": "~5.8.3"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-native": ">=0.70.0"
+  }
+}

--- a/packages/microcosm-links-api/src/api.test.ts
+++ b/packages/microcosm-links-api/src/api.test.ts
@@ -1,0 +1,150 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from '@jest/globals';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { MicrocosmLinksApi } from './api';
+import { createMicrocosmLinksApi } from './index';
+
+type HeaderCollector = {
+  accept?: string;
+  custom?: string;
+};
+
+const baseUrl = 'https://microcosm.test';
+const server = setupServer();
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe('MicrocosmLinksApi', () => {
+  const createApi = () => new MicrocosmLinksApi(baseUrl, { userAgent: 'akari-tests' });
+
+  it('retrieves backlinks with cursor and did filters', async () => {
+    const query = {
+      subject: 'at://did:plc:example/app.bsky.feed.post/abc',
+      source: 'app.bsky.feed.like:subject.uri',
+      limit: 25,
+      cursor: 'cursor-token',
+      did: ['did:plc:one', 'did:plc:two'],
+    } as const;
+
+    const response = {
+      total: 2,
+      records: [
+        { did: 'did:plc:one', collection: 'app.bsky.feed.like', rkey: '1' },
+        { did: 'did:plc:two', collection: 'app.bsky.feed.like', rkey: '2' },
+      ],
+      cursor: 'next-cursor',
+    };
+
+    server.use(
+      http.get(`${baseUrl}/xrpc/blue.microcosm.links.getBacklinks`, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get('subject')).toBe(query.subject);
+        expect(url.searchParams.get('source')).toBe(query.source);
+        expect(url.searchParams.get('limit')).toBe(String(query.limit));
+        expect(url.searchParams.get('cursor')).toBe(query.cursor);
+        expect(url.searchParams.getAll('did')).toEqual([...query.did]);
+
+        return HttpResponse.json(response);
+      }),
+    );
+
+    await expect(createApi().getBacklinks(query)).resolves.toEqual(response);
+  });
+
+  it('retrieves many-to-many counts with optional filters', async () => {
+    const query = {
+      subject: 'at://did:plc:example/app.bsky.feed.post/abc',
+      source: 'app.bsky.feed.like:subject.uri',
+      pathToOther: 'subject.uri',
+      limit: 10,
+      otherSubject: [
+        'at://did:plc:example/app.bsky.feed.post/abc',
+        'at://did:plc:other/app.bsky.feed.post/def',
+      ],
+    } as const;
+
+    const response = {
+      counts_by_other_subject: [
+        { subject: query.otherSubject[0], total: 5, distinct: 5 },
+        { subject: query.otherSubject[1], total: 3, distinct: 3 },
+      ],
+      cursor: null,
+    };
+
+    server.use(
+      http.get(`${baseUrl}/xrpc/blue.microcosm.links.getManyToManyCounts`, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get('subject')).toBe(query.subject);
+        expect(url.searchParams.get('source')).toBe(query.source);
+        expect(url.searchParams.get('pathToOther')).toBe(query.pathToOther);
+        expect(url.searchParams.get('limit')).toBe(String(query.limit));
+        expect(url.searchParams.getAll('otherSubject')).toEqual([...query.otherSubject]);
+
+        return HttpResponse.json(response);
+      }),
+    );
+
+    await expect(createApi().getManyToManyCounts(query)).resolves.toEqual(response);
+  });
+
+  it('throws a descriptive error when the request fails', async () => {
+    const query = {
+      subject: 'at://did:plc:example/app.bsky.feed.post/abc',
+      source: 'app.bsky.feed.like:subject.uri',
+    };
+
+    server.use(
+      http.get(`${baseUrl}/xrpc/blue.microcosm.links.getBacklinks`, () => {
+        return HttpResponse.json({ message: 'nope' }, { status: 502, statusText: 'Bad Gateway' });
+      }),
+    );
+
+    await expect(createApi().getBacklinks(query)).rejects.toThrow(
+      'Microcosm request failed with status 502 Bad Gateway',
+    );
+  });
+
+  it('supports the factory helper with custom headers', async () => {
+    const query = {
+      subject: 'at://did:plc:example/app.bsky.feed.post/abc',
+      source: 'app.bsky.feed.like:subject.uri',
+    };
+
+    const response = {
+      total: 0,
+      records: [],
+      cursor: null,
+    };
+
+    const headers: HeaderCollector = {};
+
+    server.use(
+      http.get(`${baseUrl}/xrpc/blue.microcosm.links.getBacklinks`, ({ request }) => {
+        headers.accept = request.headers.get('accept') ?? undefined;
+        headers.custom = request.headers.get('x-akari-test') ?? undefined;
+
+        return HttpResponse.json(response);
+      }),
+    );
+
+    const api = createMicrocosmLinksApi({
+      baseUrl: `${baseUrl}/`,
+      headers: { 'X-Akari-Test': 'microcosm' },
+      userAgent: 'akari-tests',
+    });
+
+    await expect(api.getBacklinks(query)).resolves.toEqual(response);
+    expect(headers.accept).toBe('application/json');
+    expect(headers.custom).toBe('microcosm');
+  });
+});

--- a/packages/microcosm-links-api/src/api.ts
+++ b/packages/microcosm-links-api/src/api.ts
@@ -1,0 +1,40 @@
+import { MicrocosmApiClient } from './client';
+import type {
+  MicrocosmBacklinksQuery,
+  MicrocosmBacklinksResponse,
+  MicrocosmManyToManyCountsQuery,
+  MicrocosmManyToManyCountsResponse,
+} from './types';
+
+const BACKLINKS_ENDPOINT = '/xrpc/blue.microcosm.links.getBacklinks';
+const MANY_TO_MANY_ENDPOINT = '/xrpc/blue.microcosm.links.getManyToManyCounts';
+
+export class MicrocosmLinksApi extends MicrocosmApiClient {
+  async getBacklinks(query: MicrocosmBacklinksQuery): Promise<MicrocosmBacklinksResponse> {
+    const { subject, source, limit, cursor, did } = query;
+
+    return this.get<MicrocosmBacklinksResponse>(BACKLINKS_ENDPOINT, {
+      subject,
+      source,
+      limit,
+      cursor,
+      did,
+    });
+  }
+
+  async getManyToManyCounts(
+    query: MicrocosmManyToManyCountsQuery,
+  ): Promise<MicrocosmManyToManyCountsResponse> {
+    const { subject, source, pathToOther, limit, cursor, did, otherSubject } = query;
+
+    return this.get<MicrocosmManyToManyCountsResponse>(MANY_TO_MANY_ENDPOINT, {
+      subject,
+      source,
+      pathToOther,
+      limit,
+      cursor,
+      did,
+      otherSubject,
+    });
+  }
+}

--- a/packages/microcosm-links-api/src/client.ts
+++ b/packages/microcosm-links-api/src/client.ts
@@ -1,0 +1,110 @@
+export const DEFAULT_MICROCOSM_BASE_URL = 'https://constellation.microcosm.blue';
+
+export type MicrocosmClientOptions = {
+  headers?: Record<string, string>;
+  userAgent?: string;
+};
+
+type QueryValue = string | number | readonly (string | number)[] | undefined;
+
+type QueryParams = Record<string, QueryValue>;
+
+const normalizePath = (path: string): string => {
+  if (path === '') {
+    return '/';
+  }
+
+  return path.startsWith('/') ? path : `/${path}`;
+};
+
+export class MicrocosmApiClient {
+  protected readonly baseUrl: string;
+  private readonly defaultHeaders: Record<string, string>;
+
+  constructor(baseUrl: string = DEFAULT_MICROCOSM_BASE_URL, options: MicrocosmClientOptions = {}) {
+    this.baseUrl = this.normalizeBaseUrl(baseUrl);
+    this.defaultHeaders = this.createDefaultHeaders(options);
+  }
+
+  protected async get<T>(path: string, params?: QueryParams, headers?: Record<string, string>): Promise<T> {
+    const url = this.buildUrl(path, params);
+    const response = await fetch(url, {
+      headers: this.mergeHeaders(headers),
+    });
+
+    if (!response.ok) {
+      throw new Error(this.createErrorMessage(response.status, response.statusText));
+    }
+
+    return (await response.json()) as T;
+  }
+
+  private buildUrl(path: string, params?: QueryParams): string {
+    const url = new URL(`${this.baseUrl}${normalizePath(path)}`);
+
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        if (value === undefined) {
+          continue;
+        }
+
+        if (Array.isArray(value)) {
+          for (const item of value) {
+            if (item === undefined) {
+              continue;
+            }
+
+            url.searchParams.append(key, String(item));
+          }
+        } else {
+          url.searchParams.set(key, String(value));
+        }
+      }
+    }
+
+    return url.toString();
+  }
+
+  private mergeHeaders(additional?: Record<string, string>): Record<string, string> {
+    const headers: Record<string, string> = { ...this.defaultHeaders };
+
+    if (additional) {
+      for (const [key, value] of Object.entries(additional)) {
+        headers[key] = value;
+      }
+    }
+
+    return headers;
+  }
+
+  private createDefaultHeaders(options: MicrocosmClientOptions): Record<string, string> {
+    const headers: Record<string, string> = { Accept: 'application/json' };
+
+    if (options.userAgent) {
+      headers['User-Agent'] = options.userAgent;
+    }
+
+    if (options.headers) {
+      for (const [key, value] of Object.entries(options.headers)) {
+        headers[key] = value;
+      }
+    }
+
+    return headers;
+  }
+
+  private createErrorMessage(status: number, statusText: string): string {
+    const suffix = statusText ? ` ${statusText}` : '';
+    return `Microcosm request failed with status ${status}${suffix}`;
+  }
+
+  private normalizeBaseUrl(baseUrl: string): string {
+    const trimmed = baseUrl.trim();
+
+    if (!trimmed) {
+      return DEFAULT_MICROCOSM_BASE_URL;
+    }
+
+    return trimmed.replace(/\/+$/, '');
+  }
+}

--- a/packages/microcosm-links-api/src/index.ts
+++ b/packages/microcosm-links-api/src/index.ts
@@ -1,0 +1,28 @@
+import { MicrocosmLinksApi } from './api';
+import { MicrocosmApiClient, DEFAULT_MICROCOSM_BASE_URL } from './client';
+import type { MicrocosmClientOptions } from './client';
+
+export { MicrocosmLinksApi };
+export { MicrocosmApiClient, DEFAULT_MICROCOSM_BASE_URL };
+export type { MicrocosmClientOptions };
+export type {
+  MicrocosmBacklinkRecord,
+  MicrocosmBacklinksQuery,
+  MicrocosmBacklinksResponse,
+  MicrocosmManyToManyCount,
+  MicrocosmManyToManyCountsQuery,
+  MicrocosmManyToManyCountsResponse,
+} from './types';
+
+export type MicrocosmLinksApiConfig = MicrocosmClientOptions & {
+  baseUrl?: string;
+};
+
+export const createMicrocosmLinksApi = (config: MicrocosmLinksApiConfig = {}): MicrocosmLinksApi => {
+  const { baseUrl, headers, userAgent } = config;
+
+  return new MicrocosmLinksApi(baseUrl ?? DEFAULT_MICROCOSM_BASE_URL, {
+    headers,
+    userAgent,
+  });
+};

--- a/packages/microcosm-links-api/src/types.ts
+++ b/packages/microcosm-links-api/src/types.ts
@@ -1,0 +1,35 @@
+export type MicrocosmBacklinkRecord = {
+  did: string;
+  collection: string;
+  rkey: string;
+};
+
+export type MicrocosmBacklinksResponse = {
+  total: number;
+  records: MicrocosmBacklinkRecord[];
+  cursor: string | null;
+};
+
+export type MicrocosmBacklinksQuery = {
+  subject: string;
+  source: string;
+  limit?: number;
+  cursor?: string;
+  did?: string | readonly string[];
+};
+
+export type MicrocosmManyToManyCount = {
+  subject: string;
+  total: number;
+  distinct: number;
+};
+
+export type MicrocosmManyToManyCountsResponse = {
+  counts_by_other_subject: MicrocosmManyToManyCount[];
+  cursor: string | null;
+};
+
+export type MicrocosmManyToManyCountsQuery = MicrocosmBacklinksQuery & {
+  pathToOther: string;
+  otherSubject?: string | readonly string[];
+};

--- a/packages/microcosm-links-api/tsconfig.json
+++ b/packages/microcosm-links-api/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}


### PR DESCRIPTION
## Summary
- add a microcosm-links-api workspace for querying the Constellation backlink service
- implement the MicrocosmApiClient, typed endpoints, and a factory for the new package
- cover backlink and many-to-many queries plus error handling with msw-driven jest tests

## Testing
- npm run lint -- --filter=microcosm-links-api
- npm run test -- --filter=microcosm-links-api

------
https://chatgpt.com/codex/tasks/task_e_68e171c2e630832b9c5e415de2c33399