### PR TITLE
feat: scope tab post detail to tab stacks

### DIFF
--- a/apps/akari/__tests__/app/tabs-layout.test.tsx
+++ b/apps/akari/__tests__/app/tabs-layout.test.tsx
@@ -147,16 +147,7 @@ describe('TabLayout', () => {
       tabBarStyle: { display: 'none' },
     });
     const names = (require('expo-router').Tabs.Screen as jest.Mock).mock.calls.map((c: any[]) => c[0].name);
-    expect(names).toEqual([
-      'index',
-      'search',
-      'messages',
-      'notifications',
-      'bookmarks',
-      'post',
-      'profile',
-      'settings',
-    ]);
+    expect(names).toEqual(['index', 'search', 'messages', 'notifications', 'bookmarks', 'profile', 'settings']);
   });
 
   it('renders mobile tabs with badges', () => {
@@ -182,7 +173,6 @@ describe('TabLayout', () => {
         { key: 'messages-tab', name: 'messages' },
         { key: 'notifications-tab', name: 'notifications' },
         { key: 'bookmarks-tab', name: 'bookmarks' },
-        { key: 'post-tab', name: 'post' },
         { key: 'profile-tab', name: 'profile' },
         { key: 'settings-tab', name: 'settings' },
       ],
@@ -200,16 +190,7 @@ describe('TabLayout', () => {
     expect(mockTabBadge.mock.calls[0][0].count).toBe(2);
     expect(mockTabBadge.mock.calls[1][0].count).toBe(3);
     const names = (TabsModule.Tabs.Screen as jest.Mock).mock.calls.map((c: any[]) => c[0].name);
-    expect(names).toEqual([
-      'index',
-      'search',
-      'messages',
-      'notifications',
-      'bookmarks',
-      'post',
-      'profile',
-      'settings',
-    ]);
+    expect(names).toEqual(['index', 'search', 'messages', 'notifications', 'bookmarks', 'profile', 'settings']);
   });
 
   it('uses default tint and badge counts when data is unavailable', () => {
@@ -223,19 +204,18 @@ describe('TabLayout', () => {
       emit: jest.fn(() => ({ defaultPrevented: false })),
       navigate: jest.fn(),
     };
-    const state = {
-      index: 0,
-      routes: [
-        { key: 'index-tab', name: 'index' },
-        { key: 'search-tab', name: 'search' },
-        { key: 'messages-tab', name: 'messages' },
-        { key: 'notifications-tab', name: 'notifications' },
-        { key: 'bookmarks-tab', name: 'bookmarks' },
-        { key: 'post-tab', name: 'post' },
-        { key: 'profile-tab', name: 'profile' },
-        { key: 'settings-tab', name: 'settings' },
-      ],
-    };
+      const state = {
+        index: 0,
+        routes: [
+          { key: 'index-tab', name: 'index' },
+          { key: 'search-tab', name: 'search' },
+          { key: 'messages-tab', name: 'messages' },
+          { key: 'notifications-tab', name: 'notifications' },
+          { key: 'bookmarks-tab', name: 'bookmarks' },
+          { key: 'profile-tab', name: 'profile' },
+          { key: 'settings-tab', name: 'settings' },
+        ],
+      };
 
     render(
       tabBar({

--- a/apps/akari/__tests__/app/tabs-messages-layout.test.tsx
+++ b/apps/akari/__tests__/app/tabs-messages-layout.test.tsx
@@ -16,15 +16,15 @@ describe('MessagesLayout', () => {
     jest.clearAllMocks();
   });
 
-  it('renders stack with index, pending, and [handle] screens', () => {
+  it('renders stack with nested post screen', () => {
     const { Stack } = require('expo-router');
     render(<MessagesLayout />);
     expect(Stack.mock.calls[0][0].screenOptions).toEqual({ headerShown: false });
-    expect(Stack.Screen).toHaveBeenCalledTimes(3);
+    expect(Stack.Screen).toHaveBeenCalledTimes(4);
     const names: string[] = [];
     for (const call of Stack.Screen.mock.calls) {
       names.push(call[0].name);
     }
-    expect(names).toEqual(['index', 'pending', '[handle]']);
+    expect(names).toEqual(['index', 'pending', '[handle]', 'post/[id]']);
   });
 });

--- a/apps/akari/__tests__/app/tabs-nested-post-layouts.test.tsx
+++ b/apps/akari/__tests__/app/tabs-nested-post-layouts.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import HomeTabLayout from '@/app/(tabs)/index/_layout';
+import SearchTabLayout from '@/app/(tabs)/search/_layout';
+import NotificationsTabLayout from '@/app/(tabs)/notifications/_layout';
+import ProfileTabLayout from '@/app/(tabs)/profile/_layout';
+
+jest.mock('expo-router', () => {
+  const React = require('react');
+  const Screen = jest.fn(() => null);
+  const Stack = jest.fn(({ children }: { children: React.ReactNode }) => <>{children}</>);
+  // @ts-ignore
+  Stack.Screen = Screen;
+  return { Stack };
+});
+
+describe('Tab stacks include nested post routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const cases: Array<[
+    string,
+    React.ComponentType,
+  ]> = [
+    ['home', HomeTabLayout],
+    ['search', SearchTabLayout],
+    ['notifications', NotificationsTabLayout],
+    ['profile', ProfileTabLayout],
+  ];
+
+  it.each(cases)('%s tab layout registers post screen', (_name, Layout) => {
+    const { Stack } = require('expo-router');
+    Stack.mockClear();
+    Stack.Screen.mockClear();
+
+    render(<Layout />);
+
+    expect(Stack.mock.calls[0][0].screenOptions).toEqual({ headerShown: false });
+    const names = Stack.Screen.mock.calls.map((call: any[]) => call[0].name);
+    expect(names).toContain('post/[id]');
+  });
+});

--- a/apps/akari/__tests__/app/tabs/notifications.test.tsx
+++ b/apps/akari/__tests__/app/tabs/notifications.test.tsx
@@ -129,7 +129,9 @@ describe('NotificationsScreen', () => {
     expect(getByText('notifications.startedFollowingYou')).toBeTruthy();
 
     fireEvent.press(getByText('notifications.andOneOther'));
-    expect(mockRouterPush).toHaveBeenCalledWith('/post/post1');
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      '/(tabs)/notifications/post/' + encodeURIComponent('post1'),
+    );
 
     fireEvent.press(getByText('notifications.startedFollowingYou'));
     expect(mockRouterPush).toHaveBeenCalledWith('/profile/carol');

--- a/apps/akari/__tests__/components/profile/LikesTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/LikesTab.test.tsx
@@ -113,7 +113,7 @@ describe('LikesTab', () => {
 
     const { getByText, UNSAFE_getByType } = render(<LikesTab handle="tester" />);
     fireEvent.press(getByText('liked post'));
-    expect(router.push).toHaveBeenCalledWith(`/post/${encodeURIComponent(like.uri)}`);
+    expect(router.push).toHaveBeenCalledWith(`/(tabs)/profile/post/${encodeURIComponent(like.uri)}`);
 
     const list = UNSAFE_getByType(VirtualizedList);
     act(() => {

--- a/apps/akari/__tests__/components/profile/MediaTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/MediaTab.test.tsx
@@ -115,7 +115,7 @@ describe('MediaTab', () => {
     expect(PostCardMock).toHaveBeenCalledTimes(1);
     const press = PostCardMock.mock.calls[0][0].onPress;
     press();
-    expect(router.push).toHaveBeenCalledWith('/post/' + encodeURIComponent('at://post1'));
+    expect(router.push).toHaveBeenCalledWith('/(tabs)/profile/post/' + encodeURIComponent('at://post1'));
   });
 
   it('formats reply data and uses unknown handle when missing', () => {

--- a/apps/akari/__tests__/components/profile/PostsTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/PostsTab.test.tsx
@@ -107,7 +107,7 @@ describe('PostsTab', () => {
     expect(mockPostCard).toHaveBeenCalledTimes(1);
     const button = getByRole('button');
     fireEvent.press(button);
-    expect(router.push).toHaveBeenCalledWith(`/post/${encodeURIComponent(post.uri)}`);
+    expect(router.push).toHaveBeenCalledWith(`/(tabs)/profile/post/${encodeURIComponent(post.uri)}`);
     const call = mockPostCard.mock.calls[0][0];
     expect(call.post.replyTo).toEqual({
       author: { handle: 'bob', displayName: 'Bob' },

--- a/apps/akari/__tests__/components/profile/RepliesTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/RepliesTab.test.tsx
@@ -86,7 +86,7 @@ describe('RepliesTab', () => {
 
     const { getByText } = render(<RepliesTab handle="alice" />);
     fireEvent.press(getByText('Hello world'));
-    expect(mockPush).toHaveBeenCalledWith(`/post/${encodeURIComponent(reply.uri)}`);
+    expect(mockPush).toHaveBeenCalledWith(`/(tabs)/profile/post/${encodeURIComponent(reply.uri)}`);
   });
 
   it('fetches more replies on end reached', () => {

--- a/apps/akari/__tests__/components/profile/VideosTab.test.tsx
+++ b/apps/akari/__tests__/components/profile/VideosTab.test.tsx
@@ -101,7 +101,7 @@ describe('VideosTab', () => {
 
     const { getByText } = render(<VideosTab handle="alice" />);
     fireEvent.press(getByText('at://video/1'));
-    expect(router.push).toHaveBeenCalledWith('/post/' + encodeURIComponent('at://video/1'));
+    expect(router.push).toHaveBeenCalledWith('/(tabs)/profile/post/' + encodeURIComponent('at://video/1'));
   });
 
   it('fetches next page on end reached', () => {

--- a/apps/akari/app/(tabs)/_layout.tsx
+++ b/apps/akari/app/(tabs)/_layout.tsx
@@ -267,7 +267,6 @@ export default function TabLayout() {
                 <Tabs.Screen name="messages" />
                 <Tabs.Screen name="notifications" />
                 <Tabs.Screen name="bookmarks" options={{ href: null }} />
-                <Tabs.Screen name="post" options={{ href: null }} />
                 <Tabs.Screen name="profile" />
                 <Tabs.Screen name="settings" />
               </Tabs>
@@ -330,12 +329,6 @@ export default function TabLayout() {
         />
         <Tabs.Screen
           name="bookmarks"
-          options={{
-            href: null,
-          }}
-        />
-        <Tabs.Screen
-          name="post"
           options={{
             href: null,
           }}

--- a/apps/akari/app/(tabs)/index/_layout.tsx
+++ b/apps/akari/app/(tabs)/index/_layout.tsx
@@ -1,11 +1,9 @@
 import { Stack } from 'expo-router';
 
-export default function MessagesLayout() {
+export default function HomeTabLayout() {
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />
-      <Stack.Screen name="pending" />
-      <Stack.Screen name="[handle]" />
       <Stack.Screen name="post/[id]" />
     </Stack>
   );

--- a/apps/akari/app/(tabs)/index/index.tsx
+++ b/apps/akari/app/(tabs)/index/index.tsx
@@ -254,7 +254,7 @@ export default function HomeScreen() {
             cid: post.cid,
           }}
           onPress={() => {
-            router.push(`/post/${encodeURIComponent(post.uri)}`);
+            router.push(`/(tabs)/index/post/${encodeURIComponent(post.uri)}`);
           }}
         />
       );

--- a/apps/akari/app/(tabs)/index/post/[id].tsx
+++ b/apps/akari/app/(tabs)/index/post/[id].tsx
@@ -1,0 +1,1 @@
+export { default, renderComment } from '../../post/[id]';

--- a/apps/akari/app/(tabs)/messages/post/[id].tsx
+++ b/apps/akari/app/(tabs)/messages/post/[id].tsx
@@ -1,0 +1,1 @@
+export { default, renderComment } from '../../post/[id]';

--- a/apps/akari/app/(tabs)/notifications/_layout.tsx
+++ b/apps/akari/app/(tabs)/notifications/_layout.tsx
@@ -1,11 +1,9 @@
 import { Stack } from 'expo-router';
 
-export default function MessagesLayout() {
+export default function NotificationsTabLayout() {
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />
-      <Stack.Screen name="pending" />
-      <Stack.Screen name="[handle]" />
       <Stack.Screen name="post/[id]" />
     </Stack>
   );

--- a/apps/akari/app/(tabs)/notifications/index.tsx
+++ b/apps/akari/app/(tabs)/notifications/index.tsx
@@ -418,7 +418,7 @@ export default function NotificationsScreen() {
       router.push(`/profile/${encodeURIComponent(notification.authors[0].handle)}`);
     } else if (notification.subject) {
       // Navigate to the post
-      router.push(`/post/${encodeURIComponent(notification.subject)}`);
+      router.push(`/(tabs)/notifications/post/${encodeURIComponent(notification.subject)}`);
     } else {
       // For notifications without a subject, navigate to the first author's profile
       router.push(`/profile/${encodeURIComponent(notification.authors[0].handle)}`);

--- a/apps/akari/app/(tabs)/notifications/post/[id].tsx
+++ b/apps/akari/app/(tabs)/notifications/post/[id].tsx
@@ -1,0 +1,1 @@
+export { default, renderComment } from '../../post/[id]';

--- a/apps/akari/app/(tabs)/profile/_layout.tsx
+++ b/apps/akari/app/(tabs)/profile/_layout.tsx
@@ -5,6 +5,7 @@ export default function ProfileLayout() {
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />
       <Stack.Screen name="[handle]" />
+      <Stack.Screen name="post/[id]" />
     </Stack>
   );
 }

--- a/apps/akari/app/(tabs)/profile/post/[id].tsx
+++ b/apps/akari/app/(tabs)/profile/post/[id].tsx
@@ -1,0 +1,1 @@
+export { default, renderComment } from '../../post/[id]';

--- a/apps/akari/app/(tabs)/search/_layout.tsx
+++ b/apps/akari/app/(tabs)/search/_layout.tsx
@@ -1,11 +1,9 @@
 import { Stack } from 'expo-router';
 
-export default function MessagesLayout() {
+export default function SearchTabLayout() {
   return (
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Screen name="index" />
-      <Stack.Screen name="pending" />
-      <Stack.Screen name="[handle]" />
       <Stack.Screen name="post/[id]" />
     </Stack>
   );

--- a/apps/akari/app/(tabs)/search/index.tsx
+++ b/apps/akari/app/(tabs)/search/index.tsx
@@ -203,7 +203,7 @@ export default function SearchScreen() {
           cid: post.cid,
         }}
         onPress={() => {
-          router.push('/post/' + encodeURIComponent(post.uri));
+          router.push('/(tabs)/search/post/' + encodeURIComponent(post.uri));
         }}
       />
     );

--- a/apps/akari/app/(tabs)/search/post/[id].tsx
+++ b/apps/akari/app/(tabs)/search/post/[id].tsx
@@ -1,0 +1,1 @@
+export { default, renderComment } from '../../post/[id]';

--- a/apps/akari/components/profile/LikesTab.tsx
+++ b/apps/akari/components/profile/LikesTab.tsx
@@ -62,7 +62,7 @@ export function LikesTab({ handle }: LikesTabProps) {
           cid: item.cid,
         }}
         onPress={() => {
-          router.push(`/post/${encodeURIComponent(item.uri)}`);
+          router.push(`/(tabs)/profile/post/${encodeURIComponent(item.uri)}`);
         }}
       />
     );

--- a/apps/akari/components/profile/MediaTab.tsx
+++ b/apps/akari/components/profile/MediaTab.tsx
@@ -68,7 +68,7 @@ export function MediaTab({ handle }: MediaTabProps) {
           cid: item.cid,
         }}
         onPress={() => {
-          router.push(`/post/${encodeURIComponent(item.uri)}`);
+          router.push(`/(tabs)/profile/post/${encodeURIComponent(item.uri)}`);
         }}
       />
     );

--- a/apps/akari/components/profile/PostsTab.tsx
+++ b/apps/akari/components/profile/PostsTab.tsx
@@ -62,7 +62,7 @@ export function PostsTab({ handle }: PostsTabProps) {
           cid: item.cid,
         }}
         onPress={() => {
-          router.push(`/post/${encodeURIComponent(item.uri)}`);
+          router.push(`/(tabs)/profile/post/${encodeURIComponent(item.uri)}`);
         }}
       />
     );

--- a/apps/akari/components/profile/RepliesTab.tsx
+++ b/apps/akari/components/profile/RepliesTab.tsx
@@ -62,7 +62,7 @@ export function RepliesTab({ handle }: RepliesTabProps) {
           cid: item.cid,
         }}
         onPress={() => {
-          router.push(`/post/${encodeURIComponent(item.uri)}`);
+          router.push(`/(tabs)/profile/post/${encodeURIComponent(item.uri)}`);
         }}
       />
     );

--- a/apps/akari/components/profile/VideosTab.tsx
+++ b/apps/akari/components/profile/VideosTab.tsx
@@ -62,7 +62,7 @@ export function VideosTab({ handle }: VideosTabProps) {
           cid: item.cid,
         }}
         onPress={() => {
-          router.push(`/post/${encodeURIComponent(item.uri)}`);
+          router.push(`/(tabs)/profile/post/${encodeURIComponent(item.uri)}`);
         }}
       />
     );


### PR DESCRIPTION
## Summary
- create tab-scoped stack layouts for the home, search, notifications, messages, and profile tabs so they can present post detail screens in place
- update tab navigation wiring so both mobile and large-screen tab layouts push to the new nested post routes
- adjust tab screens and profile list components to target the tab-level post routes and add regression tests for the nested routing

## Testing
- npm run lint -- --filter=akari
- npm run test -- --runTestsByPath __tests__/app/tabs/index.test.tsx __tests__/app/tabs/search.test.tsx __tests__/app/tabs/notifications.test.tsx __tests__/app/tabs-messages-layout.test.tsx __tests__/app/tabs-layout.test.tsx __tests__/app/tabs-nested-post-layouts.test.tsx __tests__/components/profile/PostsTab.test.tsx __tests__/components/profile/RepliesTab.test.tsx __tests__/components/profile/LikesTab.test.tsx __tests__/components/profile/MediaTab.test.tsx __tests__/components/profile/VideosTab.test.tsx
- npm run test -- --runTestsByPath __tests__/app/tabs-layout.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68e298cc5360832b896501c4266798b4