### PR TITLE
feat: hardcode mobile tab bar

### DIFF
--- a/apps/akari/app/(tabs)/_layout.tsx
+++ b/apps/akari/app/(tabs)/_layout.tsx
@@ -396,7 +396,10 @@ const hardcodedTabStyles = StyleSheet.create({
   },
   content: {
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: 'stretch',
+    justifyContent: 'space-between',
+    alignSelf: 'stretch',
+    width: '100%',
   },
   tabButton: {
     marginHorizontal: 4,

--- a/apps/akari/components/HapticTab.tsx
+++ b/apps/akari/components/HapticTab.tsx
@@ -57,14 +57,6 @@ export function HapticTab(props: HapticTabProps) {
         restProps.onPress?.(ev);
       }}
     >
-      <View style={styles.indicatorContainer} pointerEvents="none">
-        <View
-          style={[
-            styles.indicator,
-            { backgroundColor: isActive ? accentColor : "transparent" },
-          ]}
-        />
-      </View>
       <View style={styles.content}>{children}</View>
     </PlatformPressable>
   );
@@ -81,16 +73,6 @@ const styles = StyleSheet.create({
     borderRadius: 0,
     alignItems: "center",
     justifyContent: "center",
-  },
-  indicatorContainer: {
-    position: "absolute",
-    top: 0,
-    left: 0,
-    right: 0,
-    height: 3,
-  },
-  indicator: {
-    height: 3,
   },
   content: {
     alignItems: "center",


### PR DESCRIPTION
## Summary
- replace the Expo Router-provided tab bar with a hardcoded mobile bottom navigation component that fires scroll-to-top and long-press events
- adjust the tabs layout test suite to exercise the new tab bar implementation and updated mocks

## Testing
- npm run lint -- --filter=akari
- npm run test -- --runTestsByPath __tests__/app/tabs-layout.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68e177686d78832b983a29e1d462920b