### PR TITLE
feat: open account switcher from profile nav long press

### DIFF
--- a/apps/akari/__tests__/components/Sidebar.test.tsx
+++ b/apps/akari/__tests__/components/Sidebar.test.tsx
@@ -193,6 +193,27 @@ describe('Sidebar', () => {
     expect(getByPlaceholderText('username.bsky.social or @username')).toBeTruthy();
   });
 
+  it('opens the account selector when long pressing the profile navigation item', () => {
+    const { getByLabelText, getByText, queryByText } = render(
+      <DialogProvider>
+        <Sidebar />
+      </DialogProvider>,
+    );
+
+    const profileButton = getByLabelText('Profile');
+    expect(queryByText('@alice.work')).toBeNull();
+
+    fireEvent(profileButton, 'longPress');
+    expect(getByText('@alice.work')).toBeTruthy();
+    expect(push).not.toHaveBeenCalledWith('/(tabs)/profile');
+
+    fireEvent(profileButton, 'press');
+    expect(push).not.toHaveBeenCalledWith('/(tabs)/profile');
+
+    fireEvent(profileButton, 'press');
+    expect(push).toHaveBeenCalledWith('/(tabs)/profile');
+  });
+
   it('marks the active navigation item based on the current path', () => {
     mockUsePathname.mockReturnValue('/(tabs)/notifications');
 


### PR DESCRIPTION
## Summary
- open the sidebar account selector when the profile navigation item is long pressed
- guard against navigating immediately after the long press so the drawer stays visible
- add a regression test covering the long-press behaviour on the profile navigation item

## Testing
- npm run lint -- --filter=akari
- npm run test -- --runTestsByPath __tests__/components/Sidebar.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e0646c79d4832ba8260281e4446010