### PR TITLE
feat: add activity analytics summary to activity tab

### DIFF
--- a/apps/akari/components/Sidebar.tsx
+++ b/apps/akari/components/Sidebar.tsx
@@ -66,7 +66,7 @@ export function Sidebar() {
       { id: 'timeline', label: 'Timeline', icon: 'house.fill', route: '/(tabs)' },
       {
         id: 'notifications',
-        label: 'Notifications',
+        label: 'Activity',
         icon: 'bell.fill',
         route: '/(tabs)/notifications',
         badge: unreadNotificationsCount,

--- a/apps/akari/translations/ar.json
+++ b/apps/akari/translations/ar.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "البحث",
-      "notifications": "الإشعارات",
+      "notifications": "النشاط",
       "post": "المنشور",
       "settings": "الإعدادات"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "رد على منشورك",
       "mentionedYou": "ذكرك",
       "quotedYourPost": "اقتبس منشورك",
+      "activitySummaryTitle": "ملخص النشاط",
+      "activityLastNDays": "آخر {{count}} أيام",
+      "activityNotes": "الملاحظات",
+      "activityNewFollowers": "متابعون جدد",
+      "activityTotalFollowers": "إجمالي المتابعين",
       "andOneOther": "وشخص آخر {{action}}",
       "andOthers": "و{{count}} آخرين {{action}}",
       "noNotificationsYet": "لا توجد إشعارات بعد",

--- a/apps/akari/translations/az.json
+++ b/apps/akari/translations/az.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Axtarış",
-      "notifications": "Bildirişlər",
+      "notifications": "Fəaliyyət",
       "post": "Post",
       "settings": "Parametrlər"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "postunuza cavab verdi",
       "mentionedYou": "səni xatırlatdı",
       "quotedYourPost": "Yazınıza sitat gətirdi",
+      "activitySummaryTitle": "Fəaliyyət xülasəsi",
+      "activityLastNDays": "Son {{count}} gün",
+      "activityNotes": "Qeydlər",
+      "activityNewFollowers": "Yeni izləyicilər",
+      "activityTotalFollowers": "Ümumi izləyicilər",
       "andOneOther": "və 1 digər {{action}}",
       "andOthers": "və {{count}} Digərləri {{action}}",
       "noNotificationsYet": "Hələ bildiriş yoxdur",

--- a/apps/akari/translations/bg.json
+++ b/apps/akari/translations/bg.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Търсене",
-      "notifications": "Известия",
+      "notifications": "Активност",
       "post": "Публикуване",
       "settings": "Настройки"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "отговори на публикацията ви",
       "mentionedYou": "ви спомена",
       "quotedYourPost": "цитиран публикацията ви",
+      "activitySummaryTitle": "Обобщение на активността",
+      "activityLastNDays": "Последните {{count}} дни",
+      "activityNotes": "Бележки",
+      "activityNewFollowers": "Нови последователи",
+      "activityTotalFollowers": "Общ брой последователи",
       "andOneOther": "и 1 други {{action}}",
       "andOthers": "и {{count}} други {{action}}",
       "noNotificationsYet": "Все още няма известия",

--- a/apps/akari/translations/cs.json
+++ b/apps/akari/translations/cs.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Vyhledávání",
-      "notifications": "Oznámení",
+      "notifications": "Aktivita",
       "post": "Zveřejnit",
       "settings": "Nastavení"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "odpověděl na váš příspěvek",
       "mentionedYou": "zmínil se o tom",
       "quotedYourPost": "citoval váš příspěvek",
+      "activitySummaryTitle": "Souhrn aktivity",
+      "activityLastNDays": "Posledních {{count}} dní",
+      "activityNotes": "Poznámky",
+      "activityNewFollowers": "Noví sledující",
+      "activityTotalFollowers": "Celkem sledujících",
       "andOneOther": "a 1 další {{action}}",
       "andOthers": "a {{count}} další {{action}}",
       "noNotificationsYet": "Zatím žádná oznámení",

--- a/apps/akari/translations/cy.json
+++ b/apps/akari/translations/cy.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Chwilio",
-      "notifications": "Hysbysiadau",
+      "notifications": "Gweithgarwch",
       "post": "Post",
       "settings": "Gosodiadau"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "atebodd eich swydd",
       "mentionedYou": "sôn amdanoch",
       "quotedYourPost": "dyfynnu eich swydd",
+      "activitySummaryTitle": "Crynodeb gweithgarwch",
+      "activityLastNDays": "Y {{count}} diwrnod diwethaf",
+      "activityNotes": "Nodiadau",
+      "activityNewFollowers": "Dilynwyr newydd",
+      "activityTotalFollowers": "Cyfanswm dilynwyr",
       "andOneOther": "ac 1 arall {{action}}",
       "andOthers": "ac {{count}} eraill {{action}}",
       "noNotificationsYet": "Dim hysbysiadau eto",

--- a/apps/akari/translations/da.json
+++ b/apps/akari/translations/da.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Søge",
-      "notifications": "Underretninger",
+      "notifications": "Aktivitet",
       "post": "Stolpe",
       "settings": "Indstillinger"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "svarede på dit indlæg",
       "mentionedYou": "nævnte dig",
       "quotedYourPost": "citerede dit indlæg",
+      "activitySummaryTitle": "Aktivitetsoversigt",
+      "activityLastNDays": "Seneste {{count}} dage",
+      "activityNotes": "Noter",
+      "activityNewFollowers": "Nye følgere",
+      "activityTotalFollowers": "Samlede følgere",
       "andOneOther": "og 1 andre {{action}}",
       "andOthers": "og {{count}} andre {{action}}",
       "noNotificationsYet": "Ingen meddelelser endnu",

--- a/apps/akari/translations/de.json
+++ b/apps/akari/translations/de.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Suchen",
-      "notifications": "Benachrichtigungen",
+      "notifications": "Aktivität",
       "post": "Beitrag",
       "settings": "Einstellungen"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "hat auf deinen Beitrag geantwortet",
       "mentionedYou": "hat dich erwähnt",
       "quotedYourPost": "hat deinen Beitrag zitiert",
+      "activitySummaryTitle": "Aktivitätsübersicht",
+      "activityLastNDays": "Letzte {{count}} Tage",
+      "activityNotes": "Notizen",
+      "activityNewFollowers": "Neue Follower",
+      "activityTotalFollowers": "Follower insgesamt",
       "andOneOther": "und 1 anderer {{action}}",
       "andOthers": "und {{count}} andere {{action}}",
       "noNotificationsYet": "Noch keine Benachrichtigungen",

--- a/apps/akari/translations/el.json
+++ b/apps/akari/translations/el.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Ερευνα",
-      "notifications": "Ειδοποιήσεις",
+      "notifications": "Δραστηριότητα",
       "post": "Θέση",
       "settings": "Ρυθμίσεις"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "απάντησε στην ανάρτησή σας",
       "mentionedYou": "σε αναφέρθηκε",
       "quotedYourPost": "Αναφέρεται η ανάρτησή σας",
+      "activitySummaryTitle": "Σύνοψη δραστηριότητας",
+      "activityLastNDays": "Τελευταίες {{count}} ημέρες",
+      "activityNotes": "Σημειώσεις",
+      "activityNewFollowers": "Νέοι ακόλουθοι",
+      "activityTotalFollowers": "Σύνολο ακολούθων",
       "andOneOther": "και 1 άλλο {{action}}",
       "andOthers": "και {{count}} άλλοι {{action}}",
       "noNotificationsYet": "Δεν υπάρχουν ακόμη ειδοποιήσεις",

--- a/apps/akari/translations/en-US.json
+++ b/apps/akari/translations/en-US.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Search",
-      "notifications": "Notifications",
+      "notifications": "Activity",
       "post": "Post",
       "settings": "Settings"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "replied to your post",
       "mentionedYou": "mentioned you",
       "quotedYourPost": "quoted your post",
+      "activitySummaryTitle": "Activity summary",
+      "activityLastNDays": "Last {{count}} days",
+      "activityNotes": "Notes",
+      "activityNewFollowers": "New followers",
+      "activityTotalFollowers": "Total followers",
       "andOneOther": "and 1 other {{action}}",
       "andOthers": "and {{count}} others {{action}}",
       "noNotificationsYet": "No notifications yet",

--- a/apps/akari/translations/en.json
+++ b/apps/akari/translations/en.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Search",
-      "notifications": "Notifications",
+      "notifications": "Activity",
       "post": "Post",
       "settings": "Settings"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "replied to your post",
       "mentionedYou": "mentioned you",
       "quotedYourPost": "quoted your post",
+      "activitySummaryTitle": "Activity summary",
+      "activityLastNDays": "Last {{count}} days",
+      "activityNotes": "Notes",
+      "activityNewFollowers": "New followers",
+      "activityTotalFollowers": "Total followers",
       "andOneOther": "and 1 other {{action}}",
       "andOthers": "and {{count}} others {{action}}",
       "noNotificationsYet": "No notifications yet",

--- a/apps/akari/translations/es.json
+++ b/apps/akari/translations/es.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Buscar",
-      "notifications": "Notificaciones",
+      "notifications": "Actividad",
       "post": "Publicación",
       "settings": "Configuración"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "respondió a tu publicación",
       "mentionedYou": "te mencionó",
       "quotedYourPost": "citó tu publicación",
+      "activitySummaryTitle": "Resumen de actividad",
+      "activityLastNDays": "Últimos {{count}} días",
+      "activityNotes": "Notas",
+      "activityNewFollowers": "Nuevos seguidores",
+      "activityTotalFollowers": "Seguidores totales",
       "andOneOther": "y 1 otro {{action}}",
       "andOthers": "y {{count}} otros {{action}}",
       "noNotificationsYet": "Aún no hay notificaciones",

--- a/apps/akari/translations/fa.json
+++ b/apps/akari/translations/fa.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "جستجو",
-      "notifications": "اعلان ها",
+      "notifications": "فعالیت",
       "post": "پست",
       "settings": "تنظیمات"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "به پست شما پاسخ داد",
       "mentionedYou": "شما را ذکر کرد",
       "quotedYourPost": "به نقل از پست شما",
+      "activitySummaryTitle": "خلاصه فعالیت",
+      "activityLastNDays": "آخرین {{count}} روز",
+      "activityNotes": "یادداشت‌ها",
+      "activityNewFollowers": "دنبال‌کنندگان جدید",
+      "activityTotalFollowers": "کل دنبال‌کنندگان",
       "andOneOther": "و 1 {{action}} دیگر",
       "andOthers": "و {{count}} دیگران {{action}}",
       "noNotificationsYet": "هنوز اعلان ها وجود ندارد",

--- a/apps/akari/translations/fi.json
+++ b/apps/akari/translations/fi.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Haku",
-      "notifications": "Ilmoitukset",
+      "notifications": "Toiminta",
       "post": "Lähettää",
       "settings": "Asetukset"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "vastasi viestiisi",
       "mentionedYou": "mainitsi sinut",
       "quotedYourPost": "lainasi viestisi",
+      "activitySummaryTitle": "Toimintayhteenveto",
+      "activityLastNDays": "Viimeiset {{count}} päivää",
+      "activityNotes": "Merkinnät",
+      "activityNewFollowers": "Uudet seuraajat",
+      "activityTotalFollowers": "Seuraajia yhteensä",
       "andOneOther": "ja 1 muuta {{action}}",
       "andOthers": "ja {{count}} muut {{action}}",
       "noNotificationsYet": "Ei vielä ilmoituksia",

--- a/apps/akari/translations/fr.json
+++ b/apps/akari/translations/fr.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Recherche",
-      "notifications": "Notifications",
+      "notifications": "Activité",
       "post": "Publication",
       "settings": "Paramètres"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "a répondu à votre publication",
       "mentionedYou": "vous a mentionné",
       "quotedYourPost": "a cité votre publication",
+      "activitySummaryTitle": "Résumé d'activité",
+      "activityLastNDays": "Derniers {{count}} jours",
+      "activityNotes": "Notes",
+      "activityNewFollowers": "Nouveaux abonnés",
+      "activityTotalFollowers": "Total d'abonnés",
       "andOneOther": "et 1 autre {{action}}",
       "andOthers": "et {{count}} autres {{action}}",
       "noNotificationsYet": "Aucune notification pour le moment",

--- a/apps/akari/translations/he.json
+++ b/apps/akari/translations/he.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "לְחַפֵּשׂ",
-      "notifications": "התראות",
+      "notifications": "פעילות",
       "post": "שֶׁלְאַחַר",
       "settings": "הגדרות"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "ענה לפוסט שלך",
       "mentionedYou": "הזכיר אותך",
       "quotedYourPost": "ציטט את ההודעה שלך",
+      "activitySummaryTitle": "סיכום פעילות",
+      "activityLastNDays": "‏{{count}} הימים האחרונים",
+      "activityNotes": "הערות",
+      "activityNewFollowers": "עוקבים חדשים",
+      "activityTotalFollowers": "סה\"כ עוקבים",
       "andOneOther": "ועוד {{action}} אחר",
       "andOthers": "ו- {{count}} אחרים {{action}}",
       "noNotificationsYet": "עדיין אין התראות",

--- a/apps/akari/translations/hi.json
+++ b/apps/akari/translations/hi.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "खोज",
-      "notifications": "सूचनाएं",
+      "notifications": "गतिविधि",
       "post": "पोस्ट",
       "settings": "सेटिंग्स"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "आपकी पोस्ट का जवाब दिया",
       "mentionedYou": "आपका उल्लेख किया",
       "quotedYourPost": "आपकी पोस्ट को क्वोट किया",
+      "activitySummaryTitle": "गतिविधि सारांश",
+      "activityLastNDays": "पिछले {{count}} दिन",
+      "activityNotes": "नोट्स",
+      "activityNewFollowers": "नए अनुयायी",
+      "activityTotalFollowers": "कुल अनुयायी",
       "andOneOther": "और 1 अन्य {{action}}",
       "andOthers": "और {{count}} अन्य {{action}}",
       "noNotificationsYet": "अभी तक कोई सूचना नहीं",

--- a/apps/akari/translations/hu.json
+++ b/apps/akari/translations/hu.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Keresés",
-      "notifications": "Értesítések",
+      "notifications": "Aktivitás",
       "post": "Oszlop",
       "settings": "Beállítások"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "válaszolt a hozzászólásodra",
       "mentionedYou": "megemlített téged",
       "quotedYourPost": "idézte a bejegyzését",
+      "activitySummaryTitle": "Aktivitási összegzés",
+      "activityLastNDays": "Elmúlt {{count}} nap",
+      "activityNotes": "Jegyzetek",
+      "activityNewFollowers": "Új követők",
+      "activityTotalFollowers": "Követők összesen",
       "andOneOther": "és 1 másik {{action}}",
       "andOthers": "és {{count}} mások {{action}}",
       "noNotificationsYet": "Még nincs értesítés",

--- a/apps/akari/translations/id.json
+++ b/apps/akari/translations/id.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Cari",
-      "notifications": "Notifikasi",
+      "notifications": "Aktivitas",
       "post": "Posting",
       "settings": "Pengaturan"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "membalas post Anda",
       "mentionedYou": "menyebutkan Anda",
       "quotedYourPost": "mengutip post Anda",
+      "activitySummaryTitle": "Ringkasan aktivitas",
+      "activityLastNDays": "{{count}} hari terakhir",
+      "activityNotes": "Catatan",
+      "activityNewFollowers": "Pengikut baru",
+      "activityTotalFollowers": "Total pengikut",
       "andOneOther": "dan 1 lainnya {{action}}",
       "andOthers": "dan {{count}} lainnya {{action}}",
       "noNotificationsYet": "Belum ada notifikasi",

--- a/apps/akari/translations/it.json
+++ b/apps/akari/translations/it.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Cerca",
-      "notifications": "Notifiche",
+      "notifications": "Attività",
       "post": "Post",
       "settings": "Impostazioni"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "ha risposto al tuo post",
       "mentionedYou": "ti ha menzionato",
       "quotedYourPost": "ha citato il tuo post",
+      "activitySummaryTitle": "Riepilogo attività",
+      "activityLastNDays": "Ultimi {{count}} giorni",
+      "activityNotes": "Note",
+      "activityNewFollowers": "Nuovi follower",
+      "activityTotalFollowers": "Follower totali",
       "andOneOther": "e 1 altro {{action}}",
       "andOthers": "e {{count}} altri {{action}}",
       "noNotificationsYet": "Nessuna notifica ancora",

--- a/apps/akari/translations/ja.json
+++ b/apps/akari/translations/ja.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "検索",
-      "notifications": "通知",
+      "notifications": "アクティビティ",
       "post": "投稿",
       "settings": "設定"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "があなたの投稿に返信しました",
       "mentionedYou": "があなたに言及しました",
       "quotedYourPost": "があなたの投稿を引用しました",
+      "activitySummaryTitle": "アクティビティの概要",
+      "activityLastNDays": "直近{{count}}日間",
+      "activityNotes": "ノート",
+      "activityNewFollowers": "新しいフォロワー",
+      "activityTotalFollowers": "フォロワー合計",
       "andOneOther": "と1人の他の{{action}}",
       "andOthers": "と{{count}}人の他の{{action}}",
       "noNotificationsYet": "まだ通知がありません",

--- a/apps/akari/translations/ko.json
+++ b/apps/akari/translations/ko.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "검색",
-      "notifications": "알림",
+      "notifications": "활동",
       "post": "게시물",
       "settings": "설정"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "게시물에 답장했습니다",
       "mentionedYou": "언급했습니다",
       "quotedYourPost": "게시물을 인용했습니다",
+      "activitySummaryTitle": "활동 요약",
+      "activityLastNDays": "지난 {{count}}일",
+      "activityNotes": "노트",
+      "activityNewFollowers": "새 팔로워",
+      "activityTotalFollowers": "총 팔로워",
       "andOneOther": "그리고 1명이 더 {{action}}",
       "andOthers": "그리고 {{count}}명이 더 {{action}}",
       "noNotificationsYet": "아직 알림이 없습니다",

--- a/apps/akari/translations/nl.json
+++ b/apps/akari/translations/nl.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Zoeken",
-      "notifications": "Meldingen",
+      "notifications": "Activiteit",
       "post": "Bericht",
       "settings": "Instellingen"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "heeft gereageerd op je bericht",
       "mentionedYou": "heeft je genoemd",
       "quotedYourPost": "heeft je bericht geciteerd",
+      "activitySummaryTitle": "Activiteitsoverzicht",
+      "activityLastNDays": "Laatste {{count}} dagen",
+      "activityNotes": "Notities",
+      "activityNewFollowers": "Nieuwe volgers",
+      "activityTotalFollowers": "Totaal aantal volgers",
       "andOneOther": "en 1 ander {{action}}",
       "andOthers": "en {{count}} anderen {{action}}",
       "noNotificationsYet": "Nog geen meldingen",

--- a/apps/akari/translations/pl.json
+++ b/apps/akari/translations/pl.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Szukaj",
-      "notifications": "Powiadomienia",
+      "notifications": "Aktywność",
       "post": "Post",
       "settings": "Ustawienia"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "odpowiedział na Twój post",
       "mentionedYou": "wspomniał o Tobie",
       "quotedYourPost": "zacytował Twój post",
+      "activitySummaryTitle": "Podsumowanie aktywności",
+      "activityLastNDays": "Ostatnie {{count}} dni",
+      "activityNotes": "Notatki",
+      "activityNewFollowers": "Nowi obserwujący",
+      "activityTotalFollowers": "Łącznie obserwujących",
       "andOneOther": "i 1 inny {{action}}",
       "andOthers": "i {{count}} innych {{action}}",
       "noNotificationsYet": "Brak powiadomień",

--- a/apps/akari/translations/pt.json
+++ b/apps/akari/translations/pt.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Pesquisar",
-      "notifications": "Notificações",
+      "notifications": "Atividade",
       "post": "Publicação",
       "settings": "Configurações"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "respondeu sua publicação",
       "mentionedYou": "mencionou você",
       "quotedYourPost": "citou sua publicação",
+      "activitySummaryTitle": "Resumo de atividade",
+      "activityLastNDays": "Últimos {{count}} dias",
+      "activityNotes": "Notas",
+      "activityNewFollowers": "Novos seguidores",
+      "activityTotalFollowers": "Seguidores totais",
       "andOneOther": "e mais 1 {{action}}",
       "andOthers": "e mais {{count}} {{action}}",
       "noNotificationsYet": "Ainda não há notificações",

--- a/apps/akari/translations/ro.json
+++ b/apps/akari/translations/ro.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Căutare",
-      "notifications": "Notificări",
+      "notifications": "Activitate",
       "post": "Post",
       "settings": "Setări"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "a răspuns la postarea dvs.",
       "mentionedYou": "te -a menționat",
       "quotedYourPost": "a citat postarea ta",
+      "activitySummaryTitle": "Rezumat activitate",
+      "activityLastNDays": "Ultimele {{count}} zile",
+      "activityNotes": "Note",
+      "activityNewFollowers": "Noi urmăritori",
+      "activityTotalFollowers": "Urmăritori în total",
       "andOneOther": "și alți 1 {{action}}",
       "andOthers": "și {{count}} alții {{action}}",
       "noNotificationsYet": "Nu există încă notificări",

--- a/apps/akari/translations/ru.json
+++ b/apps/akari/translations/ru.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Поиск",
-      "notifications": "Уведомления",
+      "notifications": "Активность",
       "post": "Пост",
       "settings": "Настройки"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "ответил на ваш пост",
       "mentionedYou": "упомянул вас",
       "quotedYourPost": "процитировал ваш пост",
+      "activitySummaryTitle": "Сводка активности",
+      "activityLastNDays": "Последние {{count}} дней",
+      "activityNotes": "Заметки",
+      "activityNewFollowers": "Новые подписчики",
+      "activityTotalFollowers": "Всего подписчиков",
       "andOneOther": "и еще 1 {{action}}",
       "andOthers": "и еще {{count}} {{action}}",
       "noNotificationsYet": "Пока нет уведомлений",

--- a/apps/akari/translations/sk.json
+++ b/apps/akari/translations/sk.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Prehliadka",
-      "notifications": "Oznámenia",
+      "notifications": "Aktivita",
       "post": "Post",
       "settings": "Nastavenia"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "odpovedal na váš príspevok",
       "mentionedYou": "spomenúť ťa",
       "quotedYourPost": "citoval svoj príspevok",
+      "activitySummaryTitle": "Súhrn aktivity",
+      "activityLastNDays": "Posledných {{count}} dní",
+      "activityNotes": "Poznámky",
+      "activityNewFollowers": "Noví sledovatelia",
+      "activityTotalFollowers": "Celkový počet sledovateľov",
       "andOneOther": "a 1 ďalšie {{action}}",
       "andOthers": "a {{count}} Ostatné {{action}}",
       "noNotificationsYet": "Zatiaľ žiadne upozornenia",

--- a/apps/akari/translations/sl.json
+++ b/apps/akari/translations/sl.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Iskanje",
-      "notifications": "Obvestila",
+      "notifications": "Dejavnost",
       "post": "Objavo",
       "settings": "Nastavitve"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "je odgovoril na vašo objavo",
       "mentionedYou": "te je omenil",
       "quotedYourPost": "citiral vašo objavo",
+      "activitySummaryTitle": "Povzetek dejavnosti",
+      "activityLastNDays": "Zadnjih {{count}} dni",
+      "activityNotes": "Opombe",
+      "activityNewFollowers": "Novi sledilci",
+      "activityTotalFollowers": "Skupno število sledilcev",
       "andOneOther": "in 1 drugi {{action}}",
       "andOthers": "in {{count}} drugi {{action}}",
       "noNotificationsYet": "Še ni obvestil",

--- a/apps/akari/translations/sv.json
+++ b/apps/akari/translations/sv.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Söka",
-      "notifications": "Meddelanden",
+      "notifications": "Aktivitet",
       "post": "Posta",
       "settings": "Inställningar"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "svarade på ditt inlägg",
       "mentionedYou": "nämnde dig",
       "quotedYourPost": "citerade ditt inlägg",
+      "activitySummaryTitle": "Aktivitetsöversikt",
+      "activityLastNDays": "Senaste {{count}} dagarna",
+      "activityNotes": "Anteckningar",
+      "activityNewFollowers": "Nya följare",
+      "activityTotalFollowers": "Totalt antal följare",
       "andOneOther": "och 1 annan {{action}}",
       "andOthers": "och {{count}} andra {{action}}",
       "noNotificationsYet": "Inga aviseringar än",

--- a/apps/akari/translations/th.json
+++ b/apps/akari/translations/th.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "ค้นหา",
-      "notifications": "การแจ้งเตือน",
+      "notifications": "กิจกรรม",
       "post": "โพสต์",
       "settings": "การตั้งค่า"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "ตอบกลับโพสต์ของคุณ",
       "mentionedYou": "กล่าวถึงคุณ",
       "quotedYourPost": "อ้างอิงโพสต์ของคุณ",
+      "activitySummaryTitle": "สรุปกิจกรรม",
+      "activityLastNDays": "ช่วง {{count}} วันที่ผ่านมา",
+      "activityNotes": "โน้ต",
+      "activityNewFollowers": "ผู้ติดตามใหม่",
+      "activityTotalFollowers": "ผู้ติดตามทั้งหมด",
       "andOneOther": "และอีก 1 คน {{action}}",
       "andOthers": "และอีก {{count}} คน {{action}}",
       "noNotificationsYet": "ยังไม่มีการแจ้งเตือน",

--- a/apps/akari/translations/tr.json
+++ b/apps/akari/translations/tr.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Arama",
-      "notifications": "Bildirimler",
+      "notifications": "Aktivite",
       "post": "Gönderi",
       "settings": "Ayarlar"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "gönderinizi yanıtladı",
       "mentionedYou": "sizi etiketledi",
       "quotedYourPost": "gönderinizi alıntıladı",
+      "activitySummaryTitle": "Aktivite özeti",
+      "activityLastNDays": "Son {{count}} gün",
+      "activityNotes": "Notlar",
+      "activityNewFollowers": "Yeni takipçiler",
+      "activityTotalFollowers": "Toplam takipçi",
       "andOneOther": "ve 1 kişi daha {{action}}",
       "andOthers": "ve {{count}} kişi daha {{action}}",
       "noNotificationsYet": "Henüz bildirim yok",

--- a/apps/akari/translations/uk.json
+++ b/apps/akari/translations/uk.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Пошук",
-      "notifications": "Сповіщення",
+      "notifications": "Активність",
       "post": "Допис",
       "settings": "Налаштування"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "відповів на ваш пост",
       "mentionedYou": "Згадав вас",
       "quotedYourPost": "Цитується про свою публікацію",
+      "activitySummaryTitle": "Огляд активності",
+      "activityLastNDays": "Останні {{count}} днів",
+      "activityNotes": "Нотатки",
+      "activityNewFollowers": "Нові підписники",
+      "activityTotalFollowers": "Усього підписників",
       "andOneOther": "та 1 інший {{action}}",
       "andOthers": "та {{count}} інші {{action}}",
       "noNotificationsYet": "Ще немає сповіщень",

--- a/apps/akari/translations/vi.json
+++ b/apps/akari/translations/vi.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "Tìm kiếm",
-      "notifications": "Thông báo",
+      "notifications": "Hoạt động",
       "post": "Bài đăng",
       "settings": "Cài đặt"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "đã trả lời bài đăng của bạn",
       "mentionedYou": "đã nhắc đến bạn",
       "quotedYourPost": "đã trích dẫn bài đăng của bạn",
+      "activitySummaryTitle": "Tổng quan hoạt động",
+      "activityLastNDays": "{{count}} ngày gần đây",
+      "activityNotes": "Ghi chú",
+      "activityNewFollowers": "Người theo dõi mới",
+      "activityTotalFollowers": "Tổng người theo dõi",
       "andOneOther": "và 1 người khác {{action}}",
       "andOthers": "và {{count}} người khác {{action}}",
       "noNotificationsYet": "Chưa có thông báo",

--- a/apps/akari/translations/zh-CN.json
+++ b/apps/akari/translations/zh-CN.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "搜索",
-      "notifications": "通知",
+      "notifications": "动态",
       "post": "帖子",
       "settings": "设置"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "回复了您的帖子",
       "mentionedYou": "提到了您",
       "quotedYourPost": "引用了您的帖子",
+      "activitySummaryTitle": "动态概览",
+      "activityLastNDays": "最近{{count}}天",
+      "activityNotes": "笔记",
+      "activityNewFollowers": "新增关注者",
+      "activityTotalFollowers": "关注者总数",
       "andOneOther": "和另外 1 人{{action}}",
       "andOthers": "和另外 {{count}} 人{{action}}",
       "noNotificationsYet": "还没有通知",

--- a/apps/akari/translations/zh-TW.json
+++ b/apps/akari/translations/zh-TW.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "搜尋",
-      "notifications": "通知",
+      "notifications": "動態",
       "post": "貼文",
       "settings": "設定"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "回覆了您的貼文",
       "mentionedYou": "提到了您",
       "quotedYourPost": "引用了您的貼文",
+      "activitySummaryTitle": "動態摘要",
+      "activityLastNDays": "最近 {{count}} 天",
+      "activityNotes": "筆記",
+      "activityNewFollowers": "新增追蹤者",
+      "activityTotalFollowers": "追蹤者總數",
       "andOneOther": "和 1 個其他{{action}}",
       "andOthers": "和 {{count}} 個其他{{action}}",
       "noNotificationsYet": "還沒有通知",

--- a/apps/akari/translations/zh.json
+++ b/apps/akari/translations/zh.json
@@ -99,7 +99,7 @@
     },
     "navigation": {
       "search": "搜索",
-      "notifications": "通知",
+      "notifications": "动态",
       "post": "邮政",
       "settings": "设置"
     },
@@ -123,6 +123,11 @@
       "repliedToYourPost": "回复了您的帖子",
       "mentionedYou": "提到你",
       "quotedYourPost": "引用您的帖子",
+      "activitySummaryTitle": "动态概览",
+      "activityLastNDays": "最近{{count}}天",
+      "activityNotes": "笔记",
+      "activityNewFollowers": "新增关注者",
+      "activityTotalFollowers": "关注者总数",
       "andOneOther": "和其他1个{{action}}",
       "andOthers": "和{{count}}其他",
       "noNotificationsYet": "尚未通知",


### PR DESCRIPTION
## Summary
- rename the notifications navigation copy to Activity throughout the UI and translations
- add an activity summary card above the feed with a per-day graph and follower metrics
- aggregate notification data to compute daily note counts and follower changes for the summary

## Testing
- npm run lint -- --filter=akari
- cd apps/akari && node scripts/validate-translations.js

------
https://chatgpt.com/codex/tasks/task_e_68e2c66db110832b9907be38fdaafbef