### PR TITLE
ci: cache node_modules and emit JUnit test reports

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -50,7 +50,20 @@ jobs:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
 
+      # Cache node_modules itself (not just the ~/.npm download cache) so a
+      # lockfile-unchanged run skips the ~100s npm ci extract/link/postinstall.
+      - name: Cache node_modules
+        id: node-modules
+        uses: useblacksmith/cache@v5
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            packages/*/node_modules
+          key: node-modules-${{ runner.os }}-node24-${{ hashFiles('package-lock.json') }}
+
       - name: Install dependencies
+        if: steps.node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Sync OAuth client metadata

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,5 +24,17 @@ jobs:
         with:
           node-version: 24.9.0
           cache: npm
-      - run: npm ci
+      # Cache node_modules itself (not just the ~/.npm download cache) so a
+      # lockfile-unchanged run skips the ~100s npm ci extract/link/postinstall.
+      - name: Cache node_modules
+        id: node-modules
+        uses: useblacksmith/cache@v5
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            packages/*/node_modules
+          key: node-modules-${{ runner.os }}-node24-${{ hashFiles('package-lock.json') }}
+      - if: steps.node-modules.outputs.cache-hit != 'true'
+        run: npm ci
       - run: npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,19 @@ jobs:
         with:
           node-version: 24.9.0
           cache: npm
-      - run: npm ci
+      # Cache node_modules itself (not just the ~/.npm download cache) so a
+      # lockfile-unchanged run skips the ~100s npm ci extract/link/postinstall.
+      - name: Cache node_modules
+        id: node-modules
+        uses: useblacksmith/cache@v5
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            packages/*/node_modules
+          key: node-modules-${{ runner.os }}-node24-${{ hashFiles('package-lock.json') }}
+      - if: steps.node-modules.outputs.cache-hit != 'true'
+        run: npm ci
       - run: npm run test:coverage --workspaces --if-present
       - name: Merge coverage reports
         run: node ./scripts/merge-coverage.cjs

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ playwright-report/
 test-results/
 # docs site build artifacts
 apps/docs/src/data/docs.json
+
+# Jest JUnit reports (CI)
+junit.xml
+**/junit.xml

--- a/apps/akari/jest.config.js
+++ b/apps/akari/jest.config.js
@@ -39,5 +39,5 @@ module.exports = {
     // load; the WebRTC stream player only mounts on real devices.
     '^react-native-webrtc$': '<rootDir>/__mocks__/react-native-webrtc.js',
   },
-  ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
+  ...(isGithubActions ? { reporters: ['default', 'github-actions', ['jest-junit', { outputName: 'junit.xml' }]] } : {}),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "react-native-worklets": "0.5.1"
       },
       "devDependencies": {
+        "jest-junit": "17.0.0",
         "oxlint": "^1.65.0",
         "turbo": "^2.3.0",
         "vite": "^8.0.10"
@@ -8974,6 +8975,22 @@
         "fsevents": "^2.3.2"
       }
     },
+    "node_modules/jest-junit": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/jest-junit/-/jest-junit-17.0.0.tgz",
+      "integrity": "sha512-RYWCkq4j59gUXj5DsgbIE7xFBZzu1gtibPhyjSjMmGaOTLnqlXhg7x9zuGCwgbCuMAyoyvk0Mi8wSrRR5uOeLA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "strip-ansi": "^6.0.1",
+        "uuid": "^14.0.0",
+        "xml": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
       "devOptional": true,
@@ -13696,6 +13713,13 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "react-native-worklets": "0.5.1"
   },
   "devDependencies": {
+    "jest-junit": "17.0.0",
     "oxlint": "^1.65.0",
     "turbo": "^2.3.0",
     "vite": "^8.0.10"

--- a/packages/bluesky-api/jest.config.cjs
+++ b/packages/bluesky-api/jest.config.cjs
@@ -47,5 +47,5 @@ module.exports = {
     'node_modules/.+\\.mjs$': '<rootDir>/../../scripts/jest-transform-mjs.cjs',
   },
   transformIgnorePatterns: ['node_modules/(?!until-async/|.+\\.mjs$)'],
-  ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
+  ...(isGithubActions ? { reporters: ['default', 'github-actions', ['jest-junit', { outputName: 'junit.xml' }]] } : {}),
 };

--- a/packages/clearsky-api/jest.config.cjs
+++ b/packages/clearsky-api/jest.config.cjs
@@ -32,5 +32,5 @@ module.exports = {
     'node_modules/.+\\.mjs$': '<rootDir>/../../scripts/jest-transform-mjs.cjs',
   },
   transformIgnorePatterns: ['node_modules/(?!until-async/|.+\\.mjs$)'],
-  ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
+  ...(isGithubActions ? { reporters: ['default', 'github-actions', ['jest-junit', { outputName: 'junit.xml' }]] } : {}),
 };

--- a/packages/constellation-api/jest.config.cjs
+++ b/packages/constellation-api/jest.config.cjs
@@ -28,5 +28,5 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!**/*.d.ts'],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'html'],
-  ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
+  ...(isGithubActions ? { reporters: ['default', 'github-actions', ['jest-junit', { outputName: 'junit.xml' }]] } : {}),
 };

--- a/packages/libretranslate-api/jest.config.cjs
+++ b/packages/libretranslate-api/jest.config.cjs
@@ -28,5 +28,5 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!**/*.d.ts'],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'html'],
-  ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
+  ...(isGithubActions ? { reporters: ['default', 'github-actions', ['jest-junit', { outputName: 'junit.xml' }]] } : {}),
 };

--- a/packages/microcosm-links-api/jest.config.cjs
+++ b/packages/microcosm-links-api/jest.config.cjs
@@ -28,5 +28,5 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!**/*.d.ts'],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'html'],
-  ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
+  ...(isGithubActions ? { reporters: ['default', 'github-actions', ['jest-junit', { outputName: 'junit.xml' }]] } : {}),
 };

--- a/packages/slingshot-api/jest.config.cjs
+++ b/packages/slingshot-api/jest.config.cjs
@@ -30,5 +30,5 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!**/*.d.ts'],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'html'],
-  ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
+  ...(isGithubActions ? { reporters: ['default', 'github-actions', ['jest-junit', { outputName: 'junit.xml' }]] } : {}),
 };

--- a/packages/tenor-api/jest.config.cjs
+++ b/packages/tenor-api/jest.config.cjs
@@ -28,5 +28,5 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!**/*.d.ts'],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'html'],
-  ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
+  ...(isGithubActions ? { reporters: ['default', 'github-actions', ['jest-junit', { outputName: 'junit.xml' }]] } : {}),
 };

--- a/packages/tmdb-api/jest.config.cjs
+++ b/packages/tmdb-api/jest.config.cjs
@@ -28,5 +28,5 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!**/*.d.ts'],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'html'],
-  ...(isGithubActions ? { reporters: ['default', 'github-actions'] } : {}),
+  ...(isGithubActions ? { reporters: ['default', 'github-actions', ['jest-junit', { outputName: 'junit.xml' }]] } : {}),
 };


### PR DESCRIPTION
Two CI improvements for the Blacksmith runs.

## 1. Cache `node_modules` (faster installs)
`npm ci` was taking ~100s on every `lint`/`test`/`deploy-preview` run. `setup-node`'s `cache: npm` only caches the `~/.npm` download tarballs — it doesn't cache `node_modules`, so each run re-did the extract/link/postinstall work from scratch (big Expo/RN monorepo × workspaces).

Added a `useblacksmith/cache@v5` step keyed on `package-lock.json` that caches `node_modules` (root + `apps/*` + `packages/*`) and **skips `npm ci` on a cache hit** (the common, lockfile-unchanged case) — cutting ~100s to a few seconds. On a lockfile change it misses, runs `npm ci` (warmed by the kept `~/.npm` cache), and repopulates.

## 2. JUnit XML test reports (structured detection)
Blacksmith was parsing test results from job logs. Added the `jest-junit` reporter to every workspace's jest config, **CI-only** (gated on `GITHUB_ACTIONS`), so each workspace writes a `junit.xml` that Blacksmith auto-detects for structured test reporting. Verified locally: emits valid JUnit (e.g. bluesky-api → 83 tests), and a non-CI run writes nothing. `junit.xml` is gitignored.

### Notes
- New runner step matches the repo's Blacksmith convention (`useblacksmith/cache@v5`, drop-in for `actions/cache@v4`).
- Reporter is additive (`['default', 'github-actions', ['jest-junit', …]]`) — console + GitHub annotations unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lucid-softworks/codesmith/akari/pr/403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782641661&installation_id=136510994&pr_number=403&repository=lucid-softworks%2Fakari&return_to=https%3A%2F%2Fgithub.com%2Flucid-softworks%2Fakari%2Fpull%2F403&signature=76a15eaa4edfe4c86b691c95af741b8a3b0eea2df22862a245fc74c7eb87de09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->