### PR TITLE
refactor: inline push subscription request

### DIFF
--- a/apps/akari/hooks/mutations/useRegisterPushSubscription.ts
+++ b/apps/akari/hooks/mutations/useRegisterPushSubscription.ts
@@ -1,0 +1,41 @@
+import { useMutation } from '@tanstack/react-query';
+
+type RegisterPushSubscriptionPayload = {
+  did: string;
+  expoPushToken: string;
+  platform: string;
+  devicePushToken?: string;
+};
+
+export function useRegisterPushSubscription() {
+  return useMutation({
+    mutationFn: async (payload: RegisterPushSubscriptionPayload) => {
+      const endpoint = process.env.EXPO_PUBLIC_PUSH_REGISTRY_URL?.trim();
+      if (!endpoint) {
+        throw new Error('EXPO_PUBLIC_PUSH_REGISTRY_URL is not configured.');
+      }
+
+      const registryUrl = endpoint.replace(/\/+$/, '');
+
+      const response = await fetch(`${registryUrl}/subscriptions`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          did: payload.did,
+          expoPushToken: payload.expoPushToken,
+          devicePushToken: payload.devicePushToken,
+          platform: payload.platform,
+        }),
+      });
+
+      if (!response.ok) {
+        const body = await response.text();
+        throw new Error(`Failed to create push subscription: ${response.status} ${response.statusText} - ${body}`);
+      }
+    },
+  });
+}
+
+export type { RegisterPushSubscriptionPayload };

--- a/apps/firehose-notifier/README.md
+++ b/apps/firehose-notifier/README.md
@@ -1,0 +1,45 @@
+# Firehose Notifier
+
+The Firehose Notifier is a lightweight Node.js service that listens to the AT Protocol Jetstream firehose and emits Expo push notifications when other users interact with posts owned by registered Akari users. It supports follows, likes, reposts, and replies. Subscriptions are sourced from the companion registry service in `apps/notifier-registry`.
+
+## Configuration
+
+The service reads configuration from environment variables. In production it should point at the subscription registry so every Akari user with a registered device receives notifications automatically.
+
+### Subscription registry
+
+- `AKARI_NOTIFIER_REGISTRY_URL` – HTTPS endpoint that returns a JSON array of `{ "did": string, "tokens": string[] }` objects.
+- `AKARI_NOTIFIER_REGISTRY_TOKEN` – Optional bearer token used to authenticate with the registry.
+- `AKARI_NOTIFIER_REGISTRY_REFRESH_MS` – Optional polling interval (milliseconds) for refreshing registry data (defaults to 5 minutes, minimum 30 seconds).
+
+### Optional configuration
+
+- `AKARI_EXPO_ACCESS_TOKEN` – Server access token for the Expo Push service.
+- `AKARI_NOTIFIER_LOG_LEVEL` – Set to `debug`, `info`, `warn`, or `error` (defaults to `info`).
+
+## Scripts
+
+```bash
+# Install dependencies
+npm install
+
+# Build the service
+npm run build -- --filter=firehose-notifier
+
+# Start in watch mode
+turbo run dev --filter=firehose-notifier
+
+# Run the compiled service
+npm run start -- --filter=firehose-notifier
+```
+
+## Behaviour
+
+The notifier watches the Jetstream firehose for:
+
+- `app.bsky.graph.follow` – Alerts when someone follows a monitored DID.
+- `app.bsky.feed.like` – Alerts when someone likes a post owned by a monitored DID.
+- `app.bsky.feed.repost` – Alerts when someone reposts a monitored DID's post.
+- `app.bsky.feed.post` – Alerts when someone replies to a monitored DID's post.
+
+Each notification includes metadata suitable for deep linking (interaction reason, actor DID, and relevant URIs).

--- a/apps/firehose-notifier/package.json
+++ b/apps/firehose-notifier/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "firehose-notifier",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "tsx watch src/index.ts",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@skyware/jetstream": "^0.2.5",
+    "expo-server-sdk": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.12",
+    "tsx": "^4.19.2",
+    "typescript": "~5.8.3"
+  }
+}

--- a/apps/firehose-notifier/src/config.ts
+++ b/apps/firehose-notifier/src/config.ts
@@ -1,0 +1,40 @@
+import { logger } from './logger.js';
+import type { NotifierConfig, NotifierRegistryConfig } from './types.js';
+
+function parseRegistryConfig(): NotifierRegistryConfig {
+  const endpoint = process.env.AKARI_NOTIFIER_REGISTRY_URL?.trim();
+  if (!endpoint) {
+    throw new Error('AKARI_NOTIFIER_REGISTRY_URL is required.');
+  }
+
+  const bearerToken = process.env.AKARI_NOTIFIER_REGISTRY_TOKEN?.trim();
+  const refreshRaw = process.env.AKARI_NOTIFIER_REGISTRY_REFRESH_MS?.trim();
+
+  let refreshIntervalMs: number | undefined;
+
+  if (refreshRaw) {
+    const parsed = Number.parseInt(refreshRaw, 10);
+    if (Number.isNaN(parsed) || parsed <= 0) {
+      throw new Error('AKARI_NOTIFIER_REGISTRY_REFRESH_MS must be a positive integer representing milliseconds.');
+    }
+    refreshIntervalMs = parsed;
+  }
+
+  return { endpoint, bearerToken, refreshIntervalMs } satisfies NotifierRegistryConfig;
+}
+
+export function loadConfig(): NotifierConfig {
+  const expoAccessToken = process.env.AKARI_EXPO_ACCESS_TOKEN?.trim();
+  const registry = parseRegistryConfig();
+
+  logger.info('Loaded notifier configuration.', {
+    registryEndpoint: registry.endpoint,
+    registryRefreshMs: registry.refreshIntervalMs,
+    expoAccessTokenConfigured: Boolean(expoAccessToken),
+  });
+
+  return {
+    expoAccessToken,
+    registry,
+  } satisfies NotifierConfig;
+}

--- a/apps/firehose-notifier/src/dids.ts
+++ b/apps/firehose-notifier/src/dids.ts
@@ -1,0 +1,12 @@
+export function normaliseDid(value: string | undefined): string | null {
+  if (!value) return null;
+  const did = value.trim();
+  return did.length > 0 ? did.toLowerCase() : null;
+}
+
+export function didFromUri(uri: string | undefined): string | null {
+  if (!uri) return null;
+  if (!uri.startsWith('at://')) return null;
+  const [did] = uri.substring('at://'.length).split('/', 1);
+  return normaliseDid(did);
+}

--- a/apps/firehose-notifier/src/external.d.ts
+++ b/apps/firehose-notifier/src/external.d.ts
@@ -1,0 +1,57 @@
+declare module '@skyware/jetstream' {
+  export type CommitCreateEvent<TCollection extends string = string> = {
+    did: string;
+    commit: {
+      collection: TCollection;
+      record: unknown;
+      rkey: string;
+    };
+  };
+
+  export type JetstreamOptions<TCollection extends string> = {
+    endpoint?: string;
+    wantedCollections?: readonly TCollection[];
+  };
+
+  export class Jetstream<TCollection extends string = string> {
+    constructor(options?: JetstreamOptions<TCollection>);
+
+    start(): void;
+    close(): void;
+
+    on(event: 'open', listener: () => void): void;
+    on(event: 'close', listener: () => void): void;
+    on(event: 'error', listener: (error: unknown, cursor?: string) => void): void;
+    onCreate<T extends TCollection>(collection: T, listener: (event: CommitCreateEvent<T>) => void): void;
+  }
+}
+
+declare module 'expo-server-sdk' {
+  export type ExpoPushMessage = {
+    to: string;
+    sound?: string;
+    title?: string;
+    body?: string;
+    data?: Record<string, unknown>;
+  };
+
+  export type ExpoPushTicket = {
+    status: 'ok' | 'error';
+    id?: string;
+    message?: string;
+    details?: { error?: string };
+  };
+
+  export type ExpoOptions = {
+    accessToken?: string;
+  };
+
+  export class Expo {
+    constructor(options?: ExpoOptions);
+
+    static isExpoPushToken(token: string): boolean;
+
+    chunkPushNotifications(messages: ExpoPushMessage[]): ExpoPushMessage[][];
+    sendPushNotificationsAsync(messages: ExpoPushMessage[]): Promise<ExpoPushTicket[]>;
+  }
+}

--- a/apps/firehose-notifier/src/firehose.ts
+++ b/apps/firehose-notifier/src/firehose.ts
@@ -1,0 +1,238 @@
+import { Jetstream, type CommitCreateEvent } from '@skyware/jetstream';
+import { logger } from './logger.js';
+import { ExpoNotifier } from './notifier.js';
+import { didFromUri, normaliseDid } from './dids.js';
+import { SubscriptionStore } from './subscription-store.js';
+import type { ExpoNotificationPayload, InteractionReason, NotificationMessage, Subscription } from './types.js';
+
+type FollowRecord = {
+  subject: string;
+  createdAt?: string;
+};
+
+type LikeRecord = {
+  subject: {
+    uri: string;
+    cid: string;
+  };
+  createdAt?: string;
+};
+
+type RepostRecord = LikeRecord;
+
+type ReplyRecord = {
+  text?: string;
+  createdAt?: string;
+  reply?: {
+    parent?: {
+      uri: string;
+      cid: string;
+    };
+    root?: {
+      uri: string;
+      cid: string;
+    };
+  };
+};
+
+const WATCHED_COLLECTIONS = [
+  'app.bsky.graph.follow',
+  'app.bsky.feed.like',
+  'app.bsky.feed.post',
+  'app.bsky.feed.repost',
+] as const;
+
+function createNotificationMessage(
+  reason: InteractionReason,
+  actorDid: string,
+  payload: Partial<ExpoNotificationPayload>,
+  textSnippet?: string,
+): NotificationMessage {
+  const actorLabel = actorDid;
+
+  switch (reason) {
+    case 'follow':
+      return {
+        title: 'New follower',
+        body: `${actorLabel} followed you`,
+        data: { reason, actorDid, ...payload },
+      };
+    case 'like':
+      return {
+        title: 'New like',
+        body: `${actorLabel} liked your post`,
+        data: { reason, actorDid, ...payload },
+      };
+    case 'repost':
+      return {
+        title: 'New repost',
+        body: `${actorLabel} reposted your post`,
+        data: { reason, actorDid, ...payload },
+      };
+    case 'reply':
+      return {
+        title: 'New reply',
+        body: textSnippet ? `${actorLabel} replied: ${textSnippet}` : `${actorLabel} replied to your post`,
+        data: { reason, actorDid, ...payload },
+      };
+  }
+}
+
+function createReplyUri(event: CommitCreateEvent<'app.bsky.feed.post'>): string {
+  return `at://${event.did}/${event.commit.collection}/${event.commit.rkey}`;
+}
+
+function truncateText(value: string | undefined, maxLength: number = 120): string | undefined {
+  if (!value) return undefined;
+  if (value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength - 1)}…`;
+}
+
+export class FirehoseNotifier {
+  private readonly jetstream: Jetstream<(typeof WATCHED_COLLECTIONS)[number]>;
+  private readonly subscriptions: SubscriptionStore;
+  private readonly notifier: ExpoNotifier;
+
+  constructor(notifier: ExpoNotifier, subscriptions: SubscriptionStore) {
+    this.jetstream = new Jetstream<(typeof WATCHED_COLLECTIONS)[number]>({
+      wantedCollections: [...WATCHED_COLLECTIONS],
+    });
+
+    this.notifier = notifier;
+    this.subscriptions = subscriptions;
+  }
+
+  start(): void {
+    this.jetstream.on('open', () => logger.info('Connected to AT Protocol Jetstream.'));
+    this.jetstream.on('close', () => logger.warn('Disconnected from AT Protocol Jetstream.'));
+    this.jetstream.on('error', (error: unknown, cursor?: string) => {
+      logger.error('Jetstream connection error.', {
+        error: error instanceof Error ? error.message : error,
+        cursor,
+      });
+    });
+
+    this.jetstream.onCreate('app.bsky.graph.follow', (event) => {
+      this.handleFollow(event);
+    });
+
+    this.jetstream.onCreate('app.bsky.feed.like', (event) => {
+      this.handleLike(event);
+    });
+
+    this.jetstream.onCreate('app.bsky.feed.repost', (event) => {
+      this.handleRepost(event);
+    });
+
+    this.jetstream.onCreate('app.bsky.feed.post', (event) => {
+      this.handleReply(event);
+    });
+
+    this.jetstream.start();
+  }
+
+  stop(): void {
+    this.jetstream.close();
+  }
+
+  private findSubscription(did: string | null): Subscription | undefined {
+    return this.subscriptions.get(did);
+  }
+
+  private async notifySubscription(
+    subscription: Subscription,
+    reason: InteractionReason,
+    actorDid: string,
+    payload: Partial<ExpoNotificationPayload>,
+    textSnippet?: string,
+  ): Promise<void> {
+    const message = createNotificationMessage(reason, actorDid, payload, textSnippet);
+    await this.notifier.send(subscription, message);
+  }
+
+  private handleFollow(event: CommitCreateEvent<'app.bsky.graph.follow'>): void {
+    const record = event.commit.record as unknown as FollowRecord;
+    const targetDid = normaliseDid(record.subject);
+    const subscription = this.findSubscription(targetDid);
+
+    if (!subscription) return;
+    if (normaliseDid(event.did) === targetDid) return;
+
+    logger.debug('Processing follow event.', {
+      follower: event.did,
+      subject: record.subject,
+    });
+
+    void this.notifySubscription(subscription, 'follow', event.did, {});
+  }
+
+  private handleLike(event: CommitCreateEvent<'app.bsky.feed.like'>): void {
+    const record = event.commit.record as unknown as LikeRecord;
+    const targetDid = didFromUri(record.subject.uri);
+    const subscription = this.findSubscription(targetDid);
+
+    if (!subscription) return;
+    if (normaliseDid(event.did) === targetDid) return;
+
+    logger.debug('Processing like event.', {
+      actor: event.did,
+      subjectUri: record.subject.uri,
+    });
+
+    void this.notifySubscription(subscription, 'like', event.did, {
+      subjectUri: record.subject.uri,
+      recordCid: record.subject.cid,
+    });
+  }
+
+  private handleRepost(event: CommitCreateEvent<'app.bsky.feed.repost'>): void {
+    const record = event.commit.record as unknown as RepostRecord;
+    const targetDid = didFromUri(record.subject.uri);
+    const subscription = this.findSubscription(targetDid);
+
+    if (!subscription) return;
+    if (normaliseDid(event.did) === targetDid) return;
+
+    logger.debug('Processing repost event.', {
+      actor: event.did,
+      subjectUri: record.subject.uri,
+    });
+
+    void this.notifySubscription(subscription, 'repost', event.did, {
+      subjectUri: record.subject.uri,
+      recordCid: record.subject.cid,
+    });
+  }
+
+  private handleReply(event: CommitCreateEvent<'app.bsky.feed.post'>): void {
+    const record = event.commit.record as unknown as ReplyRecord;
+    if (!record.reply) return;
+
+    const potentialTargets = new Set<string>();
+    const parentDid = didFromUri(record.reply.parent?.uri);
+    const rootDid = didFromUri(record.reply.root?.uri);
+
+    if (parentDid) potentialTargets.add(parentDid);
+    if (rootDid) potentialTargets.add(rootDid);
+
+    const replyUri = createReplyUri(event);
+    const textSnippet = truncateText(record.text);
+
+    for (const did of potentialTargets) {
+      const subscription = this.findSubscription(did);
+      if (!subscription) continue;
+      if (normaliseDid(event.did) === normaliseDid(subscription.did)) continue;
+
+      logger.debug('Processing reply event.', {
+        actor: event.did,
+        target: subscription.did,
+        replyUri,
+      });
+
+      void this.notifySubscription(subscription, 'reply', event.did, {
+        replyUri,
+        subjectUri: record.reply?.root?.uri ?? record.reply?.parent?.uri,
+      }, textSnippet);
+    }
+  }
+}

--- a/apps/firehose-notifier/src/index.ts
+++ b/apps/firehose-notifier/src/index.ts
@@ -1,0 +1,39 @@
+import { loadConfig } from './config.js';
+import { FirehoseNotifier } from './firehose.js';
+import { logger } from './logger.js';
+import { ExpoNotifier } from './notifier.js';
+import { SubscriptionStore } from './subscription-store.js';
+
+let service: FirehoseNotifier | null = null;
+let subscriptionStore: SubscriptionStore | null = null;
+
+function registerShutdownHandlers() {
+  const handleShutdown = (signal: NodeJS.Signals) => {
+    logger.info(`Received ${signal}, shutting down firehose watcher.`);
+    service?.stop();
+    subscriptionStore?.stop();
+    process.exit(0);
+  };
+
+  process.once('SIGINT', handleShutdown);
+  process.once('SIGTERM', handleShutdown);
+}
+
+async function main() {
+  try {
+    const config = loadConfig();
+    const expoNotifier = new ExpoNotifier(config.expoAccessToken);
+    subscriptionStore = new SubscriptionStore(config.registry);
+    await subscriptionStore.start();
+    service = new FirehoseNotifier(expoNotifier, subscriptionStore);
+    service.start();
+    registerShutdownHandlers();
+  } catch (error) {
+    logger.error('Failed to start firehose notifier.', {
+      error: error instanceof Error ? error.message : error,
+    });
+    process.exit(1);
+  }
+}
+
+void main();

--- a/apps/firehose-notifier/src/logger.ts
+++ b/apps/firehose-notifier/src/logger.ts
@@ -1,0 +1,38 @@
+const LEVELS = ['debug', 'info', 'warn', 'error'] as const;
+
+export type LogLevel = (typeof LEVELS)[number];
+
+const levelWeights: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+const minLevel = (() => {
+  const level = process.env.AKARI_NOTIFIER_LOG_LEVEL?.toLowerCase() as LogLevel | undefined;
+  return level && LEVELS.includes(level) ? level : 'info';
+})();
+
+function timestamp(): string {
+  return new Date().toISOString();
+}
+
+export const logger = {
+  debug(message: string, metadata?: unknown) {
+    if (levelWeights[minLevel] > levelWeights.debug) return;
+    console.debug(`[${timestamp()}] [debug] ${message}`, metadata ?? '');
+  },
+  info(message: string, metadata?: unknown) {
+    if (levelWeights[minLevel] > levelWeights.info) return;
+    console.info(`[${timestamp()}] [info] ${message}`, metadata ?? '');
+  },
+  warn(message: string, metadata?: unknown) {
+    if (levelWeights[minLevel] > levelWeights.warn) return;
+    console.warn(`[${timestamp()}] [warn] ${message}`, metadata ?? '');
+  },
+  error(message: string, metadata?: unknown) {
+    if (levelWeights[minLevel] > levelWeights.error) return;
+    console.error(`[${timestamp()}] [error] ${message}`, metadata ?? '');
+  },
+};

--- a/apps/firehose-notifier/src/notifier.ts
+++ b/apps/firehose-notifier/src/notifier.ts
@@ -1,0 +1,67 @@
+import { Expo, type ExpoPushMessage, type ExpoPushTicket } from 'expo-server-sdk';
+import { logger } from './logger.js';
+import type { NotificationMessage, Subscription } from './types.js';
+
+export class ExpoNotifier {
+  private readonly expo: Expo;
+
+  constructor(accessToken?: string) {
+    this.expo = new Expo({ accessToken });
+  }
+
+  async send(subscription: Subscription, message: NotificationMessage): Promise<void> {
+    const validTokens = subscription.tokens.filter((token) => {
+      const isValid = Expo.isExpoPushToken(token);
+      if (!isValid) {
+        logger.warn('Skipping invalid Expo push token.', { token, did: subscription.did });
+      }
+      return isValid;
+    });
+
+    if (validTokens.length === 0) {
+      logger.warn('No valid Expo push tokens available for subscription.', { did: subscription.did });
+      return;
+    }
+
+    const payloads: ExpoPushMessage[] = validTokens.map((token) => ({
+      to: token,
+      sound: 'default',
+      title: message.title,
+      body: message.body,
+      data: message.data,
+    }));
+
+    const chunks = this.expo.chunkPushNotifications(payloads);
+
+    for (const chunk of chunks) {
+      try {
+        const tickets = await this.expo.sendPushNotificationsAsync(chunk);
+        this.logTickets(tickets, chunk, subscription);
+      } catch (error) {
+        logger.error('Failed to send Expo push notification chunk.', {
+          error: error instanceof Error ? error.message : error,
+          did: subscription.did,
+        });
+      }
+    }
+  }
+
+  private logTickets(tickets: ExpoPushTicket[], messages: ExpoPushMessage[], subscription: Subscription) {
+    tickets.forEach((ticket, index) => {
+      if (ticket.status === 'ok') {
+        logger.info('Delivered Expo push notification.', {
+          did: subscription.did,
+          ticketId: ticket.id,
+        });
+        return;
+      }
+
+      logger.error('Expo push notification failed.', {
+        did: subscription.did,
+        token: messages[index]?.to,
+        message: ticket.message,
+        details: ticket.details,
+      });
+    });
+  }
+}

--- a/apps/firehose-notifier/src/subscription-store.ts
+++ b/apps/firehose-notifier/src/subscription-store.ts
@@ -1,0 +1,96 @@
+import { logger } from './logger.js';
+import { parseSubscriptionPayload } from './subscription-utils.js';
+import { normaliseDid } from './dids.js';
+import type { NotifierRegistryConfig, Subscription } from './types.js';
+
+const DEFAULT_REFRESH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+function createSubscriptionMap(subscriptions: Subscription[]): Map<string, Subscription> {
+  return new Map(
+    subscriptions.map((subscription) => {
+      const key = normaliseDid(subscription.did) ?? subscription.did;
+      return [key, subscription] as const;
+    }),
+  );
+}
+
+function resolveRefreshInterval(config?: NotifierRegistryConfig): number {
+  if (!config?.refreshIntervalMs) {
+    return DEFAULT_REFRESH_INTERVAL_MS;
+  }
+
+  return Math.max(30_000, config.refreshIntervalMs);
+}
+
+export class SubscriptionStore {
+  private subscriptions: Map<string, Subscription> = new Map();
+  private readonly registryConfig: NotifierRegistryConfig;
+  private refreshTimer: NodeJS.Timeout | null = null;
+
+  constructor(config: NotifierRegistryConfig) {
+    this.registryConfig = config;
+  }
+
+  async start(): Promise<void> {
+    await this.refreshFromRegistry(true);
+
+    const interval = resolveRefreshInterval(this.registryConfig);
+    this.refreshTimer = setInterval(() => {
+      void this.refreshFromRegistry(false);
+    }, interval);
+    this.refreshTimer.unref();
+  }
+
+  stop(): void {
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+  }
+
+  get(did: string | null): Subscription | undefined {
+    if (!did) return undefined;
+    const key = normaliseDid(did) ?? did;
+    return this.subscriptions.get(key);
+  }
+
+  private async refreshFromRegistry(failOnError: boolean): Promise<void> {
+    try {
+      const response = await fetch(this.registryConfig.endpoint, {
+        headers: this.createHeaders(),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Registry request failed with status ${response.status} ${response.statusText}`);
+      }
+
+      const payload = (await response.json()) as unknown;
+      const subscriptions = parseSubscriptionPayload(payload, 'Registry response');
+      this.subscriptions = createSubscriptionMap(subscriptions);
+
+      logger.info('Loaded subscriptions from registry.', {
+        subscriptions: this.subscriptions.size,
+      });
+    } catch (error) {
+      logger.error('Failed to refresh subscriptions from registry.', {
+        error: error instanceof Error ? error.message : error,
+      });
+
+      if (failOnError) {
+        throw error instanceof Error ? error : new Error('Failed to load subscription registry.');
+      }
+    }
+  }
+
+  private createHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+    };
+
+    if (this.registryConfig.bearerToken) {
+      headers.Authorization = `Bearer ${this.registryConfig.bearerToken}`;
+    }
+
+    return headers;
+  }
+}

--- a/apps/firehose-notifier/src/subscription-utils.ts
+++ b/apps/firehose-notifier/src/subscription-utils.ts
@@ -1,0 +1,39 @@
+import type { Subscription } from './types.js';
+
+function coerceTokenArray(entry: unknown, key: 'tokens' | 'expoPushTokens'): string[] | null {
+  if (!entry || typeof entry !== 'object') return null;
+  const value = (entry as Record<string, unknown>)[key];
+  if (!Array.isArray(value)) return null;
+  return value
+    .map((token) => (typeof token === 'string' ? token.trim() : ''))
+    .filter((token) => token.length > 0);
+}
+
+export function parseSubscriptionPayload(raw: unknown, context: string): Subscription[] {
+  if (!Array.isArray(raw)) {
+    throw new Error(`${context} must be an array.`);
+  }
+
+  return raw.map((entry, index) => {
+    if (typeof entry !== 'object' || entry === null) {
+      throw new Error(`${context} entry at index ${index} must be an object.`);
+    }
+
+    const did = 'did' in entry && typeof (entry as { did?: unknown }).did === 'string'
+      ? ((entry as { did: string }).did.trim())
+      : '';
+
+    const tokens =
+      coerceTokenArray(entry, 'tokens') ?? coerceTokenArray(entry, 'expoPushTokens') ?? [];
+
+    if (!did) {
+      throw new Error(`${context} entry at index ${index} is missing a valid did.`);
+    }
+
+    if (tokens.length === 0) {
+      throw new Error(`${context} entry at index ${index} must include at least one Expo push token.`);
+    }
+
+    return { did, tokens } satisfies Subscription;
+  });
+}

--- a/apps/firehose-notifier/src/types.ts
+++ b/apps/firehose-notifier/src/types.ts
@@ -1,0 +1,31 @@
+export type InteractionReason = 'follow' | 'like' | 'reply' | 'repost';
+
+export type Subscription = {
+  did: string;
+  tokens: string[];
+};
+
+export type NotifierConfig = {
+  expoAccessToken?: string;
+  registry: NotifierRegistryConfig;
+};
+
+export type NotifierRegistryConfig = {
+  endpoint: string;
+  bearerToken?: string;
+  refreshIntervalMs?: number;
+};
+
+export type ExpoNotificationPayload = {
+  reason: InteractionReason;
+  actorDid: string;
+  subjectUri?: string;
+  replyUri?: string;
+  recordCid?: string;
+};
+
+export type NotificationMessage = {
+  title: string;
+  body: string;
+  data: ExpoNotificationPayload;
+};

--- a/apps/firehose-notifier/tsconfig.json
+++ b/apps/firehose-notifier/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/apps/notifier-registry/README.md
+++ b/apps/notifier-registry/README.md
@@ -1,0 +1,51 @@
+# Notifier Registry
+
+The Notifier Registry exposes a simple HTTP API for managing Expo push notification subscriptions. The firehose notifier polls this service to discover which Akari users should receive notifications for follows, likes, reposts, and replies.
+
+## API
+
+All responses are JSON encoded. CORS is enabled for all origins by default so mobile clients can call the registry directly.
+
+### `GET /subscriptions`
+
+Returns an array of `{ "did": string, "tokens": string[] }` objects. When `AKARI_REGISTRY_ADMIN_TOKEN` is set the request must include a matching `Authorization: Bearer <token>` header.
+
+### `POST /subscriptions`
+
+Registers a device for notifications. The request body must include:
+
+- `did` – The DID that should receive notifications.
+- `expoPushToken` – The Expo push token for the device.
+- `devicePushToken` – Optional platform device token, used for diagnostics.
+- `platform` – Client platform string (`ios`, `android`, or `web`).
+
+The registry de-duplicates tokens for a DID automatically.
+
+### `DELETE /subscriptions`
+
+Removes a token for a DID. The request body matches the payload accepted by `POST /subscriptions`.
+
+## Configuration
+
+- `AKARI_REGISTRY_PORT` – Port to listen on (defaults to `3001`).
+- `AKARI_REGISTRY_HOST` – Host interface to bind to (defaults to `0.0.0.0`).
+- `AKARI_REGISTRY_DATA_FILE` – Optional JSON file used to persist subscriptions across restarts.
+- `AKARI_REGISTRY_ADMIN_TOKEN` – Optional bearer token required to read subscriptions.
+- `AKARI_REGISTRY_CLIENT_TOKEN` – Optional bearer token required to create or delete subscriptions.
+- `AKARI_REGISTRY_LOG_LEVEL` – Optional log level (`debug`, `info`, `warn`, `error`). Defaults to `info`.
+
+## Scripts
+
+```bash
+# Install dependencies
+npm install
+
+# Build the service
+npm run build -- --filter=notifier-registry
+
+# Start in watch mode
+npm run dev -- --filter=notifier-registry
+
+# Run the compiled service
+npm run start -- --filter=notifier-registry
+```

--- a/apps/notifier-registry/package.json
+++ b/apps/notifier-registry/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "notifier-registry",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "tsx watch src/index.ts",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^20.17.12",
+    "tsx": "^4.19.2",
+    "typescript": "~5.8.3"
+  }
+}

--- a/apps/notifier-registry/src/config.ts
+++ b/apps/notifier-registry/src/config.ts
@@ -1,0 +1,26 @@
+import type { RegistryConfig } from './types.js';
+
+function parsePort(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    throw new Error('AKARI_REGISTRY_PORT must be a positive integer.');
+  }
+  return parsed;
+}
+
+export function loadConfig(): RegistryConfig {
+  const host = process.env.AKARI_REGISTRY_HOST?.trim() || '0.0.0.0';
+  const port = parsePort(process.env.AKARI_REGISTRY_PORT, 3001);
+  const dataFile = process.env.AKARI_REGISTRY_DATA_FILE?.trim() || undefined;
+  const adminToken = process.env.AKARI_REGISTRY_ADMIN_TOKEN?.trim() || undefined;
+  const clientToken = process.env.AKARI_REGISTRY_CLIENT_TOKEN?.trim() || undefined;
+
+  return {
+    host,
+    port,
+    dataFile,
+    adminToken,
+    clientToken,
+  } satisfies RegistryConfig;
+}

--- a/apps/notifier-registry/src/index.ts
+++ b/apps/notifier-registry/src/index.ts
@@ -1,0 +1,34 @@
+import { loadConfig } from './config.js';
+import { logger } from './logger.js';
+import { createRegistryServer } from './server.js';
+import { SubscriptionStore } from './subscription-store.js';
+
+async function main(): Promise<void> {
+  try {
+    const config = loadConfig();
+    const store = new SubscriptionStore(config.dataFile);
+    await store.load();
+
+    const server = createRegistryServer(config, store);
+    server.listen(config.port, config.host, () => {
+      logger.info('Notifier registry listening.', { host: config.host, port: config.port });
+    });
+
+    const shutdown = (signal: NodeJS.Signals) => {
+      logger.info(`Received ${signal}, shutting down notifier registry.`);
+      server.close(() => {
+        process.exit(0);
+      });
+    };
+
+    process.once('SIGINT', shutdown);
+    process.once('SIGTERM', shutdown);
+  } catch (error) {
+    logger.error('Failed to start notifier registry.', {
+      error: error instanceof Error ? error.message : error,
+    });
+    process.exit(1);
+  }
+}
+
+void main();

--- a/apps/notifier-registry/src/logger.ts
+++ b/apps/notifier-registry/src/logger.ts
@@ -1,0 +1,38 @@
+const LEVELS = ['debug', 'info', 'warn', 'error'] as const;
+
+export type LogLevel = (typeof LEVELS)[number];
+
+const levelWeights: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+const minLevel = (() => {
+  const level = process.env.AKARI_REGISTRY_LOG_LEVEL?.toLowerCase() as LogLevel | undefined;
+  return level && LEVELS.includes(level) ? level : 'info';
+})();
+
+function timestamp(): string {
+  return new Date().toISOString();
+}
+
+export const logger = {
+  debug(message: string, metadata?: unknown) {
+    if (levelWeights[minLevel] > levelWeights.debug) return;
+    console.debug(`[${timestamp()}] [debug] ${message}`, metadata ?? '');
+  },
+  info(message: string, metadata?: unknown) {
+    if (levelWeights[minLevel] > levelWeights.info) return;
+    console.info(`[${timestamp()}] [info] ${message}`, metadata ?? '');
+  },
+  warn(message: string, metadata?: unknown) {
+    if (levelWeights[minLevel] > levelWeights.warn) return;
+    console.warn(`[${timestamp()}] [warn] ${message}`, metadata ?? '');
+  },
+  error(message: string, metadata?: unknown) {
+    if (levelWeights[minLevel] > levelWeights.error) return;
+    console.error(`[${timestamp()}] [error] ${message}`, metadata ?? '');
+  },
+};

--- a/apps/notifier-registry/src/server.ts
+++ b/apps/notifier-registry/src/server.ts
@@ -1,0 +1,160 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import { URL } from 'node:url';
+
+import { logger } from './logger.js';
+import { SubscriptionStore } from './subscription-store.js';
+import type { RegistryConfig, RegistryPayload } from './types.js';
+
+const JSON_HEADERS = { 'content-type': 'application/json' } as const;
+
+const setCorsHeaders = (res: ServerResponse, origin?: string) => {
+  res.setHeader('Access-Control-Allow-Origin', origin ?? '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,DELETE,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+};
+
+const readBody = async (req: IncomingMessage): Promise<unknown> => {
+  const chunks: Buffer[] = [];
+
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+  }
+
+  if (chunks.length === 0) return {};
+
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf8')) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Invalid JSON payload.';
+    throw new Error(`Failed to parse request body: ${message}`);
+  }
+};
+
+const validatePayload = (raw: unknown): RegistryPayload => {
+  if (typeof raw !== 'object' || raw === null) {
+    throw new Error('Request body must be an object.');
+  }
+
+  const did = 'did' in raw && typeof (raw as { did?: unknown }).did === 'string' ? (raw as { did: string }).did : '';
+  const expoPushToken =
+    'expoPushToken' in raw && typeof (raw as { expoPushToken?: unknown }).expoPushToken === 'string'
+      ? (raw as { expoPushToken: string }).expoPushToken
+      : '';
+  const devicePushToken =
+    'devicePushToken' in raw && typeof (raw as { devicePushToken?: unknown }).devicePushToken === 'string'
+      ? (raw as { devicePushToken: string }).devicePushToken
+      : undefined;
+  const platform =
+    'platform' in raw && typeof (raw as { platform?: unknown }).platform === 'string'
+      ? (raw as { platform: string }).platform
+      : '';
+
+  if (!did.trim()) {
+    throw new Error('Request body must include a did.');
+  }
+
+  if (!expoPushToken.trim()) {
+    throw new Error('Request body must include an Expo push token.');
+  }
+
+  if (!platform.trim()) {
+    throw new Error('Request body must include a platform.');
+  }
+
+  return {
+    did: did.trim(),
+    expoPushToken: expoPushToken.trim(),
+    devicePushToken: devicePushToken?.trim() || undefined,
+    platform: platform.trim(),
+  } satisfies RegistryPayload;
+};
+
+const verifyAuthorization = (req: IncomingMessage, token?: string): boolean => {
+  if (!token) return true;
+  const header = req.headers.authorization;
+  if (!header?.startsWith('Bearer ')) {
+    return false;
+  }
+  const provided = header.slice('Bearer '.length).trim();
+  return provided === token;
+};
+
+const sendJson = (res: ServerResponse, statusCode: number, body: unknown): void => {
+  res.writeHead(statusCode, JSON_HEADERS);
+  res.end(body === undefined ? undefined : `${JSON.stringify(body)}\n`);
+};
+
+const sendError = (res: ServerResponse, statusCode: number, message: string): void => {
+  sendJson(res, statusCode, { error: message });
+};
+
+export function createRegistryServer(config: RegistryConfig, store: SubscriptionStore) {
+  return createServer(async (req, res) => {
+    try {
+      const origin = req.headers.origin;
+      setCorsHeaders(res, origin);
+
+      if (req.method === 'OPTIONS') {
+        res.writeHead(204);
+        res.end();
+        return;
+      }
+
+      const url = req.url ? new URL(req.url, `http://${req.headers.host ?? 'localhost'}`) : null;
+      const pathname = url?.pathname ?? '';
+
+      if (req.method === 'GET' && pathname === '/subscriptions') {
+        if (!verifyAuthorization(req, config.adminToken)) {
+          sendError(res, 401, 'Invalid or missing authorization token.');
+          return;
+        }
+
+        const subscriptions = store.getAll();
+        sendJson(res, 200, subscriptions);
+        return;
+      }
+
+      if (req.method === 'POST' && pathname === '/subscriptions') {
+        if (!verifyAuthorization(req, config.clientToken)) {
+          sendError(res, 401, 'Invalid or missing authorization token.');
+          return;
+        }
+
+        const payload = validatePayload(await readBody(req));
+        const result = await store.register(payload);
+        logger.info('Registered Expo push token.', {
+          did: payload.did,
+          platform: payload.platform,
+          isNewToken: result.isNewToken,
+          totalTokens: result.totalTokens,
+        });
+        sendJson(res, 200, { success: true, totalTokens: result.totalTokens });
+        return;
+      }
+
+      if (req.method === 'DELETE' && pathname === '/subscriptions') {
+        if (!verifyAuthorization(req, config.clientToken)) {
+          sendError(res, 401, 'Invalid or missing authorization token.');
+          return;
+        }
+
+        const payload = validatePayload(await readBody(req));
+        const result = await store.unregister(payload);
+        logger.info('Removed Expo push token.', {
+          did: payload.did,
+          platform: payload.platform,
+          removed: result.removed,
+          totalTokens: result.totalTokens,
+        });
+        sendJson(res, 200, { success: result.removed, totalTokens: result.totalTokens });
+        return;
+      }
+
+      sendError(res, 404, 'Not found.');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unexpected error.';
+      logger.error('Registry request failed.', { message });
+      sendError(res, 400, message);
+    }
+  });
+}

--- a/apps/notifier-registry/src/subscription-store.ts
+++ b/apps/notifier-registry/src/subscription-store.ts
@@ -1,0 +1,156 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { constants as fsConstants } from 'node:fs';
+import { access } from 'node:fs/promises';
+
+import { logger } from './logger.js';
+import type { RegistryPayload, SubscriptionRecord } from './types.js';
+
+const normaliseDid = (did: string | undefined): string | null => {
+  if (!did) return null;
+  const trimmed = did.trim().toLowerCase();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const normaliseToken = (token: string | undefined): string | null => {
+  if (!token) return null;
+  const trimmed = token.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+function parsePersistedRecords(raw: unknown): SubscriptionRecord[] {
+  if (!Array.isArray(raw)) {
+    throw new Error('Persisted subscription data must be an array.');
+  }
+
+  return raw.map((entry, index) => {
+    if (!isObject(entry)) {
+      throw new Error(`Persisted subscription entry at index ${index} must be an object.`);
+    }
+
+    const did = normaliseDid(typeof entry.did === 'string' ? entry.did : undefined);
+    if (!did) {
+      throw new Error(`Persisted subscription entry at index ${index} is missing a valid did.`);
+    }
+
+    const tokens = Array.isArray(entry.tokens)
+      ? entry.tokens
+          .map((token) => normaliseToken(typeof token === 'string' ? token : undefined))
+          .filter((token): token is string => Boolean(token))
+      : [];
+
+    if (tokens.length === 0) {
+      throw new Error(`Persisted subscription entry at index ${index} must include at least one Expo push token.`);
+    }
+
+    return { did, tokens } satisfies SubscriptionRecord;
+  });
+}
+
+const createRecordMap = (records: SubscriptionRecord[]): Map<string, Set<string>> => {
+  const map = new Map<string, Set<string>>();
+  for (const record of records) {
+    map.set(record.did, new Set(record.tokens));
+  }
+  return map;
+};
+
+export class SubscriptionStore {
+  private readonly dataFile?: string;
+  private records: Map<string, Set<string>> = new Map();
+
+  constructor(dataFile?: string) {
+    this.dataFile = dataFile;
+  }
+
+  async load(): Promise<void> {
+    if (!this.dataFile) return;
+
+    try {
+      await access(this.dataFile, fsConstants.F_OK);
+    } catch (error) {
+      logger.info('Subscription data file not found, starting with an empty registry.', {
+        dataFile: this.dataFile,
+      });
+      return;
+    }
+
+    try {
+      const raw = await readFile(this.dataFile, 'utf8');
+      const parsed = JSON.parse(raw) as unknown;
+      const records = parsePersistedRecords(parsed);
+      this.records = createRecordMap(records);
+      logger.info('Loaded subscriptions from disk.', { count: this.records.size });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Failed to load subscription data: ${message}`);
+    }
+  }
+
+  async register(payload: RegistryPayload): Promise<{ isNewToken: boolean; totalTokens: number }> {
+    const did = normaliseDid(payload.did);
+    if (!did) {
+      throw new Error('A valid did is required.');
+    }
+
+    const token = normaliseToken(payload.expoPushToken);
+    if (!token) {
+      throw new Error('A valid Expo push token is required.');
+    }
+
+    const existing = this.records.get(did) ?? new Set<string>();
+    const previousSize = existing.size;
+    existing.add(token);
+    this.records.set(did, existing);
+
+    await this.persist();
+
+    return { isNewToken: existing.size !== previousSize, totalTokens: existing.size };
+  }
+
+  async unregister(payload: RegistryPayload): Promise<{ removed: boolean; totalTokens: number }> {
+    const did = normaliseDid(payload.did);
+    if (!did) {
+      throw new Error('A valid did is required.');
+    }
+
+    const token = normaliseToken(payload.expoPushToken);
+    if (!token) {
+      throw new Error('A valid Expo push token is required.');
+    }
+
+    const existing = this.records.get(did);
+    if (!existing) {
+      return { removed: false, totalTokens: 0 };
+    }
+
+    const removed = existing.delete(token);
+
+    if (existing.size === 0) {
+      this.records.delete(did);
+    } else {
+      this.records.set(did, existing);
+    }
+
+    if (removed) {
+      await this.persist();
+    }
+
+    return { removed, totalTokens: this.records.get(did)?.size ?? 0 };
+  }
+
+  getAll(): SubscriptionRecord[] {
+    return [...this.records.entries()]
+      .sort(([aDid], [bDid]) => aDid.localeCompare(bDid))
+      .map(([did, tokens]) => ({ did, tokens: [...tokens] }));
+  }
+
+  private async persist(): Promise<void> {
+    if (!this.dataFile) return;
+
+    const records = this.getAll();
+    await writeFile(this.dataFile, `${JSON.stringify(records, null, 2)}\n`, 'utf8');
+  }
+}

--- a/apps/notifier-registry/src/types.ts
+++ b/apps/notifier-registry/src/types.ts
@@ -1,0 +1,19 @@
+export type SubscriptionRecord = {
+  did: string;
+  tokens: string[];
+};
+
+export type RegistryPayload = {
+  did: string;
+  expoPushToken: string;
+  devicePushToken?: string;
+  platform: string;
+};
+
+export type RegistryConfig = {
+  host: string;
+  port: number;
+  dataFile?: string;
+  adminToken?: string;
+  clientToken?: string;
+};

--- a/apps/notifier-registry/tsconfig.json
+++ b/apps/notifier-registry/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -223,6 +223,88 @@
         "node": ">=14.17"
       }
     },
+    "apps/firehose-notifier": {
+      "version": "0.0.1",
+      "dependencies": {
+        "@skyware/jetstream": "^0.2.5",
+        "expo-server-sdk": "^4.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.17.12",
+        "tsx": "^4.19.2",
+        "typescript": "~5.8.3"
+      }
+    },
+    "apps/firehose-notifier/node_modules/@types/node": {
+      "version": "20.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.19.tgz",
+      "integrity": "sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "apps/firehose-notifier/node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "apps/firehose-notifier/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/notifier-registry": {
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/node": "^20.17.12",
+        "tsx": "^4.19.2",
+        "typescript": "~5.8.3"
+      }
+    },
+    "apps/notifier-registry/node_modules/@types/node": {
+      "version": "20.19.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.19.tgz",
+      "integrity": "sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "apps/notifier-registry/node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "apps/notifier-registry/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@0no-co/graphql.web": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz",
@@ -306,11 +388,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@atcute/atproto": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@atcute/atproto/-/atproto-3.1.4.tgz",
+      "integrity": "sha512-v0/ue7mZYtjYw4vWbtda51bLwW88mqsUQB8F/UZNO18ANAQWmKq1HDceVqjvruaLe2QPqE43XM3WkEyZ2FhOrA==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/lexicons": "^1.1.1"
+      }
+    },
+    "node_modules/@atcute/bluesky": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@atcute/bluesky/-/bluesky-3.2.3.tgz",
+      "integrity": "sha512-IdPQQ54F1BLhW5z49k81ZUC/GQl/tVygZ+CzLHYvQySHA6GJRcvPzwEf8aV21u0SZOJF+yF4CWEGNgtryyxPmg==",
+      "license": "0BSD",
+      "dependencies": {
+        "@atcute/atproto": "^3.1.4",
+        "@atcute/lexicons": "^1.1.1"
+      }
+    },
     "node_modules/@atcute/bluesky-richtext-parser": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@atcute/bluesky-richtext-parser/-/bluesky-richtext-parser-1.0.7.tgz",
       "integrity": "sha512-nOvU699OXiGMbyswao7JJnY0C9WkwE7PVC/m5WWt0UN9fsXSOor9IZWw+v9SATp+94BTJoG38XyUomUaJnoQRA==",
       "license": "MIT"
+    },
+    "node_modules/@atcute/lexicons": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@atcute/lexicons/-/lexicons-1.1.1.tgz",
+      "integrity": "sha512-k6qy5p3j9fJJ6ekaMPfEfp3ni4TW/XNuH9ZmsuwC0fi0tOjp+Fa8ZQakHwnqOzFt/cVBfGcmYE/lKNAbeTjgUg==",
+      "license": "0BSD",
+      "dependencies": {
+        "esm-env": "^1.2.2"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -2309,6 +2419,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -2326,6 +2453,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -2341,6 +2485,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -5722,6 +5883,19 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@skyware/jetstream": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@skyware/jetstream/-/jetstream-0.2.5.tgz",
+      "integrity": "sha512-fM/zs03DLwqRyzZZJFWN20e76KrdqIp97Tlm8Cek+vxn96+tu5d/fx79V6H85L0QN6HvGiX2l9A8hWFqHvYlOA==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@atcute/atproto": "^3.1.0",
+        "@atcute/bluesky": "^3.1.4",
+        "@atcute/lexicons": "^1.1.0",
+        "partysocket": "^1.1.3",
+        "tiny-emitter": "^2.1.0"
       }
     },
     "node_modules/@swc/core": {
@@ -9497,6 +9671,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "license": "MIT"
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -10202,6 +10382,12 @@
         "node": "*"
       }
     },
+    "node_modules/esm-env": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
+      "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+      "license": "MIT"
+    },
     "node_modules/espree": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
@@ -10297,6 +10483,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/event-target-polyfill": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.4.tgz",
+      "integrity": "sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==",
+      "license": "MIT"
     },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
@@ -10951,6 +11143,20 @@
         "node": ">=20.16.0"
       }
     },
+    "node_modules/expo-server-sdk": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/expo-server-sdk/-/expo-server-sdk-4.0.0.tgz",
+      "integrity": "sha512-zi83XtG2pqyP3gyn1JIRYkydo2i6HU3CYaWo/VvhZG/F29U+QIDv6LBEUsWf4ddZlVE7c9WN1N8Be49rHgO8OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.0",
+        "promise-limit": "^2.7.0",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/expo-splash-screen": {
       "version": "31.0.10",
       "resolved": "https://registry.npmjs.org/expo-splash-screen/-/expo-splash-screen-31.0.10.tgz",
@@ -11553,6 +11759,10 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/firehose-notifier": {
+      "resolved": "apps/firehose-notifier",
+      "link": true
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
@@ -16194,6 +16404,10 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/notifier-registry": {
+      "resolved": "apps/notifier-registry",
+      "link": true
+    },
     "node_modules/npm-package-arg": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
@@ -16724,6 +16938,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/partysocket": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/partysocket/-/partysocket-1.1.6.tgz",
+      "integrity": "sha512-LkEk8N9hMDDsDT0iDK0zuwUDFVrVMUXFXCeN3850Ng8wtjPqPBeJlwdeY6ROlJSEh3tPoTTasXoSBYH76y118w==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-polyfill": "^0.0.4"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -17076,6 +17299,25 @@
       "license": "MIT",
       "dependencies": {
         "asap": "~2.0.6"
+      }
+    },
+    "node_modules/promise-limit": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
+      "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==",
+      "license": "ISC"
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/prompts": {
@@ -18052,6 +18294,15 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/rettime": {
       "version": "0.7.0",
@@ -19565,6 +19816,12 @@
       "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
       "license": "MIT"
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -19879,6 +20136,474 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/turbo": {
       "version": "2.5.8",


### PR DESCRIPTION
## Summary
- inline the push registry fetch inside `useRegisterPushSubscription` so the mutation validates configuration and posts directly to the registry

## Testing
- npm run lint -- --filter=akari
- npm run test -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68e187b7c600832bbd00d6f6d91a6be5