### PR TITLE
feat: enable shared tab detail navigation

### DIFF
--- a/apps/akari/__tests__/app/internal-navigation.test.tsx
+++ b/apps/akari/__tests__/app/internal-navigation.test.tsx
@@ -1,0 +1,63 @@
+import { navigateInternal } from '@/components/InternalLink';
+import { router } from 'expo-router';
+
+jest.mock('expo-router', () => ({
+  router: {
+    push: jest.fn(),
+    replace: jest.fn(),
+    navigate: jest.fn(),
+    getState: jest.fn(),
+  },
+}));
+
+describe('navigateInternal', () => {
+  const mockPush = router.push as jest.Mock;
+  const mockReplace = router.replace as jest.Mock;
+  const mockNavigate = router.navigate as jest.Mock;
+  const mockGetState = router.getState as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('prefixes routes with tabs group when already inside tabs', () => {
+    mockGetState.mockReturnValue({
+      index: 1,
+      routes: [
+        { key: 'auth', name: '(auth)' },
+        { key: 'tabs', name: '(tabs)', state: { index: 0, routes: [{ key: 'home', name: 'index' }] } },
+      ],
+    });
+
+    navigateInternal({ href: '/post/abc' });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockPush).toHaveBeenCalledWith('/(tabs)/post/abc');
+  });
+
+  it('navigates to tabs when not already focused', () => {
+    mockGetState.mockReturnValue({
+      index: 0,
+      routes: [{ key: 'auth', name: '(auth)' }],
+    });
+
+    navigateInternal({ href: '/profile/alice' });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/(tabs)');
+    expect(mockPush).toHaveBeenCalledWith('/(tabs)/profile/alice');
+  });
+
+  it('supports replace without double prefix', () => {
+    mockGetState.mockReturnValue({
+      index: 1,
+      routes: [
+        { key: 'tabs', name: '(tabs)', state: { index: 0, routes: [{ key: 'home', name: 'index' }] } },
+      ],
+    });
+
+    navigateInternal({ href: '/(tabs)/messages/pending', action: 'replace' });
+
+    expect(mockReplace).toHaveBeenCalledWith('/(tabs)/messages/pending');
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/app/tabs/bookmarks.test.tsx
+++ b/apps/akari/__tests__/app/tabs/bookmarks.test.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { act, fireEvent, render } from '@testing-library/react-native';
 
 import BookmarksScreen from '@/app/(tabs)/bookmarks';
-import { router } from 'expo-router';
 import { VirtualizedList } from '@/components/ui/VirtualizedList';
 import { tabScrollRegistry } from '@/utils/tabScrollRegistry';
 import { useBookmarks } from '@/hooks/queries/useBookmarks';
@@ -12,7 +11,11 @@ import { formatRelativeTime } from '@/utils/timeUtils';
 
 jest.mock('@shopify/flash-list', () => require('../../../test-utils/flash-list'));
 
-jest.mock('expo-router', () => ({ router: { push: jest.fn() } }));
+jest.mock('expo-router', () => ({}));
+
+jest.mock('@/components/InternalLink', () => ({
+  navigateInternal: jest.fn(),
+}));
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
@@ -64,6 +67,8 @@ const mockUseBookmarks = useBookmarks as jest.Mock;
 const mockUseTranslation = useTranslation as jest.Mock;
 const mockRegister = tabScrollRegistry.register as jest.Mock;
 const mockFormatRelativeTime = formatRelativeTime as jest.Mock;
+const { navigateInternal } = require('@/components/InternalLink');
+const mockNavigateInternal = navigateInternal as jest.Mock;
 
 function buildBookmark() {
   const parentPost = {
@@ -118,6 +123,7 @@ function buildBookmark() {
 describe('BookmarksScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockNavigateInternal.mockReset();
     mockUseTranslation.mockReturnValue({ t: (key: string) => key });
     mockFormatRelativeTime.mockReturnValue('relative-time');
   });
@@ -157,7 +163,9 @@ describe('BookmarksScreen', () => {
     });
 
     fireEvent.press(getByText('Hello world'));
-    expect(router.push).toHaveBeenCalledWith('/post/at%3A%2F%2Fexample.com%2Fpost%2F1');
+    expect(mockNavigateInternal).toHaveBeenCalledWith({
+      href: '/post/at%3A%2F%2Fexample.com%2Fpost%2F1',
+    });
 
     const list = UNSAFE_getByType(VirtualizedList);
 

--- a/apps/akari/__tests__/app/tabs/messages-handle.test.tsx
+++ b/apps/akari/__tests__/app/tabs/messages-handle.test.tsx
@@ -22,7 +22,11 @@ jest.mock('expo-image', () => {
 
 jest.mock('expo-router', () => ({
   useLocalSearchParams: jest.fn(),
-  router: { back: jest.fn(), push: jest.fn() },
+  router: { back: jest.fn() },
+}));
+
+jest.mock('@/components/InternalLink', () => ({
+  navigateInternal: jest.fn(),
 }));
 
 jest.mock('react-native-safe-area-context', () => {
@@ -66,11 +70,13 @@ const mockUseThemeColor = useThemeColor as jest.Mock;
 const mockUseTranslation = useTranslation as jest.Mock;
 const mockShowAlert = showAlert as jest.Mock;
 const mockRouterBack = router.back as jest.Mock;
-const mockRouterPush = router.push as jest.Mock;
+const { navigateInternal } = require('@/components/InternalLink');
+const mockNavigateInternal = navigateInternal as jest.Mock;
 let keyboardListeners: { show?: () => void; hide?: () => void } = {};
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockNavigateInternal.mockReset();
   mockUseLocalSearchParams.mockReturnValue({ handle: 'alice' });
   mockUseBorderColor.mockReturnValue('#ccc');
   mockUseThemeColor.mockImplementation((c: any, t?: any) => {
@@ -255,7 +261,7 @@ describe('ConversationScreen', () => {
     const { getByText } = render(<ConversationScreen />);
 
     fireEvent.press(getByText('@alice'));
-    expect(mockRouterPush).toHaveBeenCalledWith('/profile/alice');
+    expect(mockNavigateInternal).toHaveBeenCalledWith({ href: '/profile/alice' });
 
     fireEvent.press(getByText('chevron.left'));
     expect(mockRouterBack).toHaveBeenCalledTimes(1);

--- a/apps/akari/__tests__/app/tabs/messages-index.test.tsx
+++ b/apps/akari/__tests__/app/tabs/messages-index.test.tsx
@@ -18,7 +18,11 @@ jest.mock('expo-image', () => {
   return { Image };
 });
 
-jest.mock('expo-router', () => ({ router: { push: jest.fn(), back: jest.fn() } }));
+jest.mock('expo-router', () => ({ router: { back: jest.fn() } }));
+
+jest.mock('@/components/InternalLink', () => ({
+  navigateInternal: jest.fn(),
+}));
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
@@ -53,12 +57,14 @@ jest.mock('@/utils/tabScrollRegistry', () => ({
 const mockUseConversations = useConversations as jest.Mock;
 const mockUseBorderColor = useBorderColor as jest.Mock;
 const mockUseTranslation = useTranslation as jest.Mock;
-const mockRouterPush = router.push as jest.Mock;
+const { navigateInternal } = require('@/components/InternalLink');
+const mockNavigateInternal = navigateInternal as jest.Mock;
 const mockRegister = tabScrollRegistry.register as jest.Mock;
 
 describe('MessagesScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockNavigateInternal.mockReset();
     mockUseBorderColor.mockReturnValue('#ccc');
     mockUseTranslation.mockReturnValue({ t: (k: string) => k });
     mockScrollToOffset.mockReset();
@@ -125,13 +131,17 @@ describe('MessagesScreen', () => {
     expect(getByText('common.viewPendingChats')).toBeTruthy();
 
     fireEvent.press(getByText('common.viewPendingChats'));
-    expect(mockRouterPush).toHaveBeenNthCalledWith(1, '/(tabs)/messages/pending');
+    expect(mockNavigateInternal).toHaveBeenNthCalledWith(1, {
+      href: '/(tabs)/messages/pending',
+    });
 
     fireEvent.press(getByText('Alice'));
-    expect(mockRouterPush).toHaveBeenNthCalledWith(2, '/(tabs)/messages/alice');
+    expect(mockNavigateInternal).toHaveBeenNthCalledWith(2, {
+      href: '/(tabs)/messages/alice',
+    });
 
     fireEvent.press(UNSAFE_getAllByType(TouchableOpacity)[2]);
-    expect(mockRouterPush).toHaveBeenNthCalledWith(3, '/profile/alice');
+    expect(mockNavigateInternal).toHaveBeenNthCalledWith(3, { href: '/profile/alice' });
   });
 
   it('scrolls to top when registry callback is triggered', () => {

--- a/apps/akari/__tests__/app/tabs/messages-pending.test.tsx
+++ b/apps/akari/__tests__/app/tabs/messages-pending.test.tsx
@@ -17,7 +17,11 @@ jest.mock('expo-image', () => {
   return { Image };
 });
 
-jest.mock('expo-router', () => ({ router: { push: jest.fn(), back: jest.fn() } }));
+jest.mock('expo-router', () => ({ router: { back: jest.fn() } }));
+
+jest.mock('@/components/InternalLink', () => ({
+  navigateInternal: jest.fn(),
+}));
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
@@ -52,13 +56,15 @@ jest.mock('@/utils/tabScrollRegistry', () => ({
 const mockUseConversations = useConversations as jest.Mock;
 const mockUseBorderColor = useBorderColor as jest.Mock;
 const mockUseTranslation = useTranslation as jest.Mock;
-const mockRouterPush = router.push as jest.Mock;
+const { navigateInternal } = require('@/components/InternalLink');
+const mockNavigateInternal = navigateInternal as jest.Mock;
 const mockRouterBack = router.back as jest.Mock;
 const mockRegister = tabScrollRegistry.register as jest.Mock;
 
 describe('PendingMessagesScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockNavigateInternal.mockReset();
     mockUseBorderColor.mockReturnValue('#ccc');
     mockUseTranslation.mockReturnValue({ t: (k: string) => k });
   });
@@ -102,10 +108,12 @@ describe('PendingMessagesScreen', () => {
     expect(queryByText('common.viewPendingChats')).toBeNull();
 
     fireEvent.press(getByText('Pending Pal'));
-    expect(mockRouterPush).toHaveBeenNthCalledWith(1, '/(tabs)/messages/pending-pal');
+    expect(mockNavigateInternal).toHaveBeenNthCalledWith(1, {
+      href: '/(tabs)/messages/pending-pal',
+    });
 
     fireEvent.press(UNSAFE_getAllByType(TouchableOpacity)[2]);
-    expect(mockRouterPush).toHaveBeenNthCalledWith(2, '/profile/pending-pal');
+    expect(mockNavigateInternal).toHaveBeenNthCalledWith(2, { href: '/profile/pending-pal' });
 
     fireEvent.press(UNSAFE_getAllByType(TouchableOpacity)[0]);
     expect(mockRouterBack).toHaveBeenCalledTimes(1);

--- a/apps/akari/__tests__/app/tabs/notifications.test.tsx
+++ b/apps/akari/__tests__/app/tabs/notifications.test.tsx
@@ -3,7 +3,6 @@ import { act, fireEvent, render } from '@testing-library/react-native';
 import { Image, ScrollView } from 'react-native';
 
 import NotificationsScreen from '@/app/(tabs)/notifications';
-import { router } from 'expo-router';
 import { tabScrollRegistry } from '@/utils/tabScrollRegistry';
 import { useNotifications } from '@/hooks/queries/useNotifications';
 import { useBorderColor } from '@/hooks/useBorderColor';
@@ -16,7 +15,11 @@ jest.mock('expo-image', () => {
   return { Image };
 });
 
-jest.mock('expo-router', () => ({ router: { push: jest.fn() } }));
+jest.mock('expo-router', () => ({}));
+
+jest.mock('@/components/InternalLink', () => ({
+  navigateInternal: jest.fn(),
+}));
 
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
@@ -58,13 +61,15 @@ const mockUseBorderColor = useBorderColor as jest.Mock;
 const mockUseThemeColor = useThemeColor as jest.Mock;
 const mockUseTranslation = useTranslation as jest.Mock;
 const mockUseResponsive = useResponsive as jest.Mock;
-const mockRouterPush = router.push as jest.Mock;
+const { navigateInternal } = require('@/components/InternalLink');
+const mockNavigateInternal = navigateInternal as jest.Mock;
 const mockRegister = tabScrollRegistry.register as jest.Mock;
 let tMock: jest.Mock;
 
 describe('NotificationsScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockNavigateInternal.mockReset();
     mockUseBorderColor.mockReturnValue('#ccc');
     mockUseThemeColor.mockImplementation((c: any) => (typeof c === 'string' ? c : c.light ?? '#000'));
     tMock = jest.fn((key: string) => key);
@@ -129,10 +134,10 @@ describe('NotificationsScreen', () => {
     expect(getByText('notifications.startedFollowingYou')).toBeTruthy();
 
     fireEvent.press(getByText('notifications.andOneOther'));
-    expect(mockRouterPush).toHaveBeenCalledWith('/post/post1');
+    expect(mockNavigateInternal).toHaveBeenNthCalledWith(1, { href: '/post/post1' });
 
     fireEvent.press(getByText('notifications.startedFollowingYou'));
-    expect(mockRouterPush).toHaveBeenCalledWith('/profile/carol');
+    expect(mockNavigateInternal).toHaveBeenNthCalledWith(2, { href: '/profile/carol' });
   });
 
   it('renders grouped notifications with embed images and overflow avatars', () => {

--- a/apps/akari/app/(tabs)/bookmarks/_layout.tsx
+++ b/apps/akari/app/(tabs)/bookmarks/_layout.tsx
@@ -2,7 +2,7 @@ import { Stack } from 'expo-router';
 
 import { CommonStackScreens } from '../commonScreens';
 
-export default function ProfileLayout() {
+export default function BookmarksTabLayout() {
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />

--- a/apps/akari/app/(tabs)/bookmarks/index.tsx
+++ b/apps/akari/app/(tabs)/bookmarks/index.tsx
@@ -1,9 +1,9 @@
-import { router } from 'expo-router';
 import React, { useEffect, useRef } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import type { BlueskyBookmark } from '@/bluesky-api';
+import { navigateInternal } from '@/components/InternalLink';
 import { PostCard } from '@/components/PostCard';
 import { VirtualizedList, type VirtualizedListHandle } from '@/components/ui/VirtualizedList';
 import { FeedSkeleton } from '@/components/skeletons';
@@ -91,7 +91,7 @@ export default function BookmarksScreen() {
             cid: post.cid,
           }}
           onPress={() => {
-            router.push(`/post/${encodeURIComponent(post.uri)}`);
+            navigateInternal({ href: `/post/${encodeURIComponent(post.uri)}` });
           }}
         />
       </View>

--- a/apps/akari/app/(tabs)/commonScreens.tsx
+++ b/apps/akari/app/(tabs)/commonScreens.tsx
@@ -1,0 +1,10 @@
+import { Stack } from 'expo-router';
+
+export function CommonStackScreens() {
+  return (
+    <>
+      <Stack.Screen name="post/[id]" options={{ headerShown: false }} />
+      <Stack.Screen name="profile/[handle]" options={{ headerShown: false }} />
+    </>
+  );
+}

--- a/apps/akari/app/(tabs)/index/_layout.tsx
+++ b/apps/akari/app/(tabs)/index/_layout.tsx
@@ -2,7 +2,7 @@ import { Stack } from 'expo-router';
 
 import { CommonStackScreens } from '../commonScreens';
 
-export default function ProfileLayout() {
+export default function HomeTabLayout() {
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />

--- a/apps/akari/app/(tabs)/index/index.tsx
+++ b/apps/akari/app/(tabs)/index/index.tsx
@@ -1,10 +1,10 @@
 import { useResponsive } from '@/hooks/useResponsive';
-import { router } from 'expo-router';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { StyleSheet, TouchableOpacity } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import type { BlueskyFeedItem } from '@/bluesky-api';
+import { navigateInternal } from '@/components/InternalLink';
 import { PostCard } from '@/components/PostCard';
 import { PostComposer } from '@/components/PostComposer';
 import { TabBar } from '@/components/TabBar';
@@ -254,7 +254,7 @@ export default function HomeScreen() {
             cid: post.cid,
           }}
           onPress={() => {
-            router.push(`/post/${encodeURIComponent(post.uri)}`);
+            navigateInternal({ href: `/post/${encodeURIComponent(post.uri)}` });
           }}
         />
       );

--- a/apps/akari/app/(tabs)/messages/[handle].tsx
+++ b/apps/akari/app/(tabs)/messages/[handle].tsx
@@ -5,6 +5,7 @@ import { Keyboard, KeyboardAvoidingView, Platform, StyleSheet, TextInput, Toucha
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { BlueskyEmbed } from '@/bluesky-api';
+import { navigateInternal } from '@/components/InternalLink';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { ExternalEmbed } from '@/components/ExternalEmbed';
@@ -501,7 +502,7 @@ export default function ConversationScreen() {
               style={styles.headerInfo}
               onPress={() => {
                 // Navigate to profile when header is clicked
-                router.push(`/profile/${encodeURIComponent(handle)}`);
+                navigateInternal({ href: `/profile/${encodeURIComponent(handle)}` });
               }}
               activeOpacity={0.7}
             >

--- a/apps/akari/app/(tabs)/messages/_layout.tsx
+++ b/apps/akari/app/(tabs)/messages/_layout.tsx
@@ -1,4 +1,6 @@
-import { Stack } from "expo-router";
+import { Stack } from 'expo-router';
+
+import { CommonStackScreens } from '../commonScreens';
 
 export default function MessagesLayout() {
   return (
@@ -6,6 +8,7 @@ export default function MessagesLayout() {
       <Stack.Screen name="index" />
       <Stack.Screen name="pending" />
       <Stack.Screen name="[handle]" />
+      <CommonStackScreens />
     </Stack>
   );
 }

--- a/apps/akari/app/(tabs)/messages/index.tsx
+++ b/apps/akari/app/(tabs)/messages/index.tsx
@@ -1,8 +1,8 @@
-import { router } from 'expo-router';
 import React from 'react';
 import { StyleSheet, TouchableOpacity } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { navigateInternal } from '@/components/InternalLink';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { IconSymbol } from '@/components/ui/IconSymbol';
@@ -91,14 +91,14 @@ export function MessagesListScreen({
       <TouchableOpacity
         style={[styles.conversationItem, { borderBottomColor: borderColor }]}
         onPress={() => {
-          router.push(`/(tabs)/messages/${encodeURIComponent(item.handle)}`);
+          navigateInternal({ href: `/(tabs)/messages/${encodeURIComponent(item.handle)}` });
         }}
       >
         <ThemedView style={styles.conversationContent}>
           <TouchableOpacity
             style={styles.avatarContainer}
             onPress={() => {
-              router.push(`/profile/${encodeURIComponent(item.handle)}`);
+              navigateInternal({ href: `/profile/${encodeURIComponent(item.handle)}` });
             }}
             activeOpacity={0.7}
           >
@@ -226,7 +226,7 @@ export function MessagesListScreen({
 
 export default function MessagesScreen() {
   const handleNavigateToPending = React.useCallback(() => {
-    router.push('/(tabs)/messages/pending');
+    navigateInternal({ href: '/(tabs)/messages/pending' });
   }, []);
 
   return (

--- a/apps/akari/app/(tabs)/notifications/_layout.tsx
+++ b/apps/akari/app/(tabs)/notifications/_layout.tsx
@@ -2,7 +2,7 @@ import { Stack } from 'expo-router';
 
 import { CommonStackScreens } from '../commonScreens';
 
-export default function ProfileLayout() {
+export default function NotificationsTabLayout() {
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />

--- a/apps/akari/app/(tabs)/notifications/index.tsx
+++ b/apps/akari/app/(tabs)/notifications/index.tsx
@@ -1,10 +1,10 @@
 import { useResponsive } from '@/hooks/useResponsive';
 import { Image } from 'expo-image';
-import { router } from 'expo-router';
 import React, { useCallback, useMemo, useRef, useState } from 'react';
 import { Dimensions, StyleSheet, Text, TouchableOpacity, View, type ImageStyle } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
+import { navigateInternal } from '@/components/InternalLink';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
 import { NotificationSkeleton } from '@/components/skeletons';
@@ -415,13 +415,17 @@ export default function NotificationsScreen() {
   const handleNotificationPress = useCallback((notification: GroupedNotification) => {
     if (notification.type === 'follow') {
       // Navigate to the first author's profile
-      router.push(`/profile/${encodeURIComponent(notification.authors[0].handle)}`);
+      navigateInternal({
+        href: `/profile/${encodeURIComponent(notification.authors[0].handle)}`,
+      });
     } else if (notification.subject) {
       // Navigate to the post
-      router.push(`/post/${encodeURIComponent(notification.subject)}`);
+      navigateInternal({ href: `/post/${encodeURIComponent(notification.subject)}` });
     } else {
       // For notifications without a subject, navigate to the first author's profile
-      router.push(`/profile/${encodeURIComponent(notification.authors[0].handle)}`);
+      navigateInternal({
+        href: `/profile/${encodeURIComponent(notification.authors[0].handle)}`,
+      });
     }
   }, []);
 

--- a/apps/akari/app/(tabs)/search/_layout.tsx
+++ b/apps/akari/app/(tabs)/search/_layout.tsx
@@ -2,7 +2,7 @@ import { Stack } from 'expo-router';
 
 import { CommonStackScreens } from '../commonScreens';
 
-export default function ProfileLayout() {
+export default function SearchTabLayout() {
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />

--- a/apps/akari/app/(tabs)/search/index.tsx
+++ b/apps/akari/app/(tabs)/search/index.tsx
@@ -1,5 +1,5 @@
 import { Image } from 'expo-image';
-import { router, useLocalSearchParams } from 'expo-router';
+import { useLocalSearchParams } from 'expo-router';
 import React, { useEffect, useRef, useState } from 'react';
 import { Keyboard, StyleSheet, TextInput, TouchableOpacity } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -7,6 +7,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Labels } from '@/components/Labels';
 
 import { PostCard } from '@/components/PostCard';
+import { navigateInternal } from '@/components/InternalLink';
 import { SearchTabs } from '@/components/SearchTabs';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedView } from '@/components/ThemedView';
@@ -133,7 +134,10 @@ export default function SearchScreen() {
     return (
       <TouchableOpacity
         style={[styles.resultItem, { borderBottomColor: borderColor }]}
-        onPress={() => router.push('/profile/' + encodeURIComponent(profile.handle))}
+        accessibilityRole="button"
+        onPress={() =>
+          navigateInternal({ href: `/profile/${encodeURIComponent(profile.handle)}` })
+        }
         activeOpacity={0.7}
       >
         <ThemedView style={styles.profileContainer}>
@@ -203,7 +207,7 @@ export default function SearchScreen() {
           cid: post.cid,
         }}
         onPress={() => {
-          router.push('/post/' + encodeURIComponent(post.uri));
+          navigateInternal({ href: `/post/${encodeURIComponent(post.uri)}` });
         }}
       />
     );

--- a/apps/akari/app/(tabs)/settings/_layout.tsx
+++ b/apps/akari/app/(tabs)/settings/_layout.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Stack } from 'expo-router';
 
+import { CommonStackScreens } from '../commonScreens';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import { useTranslation } from '@/hooks/useTranslation';
 
@@ -40,6 +41,7 @@ export default function SettingsLayout() {
       <Stack.Screen name="languages" options={{ title: t('settings.language') }} />
       <Stack.Screen name="about" options={{ title: t('settings.about') }} />
       <Stack.Screen name="development" options={{ title: t('settings.development') }} />
+      <CommonStackScreens />
     </Stack>
   );
 }

--- a/apps/akari/app/_layout.tsx
+++ b/apps/akari/app/_layout.tsx
@@ -89,6 +89,8 @@ function AppProviders({ colorScheme }: ProvidersProps) {
             <Stack>
               <Stack.Screen name="(auth)" options={{ headerShown: false }} />
               <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+              <Stack.Screen name="post" options={{ headerShown: false }} />
+              <Stack.Screen name="profile" options={{ headerShown: false }} />
               <Stack.Screen name="debug" options={{ headerShown: false }} />
               <Stack.Screen name="+not-found" />
             </Stack>

--- a/apps/akari/app/post/[id].tsx
+++ b/apps/akari/app/post/[id].tsx
@@ -1,0 +1,1 @@
+export { default, renderComment } from '../(tabs)/post/[id]';

--- a/apps/akari/app/post/_layout.tsx
+++ b/apps/akari/app/post/_layout.tsx
@@ -1,0 +1,9 @@
+import { Stack } from 'expo-router';
+
+export default function PostRootLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="[id]" />
+    </Stack>
+  );
+}

--- a/apps/akari/app/profile/[handle].tsx
+++ b/apps/akari/app/profile/[handle].tsx
@@ -1,0 +1,1 @@
+export { default } from '../(tabs)/profile/[handle]';

--- a/apps/akari/app/profile/_layout.tsx
+++ b/apps/akari/app/profile/_layout.tsx
@@ -1,0 +1,9 @@
+import { Stack } from 'expo-router';
+
+export default function ProfileRootLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="[handle]" />
+    </Stack>
+  );
+}

--- a/apps/akari/components/InternalLink.tsx
+++ b/apps/akari/components/InternalLink.tsx
@@ -1,0 +1,76 @@
+import React, { useCallback } from 'react';
+import { Pressable, type PressableProps } from 'react-native';
+import type { NavigationState, PartialState } from '@react-navigation/native';
+import { router } from 'expo-router';
+
+type InternalNavigationAction = 'push' | 'replace';
+
+type NavigateInternalOptions = {
+  href: string;
+  action?: InternalNavigationAction;
+};
+
+type InternalLinkProps = Omit<PressableProps, 'onPress'> & {
+  href: string;
+  action?: InternalNavigationAction;
+  onPress?: () => void;
+  children: React.ReactNode;
+};
+
+function findActiveRoute(
+  state: NavigationState | PartialState<NavigationState> | undefined,
+): NavigationState | PartialState<NavigationState> | undefined {
+  if (!state || !('routes' in state)) {
+    return undefined;
+  }
+
+  const index = state.index ?? state.routes.length - 1;
+  const activeRoute = state.routes[index];
+
+  if (!activeRoute) {
+    return undefined;
+  }
+
+  if (activeRoute.name === '(tabs)') {
+    return state;
+  }
+
+  if (activeRoute.state) {
+    return findActiveRoute(activeRoute.state as NavigationState | PartialState<NavigationState>);
+  }
+
+  return undefined;
+}
+
+function resolveHref(href: string) {
+  if (href.startsWith('/(tabs)') || href.startsWith('/(')) {
+    return href;
+  }
+
+  const normalized = href.startsWith('/') ? href : `/${href}`;
+  return `/(tabs)${normalized}`;
+}
+
+export function navigateInternal({ href, action = 'push' }: NavigateInternalOptions) {
+  const resolvedHref = resolveHref(href);
+  const state = router.getState();
+
+  if (state && !findActiveRoute(state)) {
+    router.navigate('/(tabs)');
+  }
+
+  router[action](resolvedHref as never);
+}
+
+export function InternalLink({ href, action = 'push', onPress, children, ...pressableProps }: InternalLinkProps) {
+  const handlePress = useCallback(() => {
+    onPress?.();
+    navigateInternal({ href, action });
+  }, [action, href, onPress]);
+
+  return (
+    <Pressable {...pressableProps} onPress={handlePress}>
+      {children}
+    </Pressable>
+  );
+}


### PR DESCRIPTION
## Summary
- register shared post and profile stacks in the root navigator and add per-tab stack layouts that include a common detail screen fragment
- add an InternalLink helper that routes post and profile taps through the active tab stack instead of calling router.push directly
- update search, notifications, bookmarks, and messages tests and add internal-navigation tests to cover the new helper

## Testing
- npm run lint -- --filter=akari

------
https://chatgpt.com/codex/tasks/task_e_68e21e4a13c0832ba7931303b43c88ad