### PR TITLE
fix: nest post and profile navigation under tabs stack

### DIFF
--- a/apps/akari/__tests__/app/tabs/bookmarks.test.tsx
+++ b/apps/akari/__tests__/app/tabs/bookmarks.test.tsx
@@ -157,7 +157,7 @@ describe('BookmarksScreen', () => {
     });
 
     fireEvent.press(getByText('Hello world'));
-    expect(router.push).toHaveBeenCalledWith('/post/at%3A%2F%2Fexample.com%2Fpost%2F1');
+    expect(router.push).toHaveBeenCalledWith('/(tabs)/post/at%3A%2F%2Fexample.com%2Fpost%2F1');
 
     const list = UNSAFE_getByType(VirtualizedList);
 

--- a/apps/akari/__tests__/app/tabs/messages-handle.test.tsx
+++ b/apps/akari/__tests__/app/tabs/messages-handle.test.tsx
@@ -255,7 +255,7 @@ describe('ConversationScreen', () => {
     const { getByText } = render(<ConversationScreen />);
 
     fireEvent.press(getByText('@alice'));
-    expect(mockRouterPush).toHaveBeenCalledWith('/profile/alice');
+    expect(mockRouterPush).toHaveBeenCalledWith('/(tabs)/profile/alice');
 
     fireEvent.press(getByText('chevron.left'));
     expect(mockRouterBack).toHaveBeenCalledTimes(1);

--- a/apps/akari/__tests__/app/tabs/messages-index.test.tsx
+++ b/apps/akari/__tests__/app/tabs/messages-index.test.tsx
@@ -131,7 +131,7 @@ describe('MessagesScreen', () => {
     expect(mockRouterPush).toHaveBeenNthCalledWith(2, '/(tabs)/messages/alice');
 
     fireEvent.press(UNSAFE_getAllByType(TouchableOpacity)[2]);
-    expect(mockRouterPush).toHaveBeenNthCalledWith(3, '/profile/alice');
+    expect(mockRouterPush).toHaveBeenNthCalledWith(3, '/(tabs)/profile/alice');
   });
 
   it('scrolls to top when registry callback is triggered', () => {

--- a/apps/akari/__tests__/app/tabs/messages-pending.test.tsx
+++ b/apps/akari/__tests__/app/tabs/messages-pending.test.tsx
@@ -105,7 +105,7 @@ describe('PendingMessagesScreen', () => {
     expect(mockRouterPush).toHaveBeenNthCalledWith(1, '/(tabs)/messages/pending-pal');
 
     fireEvent.press(UNSAFE_getAllByType(TouchableOpacity)[2]);
-    expect(mockRouterPush).toHaveBeenNthCalledWith(2, '/profile/pending-pal');
+    expect(mockRouterPush).toHaveBeenNthCalledWith(2, '/(tabs)/profile/pending-pal');
 
     fireEvent.press(UNSAFE_getAllByType(TouchableOpacity)[0]);
     expect(mockRouterBack).toHaveBeenCalledTimes(1);

--- a/apps/akari/__tests__/app/tabs/notifications.test.tsx
+++ b/apps/akari/__tests__/app/tabs/notifications.test.tsx
@@ -129,10 +129,10 @@ describe('NotificationsScreen', () => {
     expect(getByText('notifications.startedFollowingYou')).toBeTruthy();
 
     fireEvent.press(getByText('notifications.andOneOther'));
-    expect(mockRouterPush).toHaveBeenCalledWith('/post/post1');
+    expect(mockRouterPush).toHaveBeenCalledWith('/(tabs)/post/post1');
 
     fireEvent.press(getByText('notifications.startedFollowingYou'));
-    expect(mockRouterPush).toHaveBeenCalledWith('/profile/carol');
+    expect(mockRouterPush).toHaveBeenCalledWith('/(tabs)/profile/carol');
   });
 
   it('renders grouped notifications with embed images and overflow avatars', () => {
@@ -389,7 +389,7 @@ describe('NotificationsScreen', () => {
     const { getByText } = render(<NotificationsScreen />);
 
     fireEvent.press(getByText('notifications.mentionedYou'));
-    expect(mockRouterPush).toHaveBeenLastCalledWith('/profile/no-subject');
+    expect(mockRouterPush).toHaveBeenLastCalledWith('/(tabs)/profile/no-subject');
   });
 });
 

--- a/apps/akari/__tests__/components/PostCard.test.tsx
+++ b/apps/akari/__tests__/components/PostCard.test.tsx
@@ -140,7 +140,7 @@ describe('PostCard', () => {
     const { getByRole } = render(<PostCard post={basePost} />);
     const button = getByRole('button', { name: 'View profile of Alice' });
     fireEvent.press(button);
-    expect(router.push).toHaveBeenCalledWith('/profile/alice');
+    expect(router.push).toHaveBeenCalledWith('/(tabs)/profile/alice');
   });
 
   it('navigates to profile when avatar pressed', () => {
@@ -148,7 +148,7 @@ describe('PostCard', () => {
     const { getByRole } = render(<PostCard post={basePost} />);
     const avatarButton = getByRole('button', { name: "View Alice's profile via avatar" });
     fireEvent.press(avatarButton);
-    expect(router.push).toHaveBeenCalledWith('/profile/alice');
+    expect(router.push).toHaveBeenCalledWith('/(tabs)/profile/alice');
   });
 
   it('likes a post when not previously liked', () => {

--- a/apps/akari/__tests__/components/RecordEmbed.test.tsx
+++ b/apps/akari/__tests__/components/RecordEmbed.test.tsx
@@ -243,10 +243,10 @@ describe('RecordEmbed Component', () => {
     const { getByTestId, getByText } = render(<RecordEmbed embed={embed} />);
 
     fireEvent.press(getByTestId('record-embed-touchable'));
-    expect(router.push).toHaveBeenCalledWith(`/post/${encodeURIComponent(embed.record.uri)}`);
+    expect(router.push).toHaveBeenCalledWith(`/(tabs)/post/${encodeURIComponent(embed.record.uri)}`);
 
     fireEvent.press(getByText('Test User'));
-    expect(router.push).toHaveBeenCalledWith(`/profile/${encodeURIComponent(embed.record.author.handle)}`);
+    expect(router.push).toHaveBeenCalledWith(`/(tabs)/profile/${encodeURIComponent(embed.record.author.handle)}`);
   });
 
   it('should render images and handle load events', () => {

--- a/apps/akari/__tests__/components/profile/LikesTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/LikesTab.test.tsx
@@ -113,7 +113,7 @@ describe('LikesTab', () => {
 
     const { getByText, UNSAFE_getByType } = render(<LikesTab handle="tester" />);
     fireEvent.press(getByText('liked post'));
-    expect(router.push).toHaveBeenCalledWith(`/post/${encodeURIComponent(like.uri)}`);
+    expect(router.push).toHaveBeenCalledWith(`/(tabs)/post/${encodeURIComponent(like.uri)}`);
 
     const list = UNSAFE_getByType(VirtualizedList);
     act(() => {

--- a/apps/akari/__tests__/components/profile/MediaTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/MediaTab.test.tsx
@@ -115,7 +115,7 @@ describe('MediaTab', () => {
     expect(PostCardMock).toHaveBeenCalledTimes(1);
     const press = PostCardMock.mock.calls[0][0].onPress;
     press();
-    expect(router.push).toHaveBeenCalledWith('/post/' + encodeURIComponent('at://post1'));
+    expect(router.push).toHaveBeenCalledWith('/(tabs)/post/' + encodeURIComponent('at://post1'));
   });
 
   it('formats reply data and uses unknown handle when missing', () => {

--- a/apps/akari/__tests__/components/profile/PostsTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/PostsTab.test.tsx
@@ -107,7 +107,7 @@ describe('PostsTab', () => {
     expect(mockPostCard).toHaveBeenCalledTimes(1);
     const button = getByRole('button');
     fireEvent.press(button);
-    expect(router.push).toHaveBeenCalledWith(`/post/${encodeURIComponent(post.uri)}`);
+    expect(router.push).toHaveBeenCalledWith(`/(tabs)/post/${encodeURIComponent(post.uri)}`);
     const call = mockPostCard.mock.calls[0][0];
     expect(call.post.replyTo).toEqual({
       author: { handle: 'bob', displayName: 'Bob' },

--- a/apps/akari/__tests__/components/profile/RepliesTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/RepliesTab.test.tsx
@@ -86,7 +86,7 @@ describe('RepliesTab', () => {
 
     const { getByText } = render(<RepliesTab handle="alice" />);
     fireEvent.press(getByText('Hello world'));
-    expect(mockPush).toHaveBeenCalledWith(`/post/${encodeURIComponent(reply.uri)}`);
+    expect(mockPush).toHaveBeenCalledWith(`/(tabs)/post/${encodeURIComponent(reply.uri)}`);
   });
 
   it('fetches more replies on end reached', () => {

--- a/apps/akari/__tests__/components/profile/VideosTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/VideosTab.test.tsx
@@ -101,7 +101,7 @@ describe('VideosTab', () => {
 
     const { getByText } = render(<VideosTab handle="alice" />);
     fireEvent.press(getByText('at://video/1'));
-    expect(router.push).toHaveBeenCalledWith('/post/' + encodeURIComponent('at://video/1'));
+    expect(router.push).toHaveBeenCalledWith('/(tabs)/post/' + encodeURIComponent('at://video/1'));
   });
 
   it('fetches next page on end reached', () => {

--- a/apps/akari/__tests__/hooks/usePushNotifications.test.ts
+++ b/apps/akari/__tests__/hooks/usePushNotifications.test.ts
@@ -410,8 +410,8 @@ describe('usePushNotifications', () => {
     });
 
     const scenarios = [
-      { type: 'post', id: 'abc def', expected: '/post/abc%20def' },
-      { type: 'profile', id: 'user', expected: '/profile/user' },
+      { type: 'post', id: 'abc def', expected: '/(tabs)/post/abc%20def' },
+      { type: 'profile', id: 'user', expected: '/(tabs)/profile/user' },
       { type: 'conversation', id: '42', expected: '/messages/42' },
       { type: 'notification', id: 'any', expected: '/notifications' },
       { type: 'unknown', id: '??', expected: '/notifications' },

--- a/apps/akari/app/(tabs)/bookmarks.tsx
+++ b/apps/akari/app/(tabs)/bookmarks.tsx
@@ -91,7 +91,7 @@ export default function BookmarksScreen() {
             cid: post.cid,
           }}
           onPress={() => {
-            router.push(`/post/${encodeURIComponent(post.uri)}`);
+            router.push(`/(tabs)/post/${encodeURIComponent(post.uri)}`);
           }}
         />
       </View>

--- a/apps/akari/app/(tabs)/index.tsx
+++ b/apps/akari/app/(tabs)/index.tsx
@@ -254,7 +254,7 @@ export default function HomeScreen() {
             cid: post.cid,
           }}
           onPress={() => {
-            router.push(`/post/${encodeURIComponent(post.uri)}`);
+            router.push(`/(tabs)/post/${encodeURIComponent(post.uri)}`);
           }}
         />
       );

--- a/apps/akari/app/(tabs)/messages/[handle].tsx
+++ b/apps/akari/app/(tabs)/messages/[handle].tsx
@@ -501,7 +501,7 @@ export default function ConversationScreen() {
               style={styles.headerInfo}
               onPress={() => {
                 // Navigate to profile when header is clicked
-                router.push(`/profile/${encodeURIComponent(handle)}`);
+                router.push(`/(tabs)/profile/${encodeURIComponent(handle)}`);
               }}
               activeOpacity={0.7}
             >

--- a/apps/akari/app/(tabs)/messages/index.tsx
+++ b/apps/akari/app/(tabs)/messages/index.tsx
@@ -98,7 +98,7 @@ export function MessagesListScreen({
           <TouchableOpacity
             style={styles.avatarContainer}
             onPress={() => {
-              router.push(`/profile/${encodeURIComponent(item.handle)}`);
+              router.push(`/(tabs)/profile/${encodeURIComponent(item.handle)}`);
             }}
             activeOpacity={0.7}
           >

--- a/apps/akari/app/(tabs)/notifications.tsx
+++ b/apps/akari/app/(tabs)/notifications.tsx
@@ -415,13 +415,13 @@ export default function NotificationsScreen() {
   const handleNotificationPress = useCallback((notification: GroupedNotification) => {
     if (notification.type === 'follow') {
       // Navigate to the first author's profile
-      router.push(`/profile/${encodeURIComponent(notification.authors[0].handle)}`);
+      router.push(`/(tabs)/profile/${encodeURIComponent(notification.authors[0].handle)}`);
     } else if (notification.subject) {
       // Navigate to the post
-      router.push(`/post/${encodeURIComponent(notification.subject)}`);
+      router.push(`/(tabs)/post/${encodeURIComponent(notification.subject)}`);
     } else {
       // For notifications without a subject, navigate to the first author's profile
-      router.push(`/profile/${encodeURIComponent(notification.authors[0].handle)}`);
+      router.push(`/(tabs)/profile/${encodeURIComponent(notification.authors[0].handle)}`);
     }
   }, []);
 

--- a/apps/akari/app/(tabs)/search.tsx
+++ b/apps/akari/app/(tabs)/search.tsx
@@ -133,7 +133,7 @@ export default function SearchScreen() {
     return (
       <TouchableOpacity
         style={[styles.resultItem, { borderBottomColor: borderColor }]}
-        onPress={() => router.push('/profile/' + encodeURIComponent(profile.handle))}
+        onPress={() => router.push('/(tabs)/profile/' + encodeURIComponent(profile.handle))}
         activeOpacity={0.7}
       >
         <ThemedView style={styles.profileContainer}>
@@ -203,7 +203,7 @@ export default function SearchScreen() {
           cid: post.cid,
         }}
         onPress={() => {
-          router.push('/post/' + encodeURIComponent(post.uri));
+          router.push('/(tabs)/post/' + encodeURIComponent(post.uri));
         }}
       />
     );

--- a/apps/akari/components/PostCard.tsx
+++ b/apps/akari/components/PostCard.tsx
@@ -589,7 +589,7 @@ export function PostCard({ post, onPress }: PostCardProps) {
   );
 
   const handleProfilePress = () => {
-    router.push(`/profile/${encodeURIComponent(post.author.handle)}`);
+    router.push(`/(tabs)/profile/${encodeURIComponent(post.author.handle)}`);
   };
 
   const livePreview = showLivePreview && liveStreamInfo

--- a/apps/akari/components/RecordEmbed.tsx
+++ b/apps/akari/components/RecordEmbed.tsx
@@ -59,13 +59,13 @@ export function RecordEmbed({ embed }: RecordEmbedProps) {
 
   const handlePress = () => {
     // Navigate to the quoted post
-    router.push(`/post/${encodeURIComponent(embed.record.uri)}`);
+    router.push(`/(tabs)/post/${encodeURIComponent(embed.record.uri)}`);
   };
 
   const handleAuthorPress = () => {
     // Navigate to the quoted post's author profile
     if (embed.record.author?.handle) {
-      router.push(`/profile/${encodeURIComponent(embed.record.author.handle)}`);
+      router.push(`/(tabs)/profile/${encodeURIComponent(embed.record.author.handle)}`);
     }
   };
 

--- a/apps/akari/components/RichText.tsx
+++ b/apps/akari/components/RichText.tsx
@@ -101,7 +101,7 @@ export function RichText({ text, style, containerStyle, onPress }: RichTextProps
 
           case 'mention':
             return (
-              <Link key={index} href={`/profile/${token.handle}`}>
+              <Link key={index} href={`/(tabs)/profile/${token.handle}`}>
                 <ThemedText style={[{ color: mentionColor }]}>@{token.handle}</ThemedText>
               </Link>
             );

--- a/apps/akari/components/RichTextWithFacets.tsx
+++ b/apps/akari/components/RichTextWithFacets.tsx
@@ -201,7 +201,7 @@ export function RichTextWithFacets({ text, facets, style, containerStyle, onPres
               // The text should contain the actual handle (e.g., "@miragreen.bsky.social")
               const handle = segment.text.replace(/^@/, ''); // Remove the @ symbol
               return (
-                <Link key={index} href={`/profile/${handle}`}>
+                <Link key={index} href={`/(tabs)/profile/${handle}`}>
                   <ThemedText style={[{ color: mentionColor }]}>{segment.text}</ThemedText>
                 </Link>
               );

--- a/apps/akari/components/profile/LikesTab.tsx
+++ b/apps/akari/components/profile/LikesTab.tsx
@@ -62,7 +62,7 @@ export function LikesTab({ handle }: LikesTabProps) {
           cid: item.cid,
         }}
         onPress={() => {
-          router.push(`/post/${encodeURIComponent(item.uri)}`);
+          router.push(`/(tabs)/post/${encodeURIComponent(item.uri)}`);
         }}
       />
     );

--- a/apps/akari/components/profile/MediaTab.tsx
+++ b/apps/akari/components/profile/MediaTab.tsx
@@ -68,7 +68,7 @@ export function MediaTab({ handle }: MediaTabProps) {
           cid: item.cid,
         }}
         onPress={() => {
-          router.push(`/post/${encodeURIComponent(item.uri)}`);
+          router.push(`/(tabs)/post/${encodeURIComponent(item.uri)}`);
         }}
       />
     );

--- a/apps/akari/components/profile/PostsTab.tsx
+++ b/apps/akari/components/profile/PostsTab.tsx
@@ -62,7 +62,7 @@ export function PostsTab({ handle }: PostsTabProps) {
           cid: item.cid,
         }}
         onPress={() => {
-          router.push(`/post/${encodeURIComponent(item.uri)}`);
+          router.push(`/(tabs)/post/${encodeURIComponent(item.uri)}`);
         }}
       />
     );

--- a/apps/akari/components/profile/RepliesTab.tsx
+++ b/apps/akari/components/profile/RepliesTab.tsx
@@ -62,7 +62,7 @@ export function RepliesTab({ handle }: RepliesTabProps) {
           cid: item.cid,
         }}
         onPress={() => {
-          router.push(`/post/${encodeURIComponent(item.uri)}`);
+          router.push(`/(tabs)/post/${encodeURIComponent(item.uri)}`);
         }}
       />
     );

--- a/apps/akari/components/profile/VideosTab.tsx
+++ b/apps/akari/components/profile/VideosTab.tsx
@@ -62,7 +62,7 @@ export function VideosTab({ handle }: VideosTabProps) {
           cid: item.cid,
         }}
         onPress={() => {
-          router.push(`/post/${encodeURIComponent(item.uri)}`);
+          router.push(`/(tabs)/post/${encodeURIComponent(item.uri)}`);
         }}
       />
     );

--- a/apps/akari/hooks/usePushNotifications.ts
+++ b/apps/akari/hooks/usePushNotifications.ts
@@ -50,10 +50,10 @@ export function usePushNotifications() {
     const handleNotificationNavigation = (type: string, id: string) => {
       switch (type) {
         case 'post':
-          router.push(`/post/${encodeURIComponent(id)}`);
+          router.push(`/(tabs)/post/${encodeURIComponent(id)}`);
           break;
         case 'profile':
-          router.push(`/profile/${encodeURIComponent(id)}`);
+          router.push(`/(tabs)/profile/${encodeURIComponent(id)}`);
           break;
         case 'conversation':
           router.push(`/messages/${encodeURIComponent(id)}`);


### PR DESCRIPTION
## Summary
- update post and profile navigation targets across feeds, lists, and embeds to point at /(tabs) routes
- ensure push notification routing uses the nested paths for posts and profiles
- align unit tests with the new route locations

## Testing
- npm run lint -- --filter=akari
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68e1b82dd624832bb05b91d5210241a5