### PR TITLE
test: cover slingshot-api and bluesky-api packages

### DIFF
--- a/packages/bluesky-api/src/actors.coverage.test.ts
+++ b/packages/bluesky-api/src/actors.coverage.test.ts
@@ -1,0 +1,497 @@
+import { BlueskyActors } from './actors';
+import type {
+  BlueskyLabelerServicesResponse,
+  BlueskyPreference,
+  BlueskyPreferencesResponse,
+  BlueskyProfileResponse,
+} from './types';
+
+type RequestOptions = {
+  method?: 'GET' | 'POST';
+  body?: Record<string, unknown> | FormData | Blob;
+  params?: Record<string, string | string[]>;
+  headers?: Record<string, string>;
+};
+
+describe('BlueskyActors (coverage)', () => {
+  class TestActors extends BlueskyActors {
+    public authCalls: { endpoint: string; accessJwt: string; options: RequestOptions }[] = [];
+    public requestCalls: { endpoint: string; options: RequestOptions }[] = [];
+
+    // Each entry is returned (or thrown, if it is an Error) for the next
+    // makeAuthenticatedRequest / makeRequest call, in order.
+    public responses: unknown[] = [];
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    private next<T>(): T {
+      const value = this.responses.shift();
+      if (value instanceof Error) {
+        throw value;
+      }
+      return (value as T) ?? (undefined as T);
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: RequestOptions = {},
+    ): Promise<T> {
+      this.authCalls.push({ endpoint, accessJwt, options });
+      return this.next<T>();
+    }
+
+    protected async makeRequest<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
+      this.requestCalls.push({ endpoint, options });
+      return this.next<T>();
+    }
+  }
+
+  it('getProfile requests a profile with labeler headers', async () => {
+    const actors = new TestActors();
+    const profile = { did: 'did:example:alice' } as unknown as BlueskyProfileResponse;
+    actors.responses = [profile];
+
+    const result = await actors.getProfile('jwt', 'did:example:alice', ['did:plc:labeler']);
+
+    expect(result).toBe(profile);
+    const call = actors.authCalls[0];
+    expect(call.endpoint).toBe('/app.bsky.actor.getProfile');
+    expect(call.accessJwt).toBe('jwt');
+    expect(call.options.params).toEqual({ actor: 'did:example:alice' });
+    expect(call.options.headers?.['atproto-accept-labelers']).toContain('did:plc:labeler');
+  });
+
+  it('getProfile works without acceptLabelers', async () => {
+    const actors = new TestActors();
+    actors.responses = [{} as BlueskyProfileResponse];
+
+    await actors.getProfile('jwt', 'did:example:bob');
+
+    expect(actors.authCalls[0].options.params).toEqual({ actor: 'did:example:bob' });
+  });
+
+  it('getProfiles batches actors with labeler headers', async () => {
+    const actors = new TestActors();
+    const response = { profiles: [] };
+    actors.responses = [response];
+
+    const result = await actors.getProfiles('jwt', ['a', 'b'], ['did:plc:labeler']);
+
+    expect(result).toBe(response);
+    const call = actors.authCalls[0];
+    expect(call.endpoint).toBe('/app.bsky.actor.getProfiles');
+    expect(call.options.params).toEqual({ actors: ['a', 'b'] });
+    expect(call.options.headers?.['atproto-accept-labelers']).toContain('did:plc:labeler');
+  });
+
+  it('getSuggestions uses default limit and omits cursor', async () => {
+    const actors = new TestActors();
+    actors.responses = [{ actors: [] }];
+
+    await actors.getSuggestions('jwt');
+
+    const call = actors.authCalls[0];
+    expect(call.endpoint).toBe('/app.bsky.actor.getSuggestions');
+    expect(call.options.params).toEqual({ limit: '10' });
+  });
+
+  it('getSuggestions forwards limit, cursor and acceptLabelers', async () => {
+    const actors = new TestActors();
+    const response = { actors: [], cursor: 'next' };
+    actors.responses = [response];
+
+    const result = await actors.getSuggestions('jwt', { limit: 30, cursor: 'c1', acceptLabelers: ['did:plc:labeler'] });
+
+    expect(result).toBe(response);
+    const call = actors.authCalls[0];
+    expect(call.options.params).toEqual({ limit: '30', cursor: 'c1' });
+    expect(call.options.headers?.['atproto-accept-labelers']).toContain('did:plc:labeler');
+  });
+
+  it('updateProfile posts the profile fields', async () => {
+    const actors = new TestActors();
+    const updated = {} as BlueskyProfileResponse;
+    actors.responses = [updated];
+
+    const result = await actors.updateProfile('jwt', {
+      displayName: 'Alice',
+      description: 'bio',
+      avatar: { $type: 'blob' } as never,
+      banner: { $type: 'blob' } as never,
+    });
+
+    expect(result).toBe(updated);
+    const call = actors.authCalls[0];
+    expect(call.endpoint).toBe('/app.bsky.actor.updateProfile');
+    expect(call.options.method).toBe('POST');
+    expect(call.options.body).toEqual({
+      displayName: 'Alice',
+      description: 'bio',
+      avatar: { $type: 'blob' },
+      banner: { $type: 'blob' },
+    });
+  });
+
+  it('getPreferences requests preferences without extra options', async () => {
+    const actors = new TestActors();
+    const prefs = { preferences: [] } as unknown as BlueskyPreferencesResponse;
+    actors.responses = [prefs];
+
+    const result = await actors.getPreferences('jwt');
+
+    expect(result).toBe(prefs);
+    expect(actors.authCalls[0]).toEqual({
+      endpoint: '/app.bsky.actor.getPreferences',
+      accessJwt: 'jwt',
+      options: {},
+    });
+  });
+
+  it('putPreferences posts the full preference list', async () => {
+    const actors = new TestActors();
+    actors.responses = [undefined];
+    const preferences = [{ $type: 'app.bsky.actor.defs#savedFeedsPref' }] as unknown as BlueskyPreference[];
+
+    await actors.putPreferences('jwt', preferences);
+
+    const call = actors.authCalls[0];
+    expect(call.endpoint).toBe('/app.bsky.actor.putPreferences');
+    expect(call.options.method).toBe('POST');
+    expect(call.options.body).toEqual({ preferences });
+  });
+
+  it('getLabelerServices defaults detailed to true', async () => {
+    const actors = new TestActors();
+    const response = { views: [] } as unknown as BlueskyLabelerServicesResponse;
+    actors.responses = [response];
+
+    const result = await actors.getLabelerServices('jwt', ['did:plc:labeler']);
+
+    expect(result).toBe(response);
+    const call = actors.authCalls[0];
+    expect(call.endpoint).toBe('/app.bsky.labeler.getServices');
+    expect(call.options.params).toEqual({ dids: ['did:plc:labeler'], detailed: 'true' });
+  });
+
+  it('getLabelerServices passes detailed=false', async () => {
+    const actors = new TestActors();
+    actors.responses = [{} as BlueskyLabelerServicesResponse];
+
+    await actors.getLabelerServices('jwt', ['did:plc:labeler'], false);
+
+    expect(actors.authCalls[0].options.params).toEqual({ dids: ['did:plc:labeler'], detailed: 'false' });
+  });
+
+  it('setPinnedPost reads existing record then writes pinnedPost', async () => {
+    const actors = new TestActors();
+    actors.responses = [
+      { uri: 'u', cid: 'c', value: { displayName: 'Alice' } },
+      { ok: true },
+    ];
+
+    await actors.setPinnedPost('jwt', 'did:example:alice', { uri: 'post-uri', cid: 'post-cid' });
+
+    expect(actors.authCalls[0].endpoint).toBe('/com.atproto.repo.getRecord');
+    const putCall = actors.authCalls[1];
+    expect(putCall.endpoint).toBe('/com.atproto.repo.putRecord');
+    expect(putCall.options.method).toBe('POST');
+    expect(putCall.options.body).toEqual({
+      repo: 'did:example:alice',
+      collection: 'app.bsky.actor.profile',
+      rkey: 'self',
+      record: { displayName: 'Alice', pinnedPost: { uri: 'post-uri', cid: 'post-cid' } },
+    });
+  });
+
+  it('setPinnedPost removes pinnedPost when passed null and handles missing record', async () => {
+    const actors = new TestActors();
+    actors.responses = [new Error('not found'), { ok: true }];
+
+    await actors.setPinnedPost('jwt', 'did:example:alice', null);
+
+    const putCall = actors.authCalls[1];
+    expect(putCall.options.body).toMatchObject({ record: {} });
+    const record = (putCall.options.body as { record: Record<string, unknown> }).record;
+    expect('pinnedPost' in record).toBe(false);
+  });
+
+  it('getProfileRecord returns the record', async () => {
+    const actors = new TestActors();
+    const record = { uri: 'u', cid: 'c', value: {} };
+    actors.responses = [record];
+
+    const result = await actors.getProfileRecord('jwt', 'did:example:alice');
+
+    expect(result).toBe(record);
+    expect(actors.authCalls[0].endpoint).toBe('/com.atproto.repo.getRecord');
+  });
+
+  it('getProfileRecord returns null on RecordNotFound', async () => {
+    const actors = new TestActors();
+    actors.responses = [Object.assign(new Error('nope'), { errorCode: 'RecordNotFound' })];
+
+    const result = await actors.getProfileRecord('jwt', 'did:example:alice');
+
+    expect(result).toBeNull();
+  });
+
+  it('getProfileRecord returns null on 404 status', async () => {
+    const actors = new TestActors();
+    actors.responses = [Object.assign(new Error('nope'), { status: 404 })];
+
+    const result = await actors.getProfileRecord('jwt', 'did:example:alice');
+
+    expect(result).toBeNull();
+  });
+
+  it('getProfileRecord rethrows other errors', async () => {
+    const actors = new TestActors();
+    actors.responses = [Object.assign(new Error('boom'), { status: 500 })];
+
+    await expect(actors.getProfileRecord('jwt', 'did:example:alice')).rejects.toThrow('boom');
+  });
+
+  it('setProfileSelfLabel adds a label to a record with no labels', async () => {
+    const actors = new TestActors();
+    actors.responses = [
+      { uri: 'u', cid: 'c', value: { displayName: 'Alice' } },
+      { ok: true },
+    ];
+
+    await actors.setProfileSelfLabel('jwt', 'did:example:alice', 'automated', true);
+
+    const putCall = actors.authCalls[1];
+    expect(putCall.endpoint).toBe('/com.atproto.repo.putRecord');
+    const record = (putCall.options.body as { record: Record<string, unknown> }).record;
+    expect(record.labels).toEqual({
+      $type: 'com.atproto.label.defs#selfLabels',
+      values: [{ val: 'automated' }],
+    });
+    expect(record.displayName).toBe('Alice');
+  });
+
+  it('setProfileSelfLabel removes the last label and deletes the labels field', async () => {
+    const actors = new TestActors();
+    actors.responses = [
+      {
+        uri: 'u',
+        cid: 'c',
+        value: {
+          labels: { $type: 'com.atproto.label.defs#selfLabels', values: [{ val: 'automated' }] },
+        },
+      },
+      { ok: true },
+    ];
+
+    await actors.setProfileSelfLabel('jwt', 'did:example:alice', 'automated', false);
+
+    const record = (actors.authCalls[1].options.body as { record: Record<string, unknown> }).record;
+    expect('labels' in record).toBe(false);
+  });
+
+  it('setProfileSelfLabel keeps other labels when removing one', async () => {
+    const actors = new TestActors();
+    actors.responses = [
+      {
+        uri: 'u',
+        cid: 'c',
+        value: {
+          labels: {
+            $type: 'com.atproto.label.defs#selfLabels',
+            values: [{ val: 'automated' }, { val: '!no-unauthenticated' }],
+          },
+        },
+      },
+      { ok: true },
+    ];
+
+    await actors.setProfileSelfLabel('jwt', 'did:example:alice', 'automated', false);
+
+    const record = (actors.authCalls[1].options.body as { record: Record<string, unknown> }).record;
+    expect(record.labels).toEqual({
+      $type: 'com.atproto.label.defs#selfLabels',
+      values: [{ val: '!no-unauthenticated' }],
+    });
+  });
+
+  it('setProfileSelfLabel handles a null existing record (no value)', async () => {
+    const actors = new TestActors();
+    // getProfileRecord returns null (RecordNotFound), then putRecord succeeds.
+    actors.responses = [Object.assign(new Error('nf'), { errorCode: 'RecordNotFound' }), { ok: true }];
+
+    await actors.setProfileSelfLabel('jwt', 'did:example:alice', 'automated', true);
+
+    const record = (actors.authCalls[1].options.body as { record: Record<string, unknown> }).record;
+    expect(record.labels).toEqual({
+      $type: 'com.atproto.label.defs#selfLabels',
+      values: [{ val: 'automated' }],
+    });
+  });
+
+  it('setLoggedOutVisibilityDiscouraged toggles the !no-unauthenticated label', async () => {
+    const actors = new TestActors();
+    actors.responses = [{ uri: 'u', cid: 'c', value: {} }, { ok: true }];
+
+    await actors.setLoggedOutVisibilityDiscouraged('jwt', 'did:example:alice', true);
+
+    const record = (actors.authCalls[1].options.body as { record: Record<string, unknown> }).record;
+    expect(record.labels).toEqual({
+      $type: 'com.atproto.label.defs#selfLabels',
+      values: [{ val: '!no-unauthenticated' }],
+    });
+  });
+
+  it('setAccountAutomated toggles the automated label', async () => {
+    const actors = new TestActors();
+    actors.responses = [{ uri: 'u', cid: 'c', value: {} }, { ok: true }];
+
+    await actors.setAccountAutomated('jwt', 'did:example:alice', true);
+
+    const record = (actors.authCalls[1].options.body as { record: Record<string, unknown> }).record;
+    expect(record.labels).toEqual({
+      $type: 'com.atproto.label.defs#selfLabels',
+      values: [{ val: 'automated' }],
+    });
+  });
+
+  it('setActorStatus writes a live status with an external embed', async () => {
+    const actors = new TestActors();
+    // getStatusRecord (existing), then putRecord succeeds.
+    actors.responses = [{ uri: 'u', cid: 'existing-cid', value: {} }, { ok: true }];
+
+    await actors.setActorStatus('jwt', 'did:example:alice', {
+      durationMinutes: 60,
+      external: { uri: 'https://live.example', title: 'Live', description: 'desc' },
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    expect(actors.authCalls[0].endpoint).toBe('/com.atproto.repo.getRecord');
+    const putCall = actors.authCalls[1];
+    expect(putCall.endpoint).toBe('/com.atproto.repo.putRecord');
+    const body = putCall.options.body as { record: Record<string, unknown>; swapRecord: string | null };
+    expect(body.swapRecord).toBe('existing-cid');
+    expect(body.record).toEqual({
+      $type: 'app.bsky.actor.status',
+      status: 'app.bsky.actor.status#live',
+      durationMinutes: 60,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      embed: {
+        $type: 'app.bsky.embed.external',
+        external: {
+          $type: 'app.bsky.embed.external#external',
+          uri: 'https://live.example',
+          title: 'Live',
+          description: 'desc',
+        },
+      },
+    });
+  });
+
+  it('setActorStatus generates createdAt and swapRecord null when no existing record', async () => {
+    const actors = new TestActors();
+    actors.responses = [Object.assign(new Error('nf'), { errorCode: 'RecordNotFound' }), { ok: true }];
+
+    await actors.setActorStatus('jwt', 'did:example:alice', { durationMinutes: 1 });
+
+    const body = actors.authCalls[1].options.body as { record: Record<string, unknown>; swapRecord: string | null };
+    expect(body.swapRecord).toBeNull();
+    expect(typeof body.record.createdAt).toBe('string');
+    expect('embed' in body.record).toBe(false);
+  });
+
+  it('setActorStatus retries on InvalidSwap then succeeds', async () => {
+    const actors = new TestActors();
+    actors.responses = [
+      // attempt 1: read then InvalidSwap
+      { uri: 'u', cid: 'c1', value: {} },
+      Object.assign(new Error('swap'), { errorCode: 'InvalidSwap' }),
+      // attempt 2: read then success
+      { uri: 'u', cid: 'c2', value: {} },
+      { ok: true },
+    ];
+
+    await actors.setActorStatus('jwt', 'did:example:alice', { durationMinutes: 5 });
+
+    // getRecord, putRecord(fail), getRecord, putRecord(success)
+    expect(actors.authCalls.map((c) => c.endpoint)).toEqual([
+      '/com.atproto.repo.getRecord',
+      '/com.atproto.repo.putRecord',
+      '/com.atproto.repo.getRecord',
+      '/com.atproto.repo.putRecord',
+    ]);
+  });
+
+  it('setActorStatus rethrows non-InvalidSwap errors', async () => {
+    const actors = new TestActors();
+    actors.responses = [
+      { uri: 'u', cid: 'c1', value: {} },
+      Object.assign(new Error('boom'), { errorCode: 'SomethingElse' }),
+    ];
+
+    await expect(actors.setActorStatus('jwt', 'did:example:alice', { durationMinutes: 5 })).rejects.toThrow('boom');
+  });
+
+  it('setActorStatus gives up after max attempts of InvalidSwap', async () => {
+    const actors = new TestActors();
+    const invalidSwap = () => Object.assign(new Error('swap'), { errorCode: 'InvalidSwap' });
+    actors.responses = [
+      { uri: 'u', cid: 'c1', value: {} }, invalidSwap(),
+      { uri: 'u', cid: 'c2', value: {} }, invalidSwap(),
+      { uri: 'u', cid: 'c3', value: {} }, invalidSwap(),
+      { uri: 'u', cid: 'c4', value: {} }, invalidSwap(),
+      { uri: 'u', cid: 'c5', value: {} }, invalidSwap(),
+    ];
+
+    await expect(actors.setActorStatus('jwt', 'did:example:alice', { durationMinutes: 5 })).rejects.toThrow('swap');
+  });
+
+  it('setActorStatus rethrows a non-404 error while reading the status record', async () => {
+    const actors = new TestActors();
+    // getStatusRecord throws a 500 (not RecordNotFound / 404) -> rethrown.
+    actors.responses = [Object.assign(new Error('read failed'), { status: 500 })];
+
+    await expect(actors.setActorStatus('jwt', 'did:example:alice', { durationMinutes: 5 })).rejects.toThrow(
+      'read failed',
+    );
+  });
+
+  it('clearActorStatus deletes the status record', async () => {
+    const actors = new TestActors();
+    actors.responses = [{ ok: true }];
+
+    await actors.clearActorStatus('jwt', 'did:example:alice');
+
+    const call = actors.authCalls[0];
+    expect(call.endpoint).toBe('/com.atproto.repo.deleteRecord');
+    expect(call.options.method).toBe('POST');
+    expect(call.options.body).toEqual({
+      repo: 'did:example:alice',
+      collection: 'app.bsky.actor.status',
+      rkey: 'self',
+    });
+  });
+
+  it('clearActorStatus treats RecordNotFound as success', async () => {
+    const actors = new TestActors();
+    actors.responses = [Object.assign(new Error('nf'), { errorCode: 'RecordNotFound' })];
+
+    await expect(actors.clearActorStatus('jwt', 'did:example:alice')).resolves.toBeUndefined();
+  });
+
+  it('clearActorStatus treats 404 as success', async () => {
+    const actors = new TestActors();
+    actors.responses = [Object.assign(new Error('nf'), { status: 404 })];
+
+    await expect(actors.clearActorStatus('jwt', 'did:example:alice')).resolves.toBeUndefined();
+  });
+
+  it('clearActorStatus rethrows other errors', async () => {
+    const actors = new TestActors();
+    actors.responses = [Object.assign(new Error('boom'), { status: 500 })];
+
+    await expect(actors.clearActorStatus('jwt', 'did:example:alice')).rejects.toThrow('boom');
+  });
+});

--- a/packages/bluesky-api/src/api.facade-part1.test.ts
+++ b/packages/bluesky-api/src/api.facade-part1.test.ts
@@ -1,0 +1,603 @@
+import { BlueskyApi } from './api';
+import type {
+  BlueskyPreference,
+  BlueskyPreferencesResponse,
+  BlueskyProfileResponse,
+  BlueskyProfileUpdateInput,
+  BlueskyRecipeRecordsResponse,
+  BlueskySession,
+  BlueskyTangledReposResponse,
+} from './types';
+
+/**
+ * Supplementary coverage for the first half of the {@link BlueskyApi} facade
+ * (roughly the createAccount -> getActorSifaEducation span). Every method here
+ * is a thin delegation to a private sub-client, so each test replaces the
+ * relevant sub-client with jest mocks and asserts both the returned value and
+ * the exact arguments forwarded (including default-value / optional branches).
+ */
+describe('BlueskyApi facade (part 1)', () => {
+  const setupApi = () => {
+    const api = new BlueskyApi('https://pds.example');
+    const internal = api as unknown as {
+      auth: Record<string, jest.Mock>;
+      actors: Record<string, jest.Mock>;
+      repos: Record<string, jest.Mock>;
+      grain: Record<string, jest.Mock>;
+      flashes: Record<string, jest.Mock>;
+      spark: Record<string, jest.Mock>;
+      poll: Record<string, jest.Mock>;
+      rpg: Record<string, jest.Mock>;
+      sifa: Record<string, jest.Mock>;
+    };
+
+    return { api, internal };
+  };
+
+  const session: BlueskySession = {
+    did: 'did:example:alice',
+    handle: 'alice.test',
+    active: true,
+    accessJwt: 'access',
+    refreshJwt: 'refresh',
+  };
+
+  describe('auth delegation', () => {
+    it('createAccount forwards the args object', async () => {
+      const { api, internal } = setupApi();
+      internal.auth = { createAccount: jest.fn().mockResolvedValue(session) };
+
+      const args = { email: 'a@b.com', handle: 'alice.test', password: 'pw', inviteCode: 'inv-1' };
+      await expect(api.createAccount(args)).resolves.toBe(session);
+      expect(internal.auth.createAccount).toHaveBeenCalledWith(args);
+    });
+
+    it('refreshSession forwards the refresh token', async () => {
+      const { api, internal } = setupApi();
+      const refreshed = { ...session, accessJwt: 'new' };
+      internal.auth = { refreshSession: jest.fn().mockResolvedValue(refreshed) };
+
+      await expect(api.refreshSession('refresh')).resolves.toBe(refreshed);
+      expect(internal.auth.refreshSession).toHaveBeenCalledWith('refresh');
+    });
+
+    it('getServiceAuth forwards aud/lxm and the optional expSeconds', async () => {
+      const { api, internal } = setupApi();
+      const token = { token: 'svc-jwt' };
+      internal.auth = { getServiceAuth: jest.fn().mockResolvedValue(token) };
+
+      await expect(api.getServiceAuth('jwt', 'did:aud', 'app.bsky.lxm', 60)).resolves.toBe(token);
+      expect(internal.auth.getServiceAuth).toHaveBeenCalledWith('jwt', 'did:aud', 'app.bsky.lxm', 60);
+    });
+
+    it('getServiceAuth omits expSeconds when not provided', async () => {
+      const { api, internal } = setupApi();
+      const token = { token: 'svc-jwt' };
+      internal.auth = { getServiceAuth: jest.fn().mockResolvedValue(token) };
+
+      await expect(api.getServiceAuth('jwt', 'did:aud', 'app.bsky.lxm')).resolves.toBe(token);
+      expect(internal.auth.getServiceAuth).toHaveBeenCalledWith('jwt', 'did:aud', 'app.bsky.lxm', undefined);
+    });
+
+    it('getSession forwards the access token', async () => {
+      const { api, internal } = setupApi();
+      const sessionInfo = { handle: 'alice.test', did: 'did:example:alice' };
+      internal.auth = { getSession: jest.fn().mockResolvedValue(sessionInfo) };
+
+      await expect(api.getSession('jwt')).resolves.toBe(sessionInfo);
+      expect(internal.auth.getSession).toHaveBeenCalledWith('jwt');
+    });
+
+    it('updateHandle forwards the new handle', async () => {
+      const { api, internal } = setupApi();
+      internal.auth = { updateHandle: jest.fn().mockResolvedValue(undefined) };
+
+      await expect(api.updateHandle('jwt', 'new.handle')).resolves.toBeUndefined();
+      expect(internal.auth.updateHandle).toHaveBeenCalledWith('jwt', 'new.handle');
+    });
+
+    it('requestEmailUpdate forwards the access token', async () => {
+      const { api, internal } = setupApi();
+      const result = { tokenRequired: true };
+      internal.auth = { requestEmailUpdate: jest.fn().mockResolvedValue(result) };
+
+      await expect(api.requestEmailUpdate('jwt')).resolves.toBe(result);
+      expect(internal.auth.requestEmailUpdate).toHaveBeenCalledWith('jwt');
+    });
+
+    it('updateEmail forwards email and the optional token', async () => {
+      const { api, internal } = setupApi();
+      internal.auth = { updateEmail: jest.fn().mockResolvedValue(undefined) };
+
+      await api.updateEmail('jwt', 'new@b.com', 'tok-1');
+      expect(internal.auth.updateEmail).toHaveBeenCalledWith('jwt', 'new@b.com', 'tok-1');
+    });
+
+    it('updateEmail omits the token when not provided', async () => {
+      const { api, internal } = setupApi();
+      internal.auth = { updateEmail: jest.fn().mockResolvedValue(undefined) };
+
+      await api.updateEmail('jwt', 'new@b.com');
+      expect(internal.auth.updateEmail).toHaveBeenCalledWith('jwt', 'new@b.com', undefined);
+    });
+
+    it('requestPasswordReset forwards the email', async () => {
+      const { api, internal } = setupApi();
+      internal.auth = { requestPasswordReset: jest.fn().mockResolvedValue(undefined) };
+
+      await api.requestPasswordReset('a@b.com');
+      expect(internal.auth.requestPasswordReset).toHaveBeenCalledWith('a@b.com');
+    });
+
+    it('deactivateAccount forwards the optional deleteAfter', async () => {
+      const { api, internal } = setupApi();
+      internal.auth = { deactivateAccount: jest.fn().mockResolvedValue(undefined) };
+
+      await api.deactivateAccount('jwt', '2026-01-01T00:00:00Z');
+      expect(internal.auth.deactivateAccount).toHaveBeenCalledWith('jwt', '2026-01-01T00:00:00Z');
+    });
+
+    it('deactivateAccount omits deleteAfter when not provided', async () => {
+      const { api, internal } = setupApi();
+      internal.auth = { deactivateAccount: jest.fn().mockResolvedValue(undefined) };
+
+      await api.deactivateAccount('jwt');
+      expect(internal.auth.deactivateAccount).toHaveBeenCalledWith('jwt', undefined);
+    });
+
+    it('requestAccountDelete forwards the access token', async () => {
+      const { api, internal } = setupApi();
+      internal.auth = { requestAccountDelete: jest.fn().mockResolvedValue(undefined) };
+
+      await api.requestAccountDelete('jwt');
+      expect(internal.auth.requestAccountDelete).toHaveBeenCalledWith('jwt');
+    });
+
+    it('deleteAccount forwards did/password/token', async () => {
+      const { api, internal } = setupApi();
+      internal.auth = { deleteAccount: jest.fn().mockResolvedValue(undefined) };
+
+      await api.deleteAccount('did:example:alice', 'pw', 'tok-1');
+      expect(internal.auth.deleteAccount).toHaveBeenCalledWith('did:example:alice', 'pw', 'tok-1');
+    });
+
+    it('exportRepo forwards jwt/did and returns the Blob', async () => {
+      const { api, internal } = setupApi();
+      const blob = new Blob(['car-data']);
+      internal.auth = { exportRepo: jest.fn().mockResolvedValue(blob) };
+
+      await expect(api.exportRepo('jwt', 'did:example:alice')).resolves.toBe(blob);
+      expect(internal.auth.exportRepo).toHaveBeenCalledWith('jwt', 'did:example:alice');
+    });
+
+    it('listAppPasswords forwards the access token', async () => {
+      const { api, internal } = setupApi();
+      const result = { passwords: [] };
+      internal.auth = { listAppPasswords: jest.fn().mockResolvedValue(result) };
+
+      await expect(api.listAppPasswords('jwt')).resolves.toBe(result);
+      expect(internal.auth.listAppPasswords).toHaveBeenCalledWith('jwt');
+    });
+
+    it('createAppPassword forwards name and privileged flag', async () => {
+      const { api, internal } = setupApi();
+      const result = { name: 'cli', password: 'secret', createdAt: 'now' };
+      internal.auth = { createAppPassword: jest.fn().mockResolvedValue(result) };
+
+      await expect(api.createAppPassword('jwt', 'cli', true)).resolves.toBe(result);
+      expect(internal.auth.createAppPassword).toHaveBeenCalledWith('jwt', 'cli', true);
+    });
+
+    it('createAppPassword defaults privileged to false', async () => {
+      const { api, internal } = setupApi();
+      const result = { name: 'cli', password: 'secret', createdAt: 'now' };
+      internal.auth = { createAppPassword: jest.fn().mockResolvedValue(result) };
+
+      await api.createAppPassword('jwt', 'cli');
+      expect(internal.auth.createAppPassword).toHaveBeenCalledWith('jwt', 'cli', false);
+    });
+
+    it('revokeAppPassword forwards the name', async () => {
+      const { api, internal } = setupApi();
+      internal.auth = { revokeAppPassword: jest.fn().mockResolvedValue(undefined) };
+
+      await api.revokeAppPassword('jwt', 'cli');
+      expect(internal.auth.revokeAppPassword).toHaveBeenCalledWith('jwt', 'cli');
+    });
+  });
+
+  describe('actors delegation', () => {
+    const profile = { handle: 'alice.test' } as unknown as BlueskyProfileResponse;
+
+    it('getProfile forwards optional acceptLabelers', async () => {
+      const { api, internal } = setupApi();
+      internal.actors = { getProfile: jest.fn().mockResolvedValue(profile) };
+
+      await expect(api.getProfile('jwt', 'did:example:alice', ['did:labeler'])).resolves.toBe(profile);
+      expect(internal.actors.getProfile).toHaveBeenCalledWith('jwt', 'did:example:alice', ['did:labeler']);
+    });
+
+    it('getProfile omits acceptLabelers when not provided', async () => {
+      const { api, internal } = setupApi();
+      internal.actors = { getProfile: jest.fn().mockResolvedValue(profile) };
+
+      await api.getProfile('jwt', 'did:example:alice');
+      expect(internal.actors.getProfile).toHaveBeenCalledWith('jwt', 'did:example:alice', undefined);
+    });
+
+    it('getProfiles forwards the actor list and optional labelers', async () => {
+      const { api, internal } = setupApi();
+      const result = { profiles: [] };
+      internal.actors = { getProfiles: jest.fn().mockResolvedValue(result) };
+
+      await expect(api.getProfiles('jwt', ['did:a', 'did:b'], ['did:labeler'])).resolves.toBe(result);
+      expect(internal.actors.getProfiles).toHaveBeenCalledWith('jwt', ['did:a', 'did:b'], ['did:labeler']);
+    });
+
+    it('getSuggestions forwards the options object', async () => {
+      const { api, internal } = setupApi();
+      const result = { actors: [] };
+      internal.actors = { getSuggestions: jest.fn().mockResolvedValue(result) };
+
+      const options = { limit: 10, cursor: 'c1' };
+      await expect(api.getSuggestions('jwt', options)).resolves.toBe(result);
+      expect(internal.actors.getSuggestions).toHaveBeenCalledWith('jwt', options);
+    });
+
+    it('getSuggestions omits options when not provided', async () => {
+      const { api, internal } = setupApi();
+      const result = { actors: [] };
+      internal.actors = { getSuggestions: jest.fn().mockResolvedValue(result) };
+
+      await api.getSuggestions('jwt');
+      expect(internal.actors.getSuggestions).toHaveBeenCalledWith('jwt', undefined);
+    });
+
+    it('updateProfile forwards the profile data', async () => {
+      const { api, internal } = setupApi();
+      internal.actors = { updateProfile: jest.fn().mockResolvedValue(profile) };
+
+      const update: BlueskyProfileUpdateInput = { displayName: 'Alice' };
+      await expect(api.updateProfile('jwt', update)).resolves.toBe(profile);
+      expect(internal.actors.updateProfile).toHaveBeenCalledWith('jwt', update);
+    });
+
+    it('getPreferences forwards the access token', async () => {
+      const { api, internal } = setupApi();
+      const prefs = { preferences: [] } as BlueskyPreferencesResponse;
+      internal.actors = { getPreferences: jest.fn().mockResolvedValue(prefs) };
+
+      await expect(api.getPreferences('jwt')).resolves.toBe(prefs);
+      expect(internal.actors.getPreferences).toHaveBeenCalledWith('jwt');
+    });
+
+    it('putPreferences forwards the preference array', async () => {
+      const { api, internal } = setupApi();
+      internal.actors = { putPreferences: jest.fn().mockResolvedValue(undefined) };
+
+      const prefs = [{ $type: 'app.bsky.actor.defs#savedFeedsPrefV2' }] as unknown as BlueskyPreference[];
+      await api.putPreferences('jwt', prefs);
+      expect(internal.actors.putPreferences).toHaveBeenCalledWith('jwt', prefs);
+    });
+
+    it('getLabelerServices forwards dids and detailed flag', async () => {
+      const { api, internal } = setupApi();
+      const result = { views: [] };
+      internal.actors = { getLabelerServices: jest.fn().mockResolvedValue(result) };
+
+      await expect(api.getLabelerServices('jwt', ['did:labeler'], false)).resolves.toBe(result);
+      expect(internal.actors.getLabelerServices).toHaveBeenCalledWith('jwt', ['did:labeler'], false);
+    });
+
+    it('getLabelerServices defaults detailed to true', async () => {
+      const { api, internal } = setupApi();
+      const result = { views: [] };
+      internal.actors = { getLabelerServices: jest.fn().mockResolvedValue(result) };
+
+      await api.getLabelerServices('jwt', ['did:labeler']);
+      expect(internal.actors.getLabelerServices).toHaveBeenCalledWith('jwt', ['did:labeler'], true);
+    });
+
+    it('setPinnedPost forwards the pinned ref', async () => {
+      const { api, internal } = setupApi();
+      const result = { uri: 'at://profile' };
+      internal.actors = { setPinnedPost: jest.fn().mockResolvedValue(result) };
+
+      const pinned = { uri: 'at://post/1', cid: 'cid1' };
+      await expect(api.setPinnedPost('jwt', 'did:example:me', pinned)).resolves.toBe(result);
+      expect(internal.actors.setPinnedPost).toHaveBeenCalledWith('jwt', 'did:example:me', pinned);
+    });
+
+    it('setPinnedPost forwards null to clear the pin', async () => {
+      const { api, internal } = setupApi();
+      internal.actors = { setPinnedPost: jest.fn().mockResolvedValue({}) };
+
+      await api.setPinnedPost('jwt', 'did:example:me', null);
+      expect(internal.actors.setPinnedPost).toHaveBeenCalledWith('jwt', 'did:example:me', null);
+    });
+
+    it('getProfileRecord forwards jwt/userDid', async () => {
+      const { api, internal } = setupApi();
+      const result = { value: {} };
+      internal.actors = { getProfileRecord: jest.fn().mockResolvedValue(result) };
+
+      await expect(api.getProfileRecord('jwt', 'did:example:me')).resolves.toBe(result);
+      expect(internal.actors.getProfileRecord).toHaveBeenCalledWith('jwt', 'did:example:me');
+    });
+
+    it('setLoggedOutVisibilityDiscouraged forwards the discouraged flag', async () => {
+      const { api, internal } = setupApi();
+      internal.actors = { setLoggedOutVisibilityDiscouraged: jest.fn().mockResolvedValue({}) };
+
+      await api.setLoggedOutVisibilityDiscouraged('jwt', 'did:example:me', true);
+      expect(internal.actors.setLoggedOutVisibilityDiscouraged).toHaveBeenCalledWith('jwt', 'did:example:me', true);
+    });
+
+    it('setAccountAutomated forwards the automated flag', async () => {
+      const { api, internal } = setupApi();
+      internal.actors = { setAccountAutomated: jest.fn().mockResolvedValue({}) };
+
+      await api.setAccountAutomated('jwt', 'did:example:me', false);
+      expect(internal.actors.setAccountAutomated).toHaveBeenCalledWith('jwt', 'did:example:me', false);
+    });
+
+    it('setActorStatus forwards the status input', async () => {
+      const { api, internal } = setupApi();
+      internal.actors = { setActorStatus: jest.fn().mockResolvedValue(undefined) };
+
+      const input = {
+        durationMinutes: 30,
+        external: { uri: 'at://live', title: 'Live', description: 'desc' },
+        createdAt: '2026-01-01T00:00:00Z',
+      };
+      await api.setActorStatus('jwt', 'did:example:me', input);
+      expect(internal.actors.setActorStatus).toHaveBeenCalledWith('jwt', 'did:example:me', input);
+    });
+
+    it('clearActorStatus forwards jwt/userDid', async () => {
+      const { api, internal } = setupApi();
+      internal.actors = { clearActorStatus: jest.fn().mockResolvedValue(undefined) };
+
+      await api.clearActorStatus('jwt', 'did:example:me');
+      expect(internal.actors.clearActorStatus).toHaveBeenCalledWith('jwt', 'did:example:me');
+    });
+  });
+
+  describe('repos delegation', () => {
+    it('getActorRepos forwards limit/cursor', async () => {
+      const { api, internal } = setupApi();
+      const result = { records: [] } as unknown as BlueskyTangledReposResponse;
+      internal.repos = { getActorRepos: jest.fn().mockResolvedValue(result) };
+
+      await expect(api.getActorRepos('jwt', 'did:example', 25, 'c1')).resolves.toBe(result);
+      expect(internal.repos.getActorRepos).toHaveBeenCalledWith('jwt', 'did:example', 25, 'c1');
+    });
+
+    it('getActorRepos defaults limit to 50 and omits cursor', async () => {
+      const { api, internal } = setupApi();
+      const result = { records: [] } as unknown as BlueskyTangledReposResponse;
+      internal.repos = { getActorRepos: jest.fn().mockResolvedValue(result) };
+
+      await api.getActorRepos('jwt', 'did:example');
+      expect(internal.repos.getActorRepos).toHaveBeenCalledWith('jwt', 'did:example', 50, undefined);
+    });
+
+    it('getActorRecipes forwards limit/cursor', async () => {
+      const { api, internal } = setupApi();
+      const result = { records: [] } as unknown as BlueskyRecipeRecordsResponse;
+      internal.repos = { getActorRecipes: jest.fn().mockResolvedValue(result) };
+
+      await expect(api.getActorRecipes('jwt', 'did:example', 10, 'c2')).resolves.toBe(result);
+      expect(internal.repos.getActorRecipes).toHaveBeenCalledWith('jwt', 'did:example', 10, 'c2');
+    });
+
+    it('getActorRecipes defaults limit to 50', async () => {
+      const { api, internal } = setupApi();
+      const result = { records: [] } as unknown as BlueskyRecipeRecordsResponse;
+      internal.repos = { getActorRecipes: jest.fn().mockResolvedValue(result) };
+
+      await api.getActorRecipes('jwt', 'did:example');
+      expect(internal.repos.getActorRecipes).toHaveBeenCalledWith('jwt', 'did:example', 50, undefined);
+    });
+  });
+
+  describe('grain delegation', () => {
+    it('getActorGalleries -> grain.getActorGalleries with explicit args', async () => {
+      const { api, internal } = setupApi();
+      const result = { records: [] };
+      internal.grain = { getActorGalleries: jest.fn().mockResolvedValue(result) };
+
+      await expect(api.getActorGalleries('jwt', 'did:example', 20, 'c1')).resolves.toBe(result);
+      expect(internal.grain.getActorGalleries).toHaveBeenCalledWith('jwt', 'did:example', 20, 'c1');
+    });
+
+    it('getActorGalleries defaults limit to 50', async () => {
+      const { api, internal } = setupApi();
+      internal.grain = { getActorGalleries: jest.fn().mockResolvedValue({ records: [] }) };
+
+      await api.getActorGalleries('jwt', 'did:example');
+      expect(internal.grain.getActorGalleries).toHaveBeenCalledWith('jwt', 'did:example', 50, undefined);
+    });
+
+    it('getActorGrainPhotos -> grain.getActorPhotos (default limit 50)', async () => {
+      const { api, internal } = setupApi();
+      const result = { records: [] };
+      internal.grain = { getActorPhotos: jest.fn().mockResolvedValue(result) };
+
+      await expect(api.getActorGrainPhotos('jwt', 'did:example')).resolves.toBe(result);
+      expect(internal.grain.getActorPhotos).toHaveBeenCalledWith('jwt', 'did:example', 50, undefined);
+    });
+
+    it('getActorGrainPhotos forwards explicit limit/cursor', async () => {
+      const { api, internal } = setupApi();
+      internal.grain = { getActorPhotos: jest.fn().mockResolvedValue({ records: [] }) };
+
+      await api.getActorGrainPhotos('jwt', 'did:example', 5, 'c3');
+      expect(internal.grain.getActorPhotos).toHaveBeenCalledWith('jwt', 'did:example', 5, 'c3');
+    });
+
+    it('getActorGrainGalleryItems -> grain.getActorGalleryItems (default limit 100)', async () => {
+      const { api, internal } = setupApi();
+      const result = { records: [] };
+      internal.grain = { getActorGalleryItems: jest.fn().mockResolvedValue(result) };
+
+      await expect(api.getActorGrainGalleryItems('jwt', 'did:example')).resolves.toBe(result);
+      expect(internal.grain.getActorGalleryItems).toHaveBeenCalledWith('jwt', 'did:example', 100, undefined);
+    });
+
+    it('getActorGrainGalleryItems forwards explicit limit/cursor', async () => {
+      const { api, internal } = setupApi();
+      internal.grain = { getActorGalleryItems: jest.fn().mockResolvedValue({ records: [] }) };
+
+      await api.getActorGrainGalleryItems('jwt', 'did:example', 7, 'c4');
+      expect(internal.grain.getActorGalleryItems).toHaveBeenCalledWith('jwt', 'did:example', 7, 'c4');
+    });
+
+    it('getActorGrainPhotoExif -> grain.getActorPhotoExif (default limit 100)', async () => {
+      const { api, internal } = setupApi();
+      const result = { records: [] };
+      internal.grain = { getActorPhotoExif: jest.fn().mockResolvedValue(result) };
+
+      await expect(api.getActorGrainPhotoExif('jwt', 'did:example')).resolves.toBe(result);
+      expect(internal.grain.getActorPhotoExif).toHaveBeenCalledWith('jwt', 'did:example', 100, undefined);
+    });
+
+    it('getActorGrainPhotoExif forwards explicit limit/cursor', async () => {
+      const { api, internal } = setupApi();
+      internal.grain = { getActorPhotoExif: jest.fn().mockResolvedValue({ records: [] }) };
+
+      await api.getActorGrainPhotoExif('jwt', 'did:example', 9, 'c5');
+      expect(internal.grain.getActorPhotoExif).toHaveBeenCalledWith('jwt', 'did:example', 9, 'c5');
+    });
+  });
+
+  describe('flashes / spark delegation', () => {
+    it('getActorFlashesStories -> flashes.getActorStories (default limit 50)', async () => {
+      const { api, internal } = setupApi();
+      const result = { records: [] };
+      internal.flashes = { getActorStories: jest.fn().mockResolvedValue(result) };
+
+      await expect(api.getActorFlashesStories('jwt', 'did:example')).resolves.toBe(result);
+      expect(internal.flashes.getActorStories).toHaveBeenCalledWith('jwt', 'did:example', 50, undefined);
+    });
+
+    it('getActorFlashesStories forwards explicit limit/cursor', async () => {
+      const { api, internal } = setupApi();
+      internal.flashes = { getActorStories: jest.fn().mockResolvedValue({ records: [] }) };
+
+      await api.getActorFlashesStories('jwt', 'did:example', 12, 'c6');
+      expect(internal.flashes.getActorStories).toHaveBeenCalledWith('jwt', 'did:example', 12, 'c6');
+    });
+
+    it('getActorSparkStories -> spark.getActorStories (default limit 50)', async () => {
+      const { api, internal } = setupApi();
+      const result = { records: [] };
+      internal.spark = { getActorStories: jest.fn().mockResolvedValue(result) };
+
+      await expect(api.getActorSparkStories('jwt', 'did:example')).resolves.toBe(result);
+      expect(internal.spark.getActorStories).toHaveBeenCalledWith('jwt', 'did:example', 50, undefined);
+    });
+
+    it('getActorSparkStories forwards explicit limit/cursor', async () => {
+      const { api, internal } = setupApi();
+      internal.spark = { getActorStories: jest.fn().mockResolvedValue({ records: [] }) };
+
+      await api.getActorSparkStories('jwt', 'did:example', 3, 'c7');
+      expect(internal.spark.getActorStories).toHaveBeenCalledWith('jwt', 'did:example', 3, 'c7');
+    });
+  });
+
+  describe('poll delegation', () => {
+    it('createPoll -> poll.createPoll', async () => {
+      const { api, internal } = setupApi();
+      const result = { uri: 'at://poll/1', cid: 'cid1' };
+      internal.poll = { createPoll: jest.fn().mockResolvedValue(result) };
+
+      const input = { options: ['a', 'b'], endsAt: '2026-02-01T00:00:00Z' };
+      await expect(api.createPoll('jwt', 'did:example:me', input)).resolves.toBe(result);
+      expect(internal.poll.createPoll).toHaveBeenCalledWith('jwt', 'did:example:me', input);
+    });
+
+    it('createPollVote -> poll.createVote', async () => {
+      const { api, internal } = setupApi();
+      const result = { uri: 'at://vote/1', cid: 'cid2' };
+      internal.poll = { createVote: jest.fn().mockResolvedValue(result) };
+
+      const input = { poll: { uri: 'at://poll/1', cid: 'cid1' }, optionIndex: 1 };
+      await expect(api.createPollVote('jwt', 'did:example:me', input)).resolves.toBe(result);
+      expect(internal.poll.createVote).toHaveBeenCalledWith('jwt', 'did:example:me', input);
+    });
+  });
+
+  describe('rpg delegation', () => {
+    it('getActorRpgInventory -> rpg.getActorInventory (default limit 50)', async () => {
+      const { api, internal } = setupApi();
+      const result = { records: [] };
+      internal.rpg = { getActorInventory: jest.fn().mockResolvedValue(result) };
+
+      await expect(api.getActorRpgInventory('jwt', 'did:example')).resolves.toBe(result);
+      expect(internal.rpg.getActorInventory).toHaveBeenCalledWith('jwt', 'did:example', 50, undefined);
+    });
+
+    it('getActorRpgInventory forwards explicit limit/cursor', async () => {
+      const { api, internal } = setupApi();
+      internal.rpg = { getActorInventory: jest.fn().mockResolvedValue({ records: [] }) };
+
+      await api.getActorRpgInventory('jwt', 'did:example', 8, 'c8');
+      expect(internal.rpg.getActorInventory).toHaveBeenCalledWith('jwt', 'did:example', 8, 'c8');
+    });
+  });
+
+  describe('sifa delegation', () => {
+    it('getSifaProfileSelf -> sifa.getProfileSelf', async () => {
+      const { api, internal } = setupApi();
+      const result = { value: {} };
+      internal.sifa = { getProfileSelf: jest.fn().mockResolvedValue(result) };
+
+      await expect(api.getSifaProfileSelf('jwt', 'did:example')).resolves.toBe(result);
+      expect(internal.sifa.getProfileSelf).toHaveBeenCalledWith('jwt', 'did:example');
+    });
+
+    it('getSifaProfileSelf can resolve null', async () => {
+      const { api, internal } = setupApi();
+      internal.sifa = { getProfileSelf: jest.fn().mockResolvedValue(null) };
+
+      await expect(api.getSifaProfileSelf('jwt', 'did:example')).resolves.toBeNull();
+      expect(internal.sifa.getProfileSelf).toHaveBeenCalledWith('jwt', 'did:example');
+    });
+
+    it('getActorSifaPositions -> sifa.getActorPositions (default limit 50)', async () => {
+      const { api, internal } = setupApi();
+      const result = { records: [] };
+      internal.sifa = { getActorPositions: jest.fn().mockResolvedValue(result) };
+
+      await expect(api.getActorSifaPositions('jwt', 'did:example')).resolves.toBe(result);
+      expect(internal.sifa.getActorPositions).toHaveBeenCalledWith('jwt', 'did:example', 50, undefined);
+    });
+
+    it('getActorSifaPositions forwards explicit limit/cursor', async () => {
+      const { api, internal } = setupApi();
+      internal.sifa = { getActorPositions: jest.fn().mockResolvedValue({ records: [] }) };
+
+      await api.getActorSifaPositions('jwt', 'did:example', 6, 'c9');
+      expect(internal.sifa.getActorPositions).toHaveBeenCalledWith('jwt', 'did:example', 6, 'c9');
+    });
+
+    it('getActorSifaEducation -> sifa.getActorEducation (default limit 50)', async () => {
+      const { api, internal } = setupApi();
+      const result = { records: [] };
+      internal.sifa = { getActorEducation: jest.fn().mockResolvedValue(result) };
+
+      await expect(api.getActorSifaEducation('jwt', 'did:example')).resolves.toBe(result);
+      expect(internal.sifa.getActorEducation).toHaveBeenCalledWith('jwt', 'did:example', 50, undefined);
+    });
+
+    it('getActorSifaEducation forwards explicit limit/cursor', async () => {
+      const { api, internal } = setupApi();
+      internal.sifa = { getActorEducation: jest.fn().mockResolvedValue({ records: [] }) };
+
+      await api.getActorSifaEducation('jwt', 'did:example', 4, 'c10');
+      expect(internal.sifa.getActorEducation).toHaveBeenCalledWith('jwt', 'did:example', 4, 'c10');
+    });
+  });
+});

--- a/packages/bluesky-api/src/api.facade-part2.test.ts
+++ b/packages/bluesky-api/src/api.facade-part2.test.ts
@@ -1,0 +1,1285 @@
+import { BlueskyApi } from './api';
+import type { AiPreferencesRecord } from './repos';
+import type {
+  BlueskyBookmarksResponse,
+  BlueskyConvosResponse,
+  BlueskyCreatePostInput,
+  BlueskyCreatePostResponse,
+  BlueskyFeedGeneratorsResponse,
+  BlueskyFeedResponse,
+  BlueskyFeedsResponse,
+  BlueskyLinkatBoardResponse,
+  BlueskyMessagesResponse,
+  BlueskyNotificationsResponse,
+  BlueskyPostView,
+  BlueskySearchActorsResponse,
+  BlueskySearchPostsResponse,
+  BlueskySendMessageInput,
+  BlueskySendMessageResponse,
+  BlueskyStarterPacksResponse,
+  BlueskyThreadResponse,
+  BlueskyTrendingTopicsResponse,
+  BlueskyUnreadNotificationCount,
+  BlueskyUploadBlobResponse,
+  CreateReviewInput,
+} from './types';
+
+const LABELER_HEADER = 'did:plc:ar7c4by46qjdydhdevvrndac;redact';
+
+type RequestOptions = {
+  method?: 'GET' | 'POST';
+  body?: Record<string, unknown> | FormData | Blob;
+  params?: Record<string, string | string[]>;
+  headers?: Record<string, string>;
+};
+
+type AuthCall = { endpoint: string; accessJwt: string; options: RequestOptions };
+type RequestCall = { endpoint: string; options: RequestOptions };
+type UploadBlobCall = { accessJwt: string; blob: Blob; mimeType: string };
+
+/**
+ * The BlueskyApi facade delegates every method to a private sub-module
+ * instance (this.feeds, this.graph, ...). Each of those sub-modules has its
+ * own copy of the protected request helpers inherited from BlueskyApiClient.
+ * To capture the real endpoint/params/body produced by the sub-module logic,
+ * we replace each sub-module instance's protected helpers with capturing
+ * functions that share a single response queue and call log.
+ */
+class TestApi extends BlueskyApi {
+  public authCalls: AuthCall[] = [];
+  public requestCalls: RequestCall[] = [];
+  public uploadBlobCalls: UploadBlobCall[] = [];
+  public responses: unknown[] = [];
+  public uploadBlobResponses: BlueskyUploadBlobResponse[] = [];
+
+  constructor() {
+    super('https://pds.example');
+
+    const submoduleNames = [
+      'actors',
+      'auth',
+      'conversations',
+      'drafts',
+      'feeds',
+      'graph',
+      'grain',
+      'flashes',
+      'spark',
+      'poll',
+      'leaflet',
+      'notifications',
+      'search',
+      'repos',
+      'rpg',
+      'sifa',
+    ];
+
+    const self = this;
+    const store = this as unknown as Record<string, Record<string, unknown>>;
+
+    for (const name of submoduleNames) {
+      const submodule = store[name];
+      if (!submodule) continue;
+
+      submodule.makeAuthenticatedRequest = async function <T>(
+        endpoint: string,
+        accessJwt: string,
+        options: RequestOptions = {},
+      ): Promise<T> {
+        self.authCalls.push({ endpoint, accessJwt, options });
+        return (self.responses.shift() as T) ?? (undefined as T);
+      };
+
+      submodule.makeRequest = async function <T>(
+        endpoint: string,
+        options: RequestOptions = {},
+      ): Promise<T> {
+        self.requestCalls.push({ endpoint, options });
+        return (self.responses.shift() as T) ?? (undefined as T);
+      };
+
+      submodule.uploadBlob = async function (
+        accessJwt: string,
+        blob: Blob,
+        mimeType: string,
+      ): Promise<BlueskyUploadBlobResponse> {
+        self.uploadBlobCalls.push({ accessJwt, blob, mimeType });
+        const response = self.uploadBlobResponses.shift();
+        if (!response) {
+          throw new Error('No uploadBlob response configured');
+        }
+        return response;
+      };
+    }
+  }
+}
+
+describe('BlueskyApi facade (part 2)', () => {
+  describe('repos / linkat / reviews / ai preferences', () => {
+    it('getActorLinkatBoards forwards repo/collection/limit and a cursor', async () => {
+      const api = new TestApi();
+      const response = { records: [] } as unknown as BlueskyLinkatBoardResponse;
+      api.responses = [response];
+
+      const result = await api.getActorLinkatBoards('jwt', 'did:example:alice', 30, 'cursor-1');
+
+      expect(result).toBe(response);
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/com.atproto.repo.listRecords',
+        accessJwt: 'jwt',
+        options: {
+          params: {
+            repo: 'did:example:alice',
+            collection: 'blue.linkat.board',
+            limit: '30',
+            cursor: 'cursor-1',
+          },
+        },
+      });
+    });
+
+    it('getActorLinkatBoards uses the default limit and omits cursor', async () => {
+      const api = new TestApi();
+      api.responses = [{ records: [] }];
+
+      await api.getActorLinkatBoards('jwt', 'did:example:bob');
+
+      expect(api.authCalls[0].options.params).toEqual({
+        repo: 'did:example:bob',
+        collection: 'blue.linkat.board',
+        limit: '50',
+      });
+    });
+
+    it('getActorLinkatBoards swallows errors and returns an empty page', async () => {
+      const api = new TestApi();
+      const store = api as unknown as Record<string, Record<string, unknown>>;
+      store.repos.makeAuthenticatedRequest = async () => {
+        throw new Error('boom');
+      };
+
+      const result = await api.getActorLinkatBoards('jwt', 'did:example:carol');
+
+      expect(result).toEqual({ records: [], cursor: undefined });
+    });
+
+    it('createReview builds the record with required and optional fields', async () => {
+      const api = new TestApi();
+      const response = { uri: 'at://review/1' } as unknown as BlueskyCreatePostResponse;
+      api.responses = [response];
+      const review: CreateReviewInput = {
+        identifiers: { tmdbId: '603' },
+        creativeWorkType: 'movie',
+        rating: 5,
+        text: 'Great film',
+        title: 'The Matrix',
+        tags: ['scifi'],
+      };
+
+      const result = await api.createReview('jwt', 'did:example:me', review);
+
+      expect(result).toBe(response);
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.repo.createRecord');
+      expect(call.options.method).toBe('POST');
+      const body = call.options.body as { repo: string; collection: string; record: Record<string, unknown> };
+      expect(body.repo).toBe('did:example:me');
+      expect(body.collection).toBe('social.popfeed.feed.review');
+      expect(body.record).toMatchObject({
+        $type: 'social.popfeed.feed.review',
+        identifiers: { tmdbId: '603' },
+        creativeWorkType: 'movie',
+        rating: 5,
+        text: 'Great film',
+        title: 'The Matrix',
+        tags: ['scifi'],
+      });
+      expect(typeof body.record.createdAt).toBe('string');
+      expect(body.record).not.toHaveProperty('genres');
+    });
+
+    it('getAiPreferences unwraps the record value', async () => {
+      const api = new TestApi();
+      const record: AiPreferencesRecord = {
+        $type: 'community.lexicon.preference.ai',
+        preferences: {
+          embedding: { allow: true, updatedAt: 'now' },
+          inference: { allow: false, updatedAt: 'now' },
+          syntheticContent: { allow: false, updatedAt: 'now' },
+          training: { allow: true, updatedAt: 'now' },
+        },
+        scope: { $type: 'community.lexicon.preference.ai#globalScope' },
+        updatedAt: 'now',
+      };
+      api.responses = [{ uri: 'at://ai/1', cid: 'cid', value: record }];
+
+      const result = await api.getAiPreferences('jwt', 'did:example:me');
+
+      expect(result).toBe(record);
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/com.atproto.repo.getRecord',
+        accessJwt: 'jwt',
+        options: {
+          params: {
+            repo: 'did:example:me',
+            collection: 'community.lexicon.preference.ai',
+            rkey: 'self',
+          },
+        },
+      });
+    });
+
+    it('getAiPreferences returns null when the record is missing', async () => {
+      const api = new TestApi();
+      const store = api as unknown as Record<string, Record<string, unknown>>;
+      store.repos.makeAuthenticatedRequest = async () => {
+        throw { errorCode: 'RecordNotFound' };
+      };
+
+      await expect(api.getAiPreferences('jwt', 'did:example:me')).resolves.toBeNull();
+    });
+
+    it('putAiPreferences writes the record at rkey self', async () => {
+      const api = new TestApi();
+      const record: AiPreferencesRecord = {
+        $type: 'community.lexicon.preference.ai',
+        preferences: {
+          embedding: { allow: true, updatedAt: 'now' },
+          inference: { allow: true, updatedAt: 'now' },
+          syntheticContent: { allow: true, updatedAt: 'now' },
+          training: { allow: true, updatedAt: 'now' },
+        },
+        scope: { $type: 'community.lexicon.preference.ai#globalScope' },
+        updatedAt: 'now',
+      };
+      api.responses = [{ uri: 'at://ai/1', cid: 'cid' }];
+
+      await api.putAiPreferences('jwt', 'did:example:me', record);
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/com.atproto.repo.putRecord',
+        accessJwt: 'jwt',
+        options: {
+          method: 'POST',
+          body: {
+            repo: 'did:example:me',
+            collection: 'community.lexicon.preference.ai',
+            rkey: 'self',
+            record,
+          },
+        },
+      });
+    });
+  });
+
+  describe('feeds', () => {
+    it('getTimeline defaults to limit 20 with the baseline labeler header', async () => {
+      const api = new TestApi();
+      const response = { feed: [] } as unknown as BlueskyFeedResponse;
+      api.responses = [response];
+
+      const result = await api.getTimeline('jwt');
+
+      expect(result).toBe(response);
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/app.bsky.feed.getTimeline');
+      expect(call.accessJwt).toBe('jwt');
+      expect(call.options.params).toEqual({ limit: '20' });
+      expect(call.options.headers?.['atproto-accept-labelers']).toBe(LABELER_HEADER);
+    });
+
+    it('getTrendingTopics is unauthenticated and honours a custom limit', async () => {
+      const api = new TestApi();
+      const response = { topics: [] } as unknown as BlueskyTrendingTopicsResponse;
+      api.responses = [response];
+
+      const result = await api.getTrendingTopics(5);
+
+      expect(result).toBe(response);
+      expect(api.authCalls).toHaveLength(0);
+      expect(api.requestCalls[0]).toEqual({
+        endpoint: '/app.bsky.unspecced.getTrendingTopics',
+        options: { params: { limit: '5' } },
+      });
+    });
+
+    it('getFeeds forwards actor/limit and an optional cursor', async () => {
+      const api = new TestApi();
+      const response = { feeds: [] } as unknown as BlueskyFeedsResponse;
+      api.responses = [response];
+
+      const result = await api.getFeeds('jwt', 'did:example:alice', 25, 'cursor-1');
+
+      expect(result).toBe(response);
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.feed.getActorFeeds',
+        accessJwt: 'jwt',
+        options: { params: { actor: 'did:example:alice', limit: '25', cursor: 'cursor-1' } },
+      });
+    });
+
+    it('getFeed targets the feed generator with the labeler header', async () => {
+      const api = new TestApi();
+      const response = { feed: [] } as unknown as BlueskyFeedResponse;
+      api.responses = [response];
+
+      const result = await api.getFeed('jwt', 'at://feed/1', 30);
+
+      expect(result).toBe(response);
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/app.bsky.feed.getFeed');
+      expect(call.options.params).toEqual({ feed: 'at://feed/1', limit: '30' });
+      expect(call.options.headers?.['atproto-accept-labelers']).toBe(LABELER_HEADER);
+    });
+
+    it('getFeedGenerators forwards the feeds array', async () => {
+      const api = new TestApi();
+      const response = { feeds: [] } as unknown as BlueskyFeedGeneratorsResponse;
+      api.responses = [response];
+
+      const result = await api.getFeedGenerators('jwt', ['at://feed/a', 'at://feed/b']);
+
+      expect(result).toBe(response);
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.feed.getFeedGenerators',
+        accessJwt: 'jwt',
+        options: { params: { feeds: ['at://feed/a', 'at://feed/b'] } },
+      });
+    });
+
+    it('getBookmarks forwards limit/cursor and the labeler header', async () => {
+      const api = new TestApi();
+      const response = { bookmarks: [] } as unknown as BlueskyBookmarksResponse;
+      api.responses = [response];
+
+      const result = await api.getBookmarks('jwt', 40, 'cursor-1');
+
+      expect(result).toBe(response);
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/app.bsky.bookmark.getBookmarks');
+      expect(call.options.params).toEqual({ limit: '40', cursor: 'cursor-1' });
+      expect(call.options.headers?.['atproto-accept-labelers']).toBe(LABELER_HEADER);
+    });
+
+    it('createBookmark posts a flat {uri, cid} body', async () => {
+      const api = new TestApi();
+      api.responses = [undefined];
+
+      await api.createBookmark('jwt', 'at://post/1', 'cid1');
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.bookmark.createBookmark',
+        accessJwt: 'jwt',
+        options: { method: 'POST', body: { uri: 'at://post/1', cid: 'cid1' } },
+      });
+    });
+
+    it('deleteBookmark posts only the uri', async () => {
+      const api = new TestApi();
+      api.responses = [undefined];
+
+      await api.deleteBookmark('jwt', 'at://post/1');
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.bookmark.deleteBookmark',
+        accessJwt: 'jwt',
+        options: { method: 'POST', body: { uri: 'at://post/1' } },
+      });
+    });
+
+    it('getPost extracts the post from the thread', async () => {
+      const api = new TestApi();
+      const post = { uri: 'at://post/1' } as unknown as BlueskyPostView;
+      api.responses = [{ thread: { post } }];
+
+      const result = await api.getPost('jwt', 'at://post/1');
+
+      expect(result).toBe(post);
+      expect(api.authCalls[0].endpoint).toBe('/app.bsky.feed.getPostThread');
+      expect(api.authCalls[0].options.params).toEqual({ uri: 'at://post/1' });
+    });
+
+    it('getPosts forwards the (capped) uri list with the labeler header', async () => {
+      const api = new TestApi();
+      const response = { posts: [] };
+      api.responses = [response];
+
+      const result = await api.getPosts('jwt', ['at://post/1', 'at://post/2']);
+
+      expect(result).toBe(response);
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/app.bsky.feed.getPosts');
+      expect(call.options.params).toEqual({ uris: ['at://post/1', 'at://post/2'] });
+      expect(call.options.headers?.['atproto-accept-labelers']).toBe(LABELER_HEADER);
+    });
+
+    it('getPosts short-circuits to an empty page for an empty uri list', async () => {
+      const api = new TestApi();
+
+      const result = await api.getPosts('jwt', []);
+
+      expect(result).toEqual({ posts: [] });
+      expect(api.authCalls).toHaveLength(0);
+    });
+
+    it('getPostThread fetches the full thread', async () => {
+      const api = new TestApi();
+      const response = { thread: {} } as unknown as BlueskyThreadResponse;
+      api.responses = [response];
+
+      const result = await api.getPostThread('jwt', 'at://post/1');
+
+      expect(result).toBe(response);
+      expect(api.authCalls[0].endpoint).toBe('/app.bsky.feed.getPostThread');
+      expect(api.authCalls[0].options.params).toEqual({ uri: 'at://post/1' });
+    });
+
+    it('getAuthorFeed forwards actor/limit/cursor/filter', async () => {
+      const api = new TestApi();
+      const response = { feed: [] } as unknown as BlueskyFeedResponse;
+      api.responses = [response];
+
+      const result = await api.getAuthorFeed('jwt', 'did:example:alice', 10, 'cursor-1', 'posts_with_media');
+
+      expect(result).toBe(response);
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/app.bsky.feed.getAuthorFeed');
+      expect(call.options.params).toEqual({
+        actor: 'did:example:alice',
+        limit: '10',
+        cursor: 'cursor-1',
+        filter: 'posts_with_media',
+      });
+    });
+
+    it('getAuthorVideos forces the video filter', async () => {
+      const api = new TestApi();
+      const response = { feed: [] } as unknown as BlueskyFeedResponse;
+      api.responses = [response];
+
+      const result = await api.getAuthorVideos('jwt', 'did:example:bob', 5);
+
+      expect(result).toBe(response);
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/app.bsky.feed.getAuthorFeed');
+      expect(call.options.params).toMatchObject({
+        actor: 'did:example:bob',
+        limit: '5',
+        filter: 'posts_with_video',
+      });
+    });
+
+    it('getAuthorFeeds lists actor feeds', async () => {
+      const api = new TestApi();
+      const response = { feeds: [] } as unknown as BlueskyFeedsResponse;
+      api.responses = [response];
+
+      const result = await api.getAuthorFeeds('jwt', 'did:example:carol', 15);
+
+      expect(result).toBe(response);
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.feed.getActorFeeds',
+        accessJwt: 'jwt',
+        options: { params: { actor: 'did:example:carol', limit: '15' } },
+      });
+    });
+
+    it('getAuthorStarterpacks lists starter packs', async () => {
+      const api = new TestApi();
+      const response = { starterPacks: [] } as unknown as BlueskyStarterPacksResponse;
+      api.responses = [response];
+
+      const result = await api.getAuthorStarterpacks('jwt', 'did:example:carol', 15);
+
+      expect(result).toBe(response);
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.graph.getActorStarterPacks',
+        accessJwt: 'jwt',
+        options: { params: { actor: 'did:example:carol', limit: '15' } },
+      });
+    });
+
+    it('createPost builds a text-only record with default langs', async () => {
+      const api = new TestApi();
+      const response = { uri: 'at://post/created' } as unknown as BlueskyCreatePostResponse;
+      api.responses = [response];
+      const input: BlueskyCreatePostInput = { text: 'Hello world' };
+
+      const result = await api.createPost('jwt', 'did:example:me', input);
+
+      expect(result).toBe(response);
+      const body = api.authCalls[0].options.body as { record: Record<string, unknown> };
+      expect(body.record).toMatchObject({
+        text: 'Hello world',
+        $type: 'app.bsky.feed.post',
+        langs: ['en'],
+      });
+    });
+
+    it('setThreadgate writes a nobody record with an empty allow list', async () => {
+      const api = new TestApi();
+      api.responses = [{ uri: 'at://gate/1' }];
+
+      await api.setThreadgate('jwt', 'did:example:me', 'at://did:example:me/app.bsky.feed.post/abc', {
+        type: 'nobody',
+      });
+
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.repo.putRecord');
+      const body = call.options.body as { repo: string; collection: string; rkey: string; record: Record<string, unknown> };
+      expect(body.repo).toBe('did:example:me');
+      expect(body.collection).toBe('app.bsky.feed.threadgate');
+      expect(body.rkey).toBe('abc');
+      expect(body.record.allow).toEqual([]);
+    });
+
+    it('setThreadgate maps limited rules to lexicon rule objects', async () => {
+      const api = new TestApi();
+      api.responses = [{ uri: 'at://gate/1' }];
+
+      await api.setThreadgate('jwt', 'did:example:me', 'at://did:example:me/app.bsky.feed.post/abc', {
+        type: 'limited',
+        mention: true,
+        following: true,
+        listUris: ['at://list/1'],
+      });
+
+      const body = api.authCalls[0].options.body as { record: Record<string, unknown> };
+      expect(body.record.allow).toEqual([
+        { $type: 'app.bsky.feed.threadgate#mentionRule' },
+        { $type: 'app.bsky.feed.threadgate#followingRule' },
+        { $type: 'app.bsky.feed.threadgate#listRule', list: 'at://list/1' },
+      ]);
+    });
+
+    it('setPostgate disables quotes when allowQuote is false', async () => {
+      const api = new TestApi();
+      api.responses = [{ uri: 'at://postgate/1' }];
+
+      await api.setPostgate('jwt', 'did:example:me', 'at://did:example:me/app.bsky.feed.post/abc', {
+        allowQuote: false,
+      });
+
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.repo.putRecord');
+      const body = call.options.body as { collection: string; rkey: string; record: Record<string, unknown> };
+      expect(body.collection).toBe('app.bsky.feed.postgate');
+      expect(body.rkey).toBe('abc');
+      expect(body.record.embeddingRules).toEqual([{ $type: 'app.bsky.feed.postgate#disableRule' }]);
+    });
+
+    it('setPostgate leaves quotes enabled with an empty rule list', async () => {
+      const api = new TestApi();
+      api.responses = [{ uri: 'at://postgate/1' }];
+
+      await api.setPostgate('jwt', 'did:example:me', 'at://did:example:me/app.bsky.feed.post/abc', {
+        allowQuote: true,
+      });
+
+      const body = api.authCalls[0].options.body as { record: Record<string, unknown> };
+      expect(body.record.embeddingRules).toEqual([]);
+    });
+
+    it('uploadImage fetches the URI then uploads the blob with its mime type', async () => {
+      const api = new TestApi();
+      const imageBlob = new Blob(['image-data'], { type: 'image/png' });
+      const uploadResponse: BlueskyUploadBlobResponse = {
+        blob: { ref: { $link: 'blob/png' }, mimeType: 'image/png', size: 1234 },
+      };
+      api.uploadBlobResponses = [uploadResponse];
+      const fetchSpy = jest.spyOn(globalThis, 'fetch').mockResolvedValue({
+        blob: async () => imageBlob,
+      } as unknown as Response);
+
+      const result = await api.uploadImage('jwt', 'file://image.png', 'image/png');
+
+      expect(result).toBe(uploadResponse);
+      expect(fetchSpy).toHaveBeenCalledWith('file://image.png');
+      expect(api.uploadBlobCalls).toEqual([{ accessJwt: 'jwt', blob: imageBlob, mimeType: 'image/png' }]);
+
+      fetchSpy.mockRestore();
+    });
+
+    it('likePost creates a like record', async () => {
+      const api = new TestApi();
+      api.responses = [{ uri: 'at://like/1' }];
+
+      const result = await api.likePost('jwt', 'at://post/5', 'cid123', 'did:example:me');
+
+      expect(result).toEqual({ uri: 'at://like/1' });
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.repo.createRecord');
+      expect(call.options.body).toMatchObject({
+        repo: 'did:example:me',
+        collection: 'app.bsky.feed.like',
+        record: { subject: { uri: 'at://post/5', cid: 'cid123' }, $type: 'app.bsky.feed.like' },
+      });
+    });
+
+    it('unlikePost deletes the like record by rkey', async () => {
+      const api = new TestApi();
+      api.responses = [{ success: true }];
+
+      await api.unlikePost('jwt', 'at://did:example:me/app.bsky.feed.like/123', 'did:example:me');
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/com.atproto.repo.deleteRecord',
+        accessJwt: 'jwt',
+        options: {
+          method: 'POST',
+          body: { collection: 'app.bsky.feed.like', repo: 'did:example:me', rkey: '123' },
+        },
+      });
+    });
+
+    it('repostPost creates a repost record', async () => {
+      const api = new TestApi();
+      api.responses = [{ uri: 'at://repost/1' }];
+
+      await api.repostPost('jwt', 'at://post/5', 'cid123', 'did:example:me');
+
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.repo.createRecord');
+      expect(call.options.body).toMatchObject({
+        repo: 'did:example:me',
+        collection: 'app.bsky.feed.repost',
+        record: { subject: { uri: 'at://post/5', cid: 'cid123' }, $type: 'app.bsky.feed.repost' },
+      });
+    });
+
+    it('unrepostPost deletes the repost record by rkey', async () => {
+      const api = new TestApi();
+      api.responses = [{ success: true }];
+
+      await api.unrepostPost('jwt', 'at://did:example:me/app.bsky.feed.repost/999', 'did:example:me');
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/com.atproto.repo.deleteRecord',
+        accessJwt: 'jwt',
+        options: {
+          method: 'POST',
+          body: { collection: 'app.bsky.feed.repost', repo: 'did:example:me', rkey: '999' },
+        },
+      });
+    });
+
+    it('unrepostPost throws when the repost URI has no rkey', async () => {
+      const api = new TestApi();
+
+      await expect(api.unrepostPost('jwt', '', 'did:example:me')).rejects.toThrow(
+        'Invalid repost URI: could not extract rkey',
+      );
+    });
+
+    it('createReport reports an account via repoRef', async () => {
+      const api = new TestApi();
+      api.responses = [{ id: 1 }];
+
+      await api.createReport('jwt', { did: 'did:example:bad' }, 'spam', 'because');
+
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.moderation.createReport');
+      expect(call.options.body).toEqual({
+        reasonType: 'com.atproto.moderation.defs#spam',
+        reason: 'because',
+        subject: { $type: 'com.atproto.admin.defs#repoRef', did: 'did:example:bad' },
+      });
+      expect(call.options.headers).toBeUndefined();
+    });
+
+    it('createReport reports a post via strongRef and routes to a labeler', async () => {
+      const api = new TestApi();
+      api.responses = [{ id: 2 }];
+
+      await api.createReport('jwt', { uri: 'at://post/1', cid: 'cid1' }, 'violation', undefined, 'did:example:labeler');
+
+      const call = api.authCalls[0];
+      expect(call.options.body).toMatchObject({
+        reasonType: 'com.atproto.moderation.defs#violation',
+        subject: { $type: 'com.atproto.repo.strongRef', uri: 'at://post/1', cid: 'cid1' },
+      });
+      expect(call.options.headers).toEqual({ 'atproto-proxy': 'did:example:labeler#atproto_labeler' });
+    });
+
+    it('sendInteractions proxies events to the feed generator', async () => {
+      const api = new TestApi();
+      api.responses = [{}];
+      const interactions = [{ event: 'app.bsky.feed.defs#requestMore', item: 'at://post/1' }];
+
+      await api.sendInteractions('jwt', 'did:example:fg', interactions);
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.feed.sendInteractions',
+        accessJwt: 'jwt',
+        options: {
+          method: 'POST',
+          body: { interactions },
+          headers: { 'atproto-proxy': 'did:example:fg#bsky_fg' },
+        },
+      });
+    });
+  });
+
+  describe('conversations', () => {
+    it('listConversations forwards limit and optional filters with the chat proxy', async () => {
+      const api = new TestApi();
+      const response = { convos: [] } as unknown as BlueskyConvosResponse;
+      api.responses = [response];
+
+      const result = await api.listConversations('jwt', 25, 'cursor-1', 'unread', 'accepted');
+
+      expect(result).toBe(response);
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/chat.bsky.convo.listConvos',
+        accessJwt: 'jwt',
+        options: {
+          params: { limit: '25', cursor: 'cursor-1', readState: 'unread', status: 'accepted' },
+          headers: { 'atproto-proxy': 'did:web:api.bsky.chat#bsky_chat' },
+        },
+      });
+    });
+
+    it('getMessages forwards convoId and limit', async () => {
+      const api = new TestApi();
+      const response = { messages: [] } as unknown as BlueskyMessagesResponse;
+      api.responses = [response];
+
+      const result = await api.getMessages('jwt', 'convo-1', 10);
+
+      expect(result).toBe(response);
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/chat.bsky.convo.getMessages');
+      expect(call.options.params).toEqual({ convoId: 'convo-1', limit: '10' });
+      expect(call.options.headers).toEqual({ 'atproto-proxy': 'did:web:api.bsky.chat#bsky_chat' });
+    });
+
+    it('sendMessage posts the message payload', async () => {
+      const api = new TestApi();
+      const response = { id: 'm1' } as unknown as BlueskySendMessageResponse;
+      api.responses = [response];
+      const message: BlueskySendMessageInput = { text: 'hi' };
+
+      const result = await api.sendMessage('jwt', 'convo-1', message);
+
+      expect(result).toBe(response);
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/chat.bsky.convo.sendMessage');
+      expect(call.options.method).toBe('POST');
+      expect(call.options.body).toEqual({ convoId: 'convo-1', message });
+      expect(call.options.headers).toEqual({ 'atproto-proxy': 'did:web:api.bsky.chat#bsky_chat' });
+    });
+
+    it('markConversationRead posts updateRead', async () => {
+      const api = new TestApi();
+      api.responses = [undefined];
+
+      await api.markConversationRead('jwt', 'convo-1');
+
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/chat.bsky.convo.updateRead');
+      expect(call.options.method).toBe('POST');
+      expect(call.options.body).toEqual({ convoId: 'convo-1' });
+    });
+
+    it('getConvoForMembers forwards the member DIDs', async () => {
+      const api = new TestApi();
+      api.responses = [{ convo: { id: 'c1' } }];
+
+      await api.getConvoForMembers('jwt', ['did:example:a', 'did:example:b']);
+
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/chat.bsky.convo.getConvoForMembers');
+      expect(call.options.params).toEqual({ members: ['did:example:a', 'did:example:b'] });
+    });
+
+    it('getConvo fetches a single convo by id', async () => {
+      const api = new TestApi();
+      api.responses = [{ convo: { id: 'c1' } }];
+
+      await api.getConvo('jwt', 'c1');
+
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/chat.bsky.convo.getConvo');
+      expect(call.options.params).toEqual({ convoId: 'c1' });
+    });
+
+    it('leaveConvo posts the convo id', async () => {
+      const api = new TestApi();
+      api.responses = [{}];
+
+      await api.leaveConvo('jwt', 'c1');
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/chat.bsky.convo.leaveConvo',
+        accessJwt: 'jwt',
+        options: {
+          method: 'POST',
+          headers: { 'atproto-proxy': 'did:web:api.bsky.chat#bsky_chat' },
+          body: { convoId: 'c1' },
+        },
+      });
+    });
+
+    it('addConvoMembers posts the dids', async () => {
+      const api = new TestApi();
+      api.responses = [{ convo: { id: 'c1' } }];
+
+      await api.addConvoMembers('jwt', 'c1', ['did:example:a']);
+
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/chat.bsky.convo.addMembers');
+      expect(call.options.body).toEqual({ convoId: 'c1', dids: ['did:example:a'] });
+    });
+
+    it('removeConvoMembers posts the dids', async () => {
+      const api = new TestApi();
+      api.responses = [{ convo: { id: 'c1' } }];
+
+      await api.removeConvoMembers('jwt', 'c1', ['did:example:a']);
+
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/chat.bsky.convo.removeMembers');
+      expect(call.options.body).toEqual({ convoId: 'c1', dids: ['did:example:a'] });
+    });
+
+    it('updateConvoName posts the new name', async () => {
+      const api = new TestApi();
+      api.responses = [{ convo: { id: 'c1' } }];
+
+      await api.updateConvoName('jwt', 'c1', 'Team chat');
+
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/chat.bsky.convo.updateConvoName');
+      expect(call.options.body).toEqual({ convoId: 'c1', name: 'Team chat' });
+    });
+
+    it('muteConvo and unmuteConvo hit their endpoints', async () => {
+      const api = new TestApi();
+      api.responses = [{ convo: { id: 'c1' } }, { convo: { id: 'c1' } }];
+
+      await api.muteConvo('jwt', 'c1');
+      await api.unmuteConvo('jwt', 'c1');
+
+      expect(api.authCalls[0].endpoint).toBe('/chat.bsky.convo.muteConvo');
+      expect(api.authCalls[0].options.body).toEqual({ convoId: 'c1' });
+      expect(api.authCalls[1].endpoint).toBe('/chat.bsky.convo.unmuteConvo');
+      expect(api.authCalls[1].options.body).toEqual({ convoId: 'c1' });
+    });
+
+    it('addReaction and removeReaction post convoId/messageId/value', async () => {
+      const api = new TestApi();
+      api.responses = [{}, {}];
+
+      await api.addReaction('jwt', 'c1', 'm1', '👍');
+      await api.removeReaction('jwt', 'c1', 'm1', '👍');
+
+      expect(api.authCalls[0].endpoint).toBe('/chat.bsky.convo.addReaction');
+      expect(api.authCalls[0].options.body).toEqual({ convoId: 'c1', messageId: 'm1', value: '👍' });
+      expect(api.authCalls[1].endpoint).toBe('/chat.bsky.convo.removeReaction');
+      expect(api.authCalls[1].options.body).toEqual({ convoId: 'c1', messageId: 'm1', value: '👍' });
+    });
+  });
+
+  describe('graph', () => {
+    it('followUser creates a follow record', async () => {
+      const api = new TestApi();
+      api.responses = [{ uri: 'at://follow/1' }];
+
+      await api.followUser('jwt', 'did:example:me', 'did:example:other');
+
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.repo.createRecord');
+      expect(call.options.body).toMatchObject({
+        repo: 'did:example:me',
+        collection: 'app.bsky.graph.follow',
+        record: { $type: 'app.bsky.graph.follow', subject: 'did:example:other' },
+      });
+    });
+
+    it('unfollowUser deletes the parsed follow record', async () => {
+      const api = new TestApi();
+      api.responses = [{}];
+
+      await api.unfollowUser('jwt', 'at://did:example:me/app.bsky.graph.follow/rk1');
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/com.atproto.repo.deleteRecord',
+        accessJwt: 'jwt',
+        options: {
+          method: 'POST',
+          body: { repo: 'did:example:me', collection: 'app.bsky.graph.follow', rkey: 'rk1' },
+        },
+      });
+    });
+
+    it('blockUser creates a block record', async () => {
+      const api = new TestApi();
+      api.responses = [{ uri: 'at://block/1' }];
+
+      await api.blockUser('jwt', 'did:example:me', 'did:example:other');
+
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.repo.createRecord');
+      expect(call.options.body).toMatchObject({
+        repo: 'did:example:me',
+        collection: 'app.bsky.graph.block',
+        record: { $type: 'app.bsky.graph.block', subject: 'did:example:other' },
+      });
+    });
+
+    it('unblockUser deletes the parsed block record', async () => {
+      const api = new TestApi();
+      api.responses = [{}];
+
+      await api.unblockUser('jwt', 'at://did:example:me/app.bsky.graph.block/rk2');
+
+      expect(api.authCalls[0].options.body).toEqual({
+        repo: 'did:example:me',
+        collection: 'app.bsky.graph.block',
+        rkey: 'rk2',
+      });
+    });
+
+    it('muteUser and unmuteUser post the actor', async () => {
+      const api = new TestApi();
+      api.responses = [{}, {}];
+
+      await api.muteUser('jwt', 'did:example:other');
+      await api.unmuteUser('jwt', 'did:example:other');
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.graph.muteActor',
+        accessJwt: 'jwt',
+        options: { method: 'POST', body: { actor: 'did:example:other' } },
+      });
+      expect(api.authCalls[1].endpoint).toBe('/app.bsky.graph.unmuteActor');
+      expect(api.authCalls[1].options.body).toEqual({ actor: 'did:example:other' });
+    });
+
+    it('muteActorList and unmuteActorList post the list uri', async () => {
+      const api = new TestApi();
+      api.responses = [{}, {}];
+
+      await api.muteActorList('jwt', 'at://list/1');
+      await api.unmuteActorList('jwt', 'at://list/1');
+
+      expect(api.authCalls[0].endpoint).toBe('/app.bsky.graph.muteActorList');
+      expect(api.authCalls[0].options.body).toEqual({ list: 'at://list/1' });
+      expect(api.authCalls[1].endpoint).toBe('/app.bsky.graph.unmuteActorList');
+      expect(api.authCalls[1].options.body).toEqual({ list: 'at://list/1' });
+    });
+
+    it('blockActorList creates a listblock record', async () => {
+      const api = new TestApi();
+      api.responses = [{ uri: 'at://listblock/1' }];
+
+      await api.blockActorList('jwt', 'did:example:me', 'at://list/1');
+
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.repo.createRecord');
+      expect(call.options.body).toMatchObject({
+        repo: 'did:example:me',
+        collection: 'app.bsky.graph.listblock',
+        record: { $type: 'app.bsky.graph.listblock', subject: 'at://list/1' },
+      });
+    });
+
+    it('unblockActorList deletes the parsed listblock record', async () => {
+      const api = new TestApi();
+      api.responses = [{}];
+
+      await api.unblockActorList('jwt', 'at://did:example:me/app.bsky.graph.listblock/rk3');
+
+      expect(api.authCalls[0].options.body).toEqual({
+        repo: 'did:example:me',
+        collection: 'app.bsky.graph.listblock',
+        rkey: 'rk3',
+      });
+    });
+
+    it('getMutes forwards limit and cursor', async () => {
+      const api = new TestApi();
+      api.responses = [{ mutes: [] }];
+
+      await api.getMutes('jwt', 10, 'cursor-1');
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.graph.getMutes',
+        accessJwt: 'jwt',
+        options: { params: { limit: '10', cursor: 'cursor-1' } },
+      });
+    });
+
+    it('getBlocks defaults the limit and omits cursor', async () => {
+      const api = new TestApi();
+      api.responses = [{ blocks: [] }];
+
+      await api.getBlocks('jwt');
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.graph.getBlocks',
+        accessJwt: 'jwt',
+        options: { params: { limit: '50' } },
+      });
+    });
+
+    it('getFollows forwards actor and default limit', async () => {
+      const api = new TestApi();
+      api.responses = [{ follows: [] }];
+
+      await api.getFollows('jwt', 'did:example:alice');
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.graph.getFollows',
+        accessJwt: 'jwt',
+        options: { params: { actor: 'did:example:alice', limit: '100' } },
+      });
+    });
+
+    it('listFollowRecords lists the follow collection records', async () => {
+      const api = new TestApi();
+      api.responses = [{ records: [] }];
+
+      await api.listFollowRecords('jwt', 'did:example:me', 50, 'cursor-1');
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/com.atproto.repo.listRecords',
+        accessJwt: 'jwt',
+        options: {
+          params: {
+            repo: 'did:example:me',
+            collection: 'app.bsky.graph.follow',
+            limit: '50',
+            cursor: 'cursor-1',
+          },
+        },
+      });
+    });
+
+    it('getListMutes and getListBlocks hit their endpoints', async () => {
+      const api = new TestApi();
+      api.responses = [{ lists: [] }, { lists: [] }];
+
+      await api.getListMutes('jwt');
+      await api.getListBlocks('jwt', 25);
+
+      expect(api.authCalls[0].endpoint).toBe('/app.bsky.graph.getListMutes');
+      expect(api.authCalls[0].options.params).toEqual({ limit: '50' });
+      expect(api.authCalls[1].endpoint).toBe('/app.bsky.graph.getListBlocks');
+      expect(api.authCalls[1].options.params).toEqual({ limit: '25' });
+    });
+
+    it('muteThread and unmuteThread post the root uri', async () => {
+      const api = new TestApi();
+      api.responses = [{}, {}];
+
+      await api.muteThread('jwt', 'at://post/root');
+      await api.unmuteThread('jwt', 'at://post/root');
+
+      expect(api.authCalls[0].endpoint).toBe('/app.bsky.graph.muteThread');
+      expect(api.authCalls[0].options.body).toEqual({ root: 'at://post/root' });
+      expect(api.authCalls[1].endpoint).toBe('/app.bsky.graph.unmuteThread');
+      expect(api.authCalls[1].options.body).toEqual({ root: 'at://post/root' });
+    });
+
+    it('getLists forwards actor and default limit', async () => {
+      const api = new TestApi();
+      api.responses = [{ lists: [] }];
+
+      await api.getLists('jwt', 'did:example:alice');
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.graph.getLists',
+        accessJwt: 'jwt',
+        options: { params: { actor: 'did:example:alice', limit: '50' } },
+      });
+    });
+
+    it('getList forwards the list uri, limit and cursor', async () => {
+      const api = new TestApi();
+      api.responses = [{ list: {}, items: [] }];
+
+      await api.getList('jwt', 'at://list/1', 20, 'cursor-1');
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.graph.getList',
+        accessJwt: 'jwt',
+        options: { params: { list: 'at://list/1', limit: '20', cursor: 'cursor-1' } },
+      });
+    });
+
+    it('createList creates a list record', async () => {
+      const api = new TestApi();
+      api.responses = [{ uri: 'at://list/1' }];
+
+      await api.createList('jwt', 'did:example:me', {
+        name: 'My list',
+        purpose: 'app.bsky.graph.defs#curatelist',
+        description: 'desc',
+      });
+
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.repo.createRecord');
+      expect(call.options.body).toMatchObject({
+        repo: 'did:example:me',
+        collection: 'app.bsky.graph.list',
+        record: {
+          $type: 'app.bsky.graph.list',
+          name: 'My list',
+          purpose: 'app.bsky.graph.defs#curatelist',
+          description: 'desc',
+        },
+      });
+    });
+
+    it('addToList creates a listitem record', async () => {
+      const api = new TestApi();
+      api.responses = [{ uri: 'at://listitem/1' }];
+
+      await api.addToList('jwt', 'did:example:me', 'at://list/1', 'did:example:other');
+
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.repo.createRecord');
+      expect(call.options.body).toMatchObject({
+        repo: 'did:example:me',
+        collection: 'app.bsky.graph.listitem',
+        record: { $type: 'app.bsky.graph.listitem', subject: 'did:example:other', list: 'at://list/1' },
+      });
+    });
+
+    it('removeFromList deletes by listitem uri', async () => {
+      const api = new TestApi();
+      api.responses = [{}];
+
+      await api.removeFromList('jwt', 'at://listitem/1');
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/com.atproto.repo.deleteRecord',
+        accessJwt: 'jwt',
+        options: { method: 'POST', body: { uri: 'at://listitem/1' } },
+      });
+    });
+  });
+
+  describe('search and notifications', () => {
+    it('searchProfiles forwards the query and default limit', async () => {
+      const api = new TestApi();
+      const response = { actors: [] } as unknown as BlueskySearchActorsResponse;
+      api.responses = [response];
+
+      const result = await api.searchProfiles('jwt', 'alice');
+
+      expect(result).toBe(response);
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.actor.searchActors',
+        accessJwt: 'jwt',
+        options: { params: { q: 'alice', limit: '20' } },
+      });
+    });
+
+    it('searchPosts forwards query, limit, cursor and sort', async () => {
+      const api = new TestApi();
+      const response = { posts: [] } as unknown as BlueskySearchPostsResponse;
+      api.responses = [response];
+
+      const result = await api.searchPosts('jwt', 'cats', 10, 'cursor-1', 'latest');
+
+      expect(result).toBe(response);
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.feed.searchPosts',
+        accessJwt: 'jwt',
+        options: { params: { q: 'cats', limit: '10', cursor: 'cursor-1', sort: 'latest' } },
+      });
+    });
+
+    it('listNotifications forwards limit, reasons, priority and seenAt', async () => {
+      const api = new TestApi();
+      const response = { notifications: [] } as unknown as BlueskyNotificationsResponse;
+      api.responses = [response];
+
+      const result = await api.listNotifications('jwt', 20, 'cursor-1', ['like', 'follow'], true, '2026-01-01');
+
+      expect(result).toBe(response);
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.notification.listNotifications',
+        accessJwt: 'jwt',
+        options: {
+          params: {
+            limit: '20',
+            cursor: 'cursor-1',
+            priority: 'true',
+            seenAt: '2026-01-01',
+            reasons: ['like', 'follow'],
+          },
+        },
+      });
+    });
+
+    it('listNotifications omits optional filters when not provided', async () => {
+      const api = new TestApi();
+      api.responses = [{ notifications: [] }];
+
+      await api.listNotifications('jwt');
+
+      expect(api.authCalls[0].options.params).toEqual({ limit: '50' });
+    });
+
+    it('getUnreadNotificationsCount hits the unread count endpoint', async () => {
+      const api = new TestApi();
+      const response = { count: 3 } as BlueskyUnreadNotificationCount;
+      api.responses = [response];
+
+      const result = await api.getUnreadNotificationsCount('jwt');
+
+      expect(result).toBe(response);
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.notification.getUnreadCount',
+        accessJwt: 'jwt',
+        options: {},
+      });
+    });
+
+    it('markNotificationsSeen posts a seenAt timestamp', async () => {
+      const api = new TestApi();
+      api.responses = [undefined];
+
+      await api.markNotificationsSeen('jwt');
+
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/app.bsky.notification.updateSeen');
+      expect(call.options.method).toBe('POST');
+      expect(typeof (call.options.body as { seenAt: string }).seenAt).toBe('string');
+    });
+
+    it('getNotificationPreferences unwraps the preferences field', async () => {
+      const api = new TestApi();
+      const prefs = { chat: { include: 'all' } };
+      api.responses = [{ preferences: prefs }];
+
+      const result = await api.getNotificationPreferences('jwt');
+
+      expect(result).toBe(prefs);
+      expect(api.authCalls[0].endpoint).toBe('/app.bsky.notification.getPreferences');
+    });
+
+    it('putNotificationPreferencesV2 posts the prefs', async () => {
+      const api = new TestApi();
+      api.responses = [undefined];
+      const prefs = { chat: { include: 'all', push: true } } as never;
+
+      await api.putNotificationPreferencesV2('jwt', prefs);
+
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/app.bsky.notification.putPreferencesV2');
+      expect(call.options.method).toBe('POST');
+      expect(call.options.body).toBe(prefs);
+    });
+  });
+
+  describe('static helper', () => {
+    it('createWithPDS returns a BlueskyApi instance', () => {
+      const api = BlueskyApi.createWithPDS('https://pds.example');
+      expect(api).toBeInstanceOf(BlueskyApi);
+    });
+  });
+});

--- a/packages/bluesky-api/src/api.facade-part2.test.ts
+++ b/packages/bluesky-api/src/api.facade-part2.test.ts
@@ -74,37 +74,36 @@ class TestApi extends BlueskyApi {
       'sifa',
     ];
 
-    const self = this;
     const store = this as unknown as Record<string, Record<string, unknown>>;
 
     for (const name of submoduleNames) {
       const submodule = store[name];
       if (!submodule) continue;
 
-      submodule.makeAuthenticatedRequest = async function <T>(
+      submodule.makeAuthenticatedRequest = async <T>(
         endpoint: string,
         accessJwt: string,
         options: RequestOptions = {},
-      ): Promise<T> {
-        self.authCalls.push({ endpoint, accessJwt, options });
-        return (self.responses.shift() as T) ?? (undefined as T);
+      ): Promise<T> => {
+        this.authCalls.push({ endpoint, accessJwt, options });
+        return (this.responses.shift() as T) ?? (undefined as T);
       };
 
-      submodule.makeRequest = async function <T>(
+      submodule.makeRequest = async <T>(
         endpoint: string,
         options: RequestOptions = {},
-      ): Promise<T> {
-        self.requestCalls.push({ endpoint, options });
-        return (self.responses.shift() as T) ?? (undefined as T);
+      ): Promise<T> => {
+        this.requestCalls.push({ endpoint, options });
+        return (this.responses.shift() as T) ?? (undefined as T);
       };
 
-      submodule.uploadBlob = async function (
+      submodule.uploadBlob = async (
         accessJwt: string,
         blob: Blob,
         mimeType: string,
-      ): Promise<BlueskyUploadBlobResponse> {
-        self.uploadBlobCalls.push({ accessJwt, blob, mimeType });
-        const response = self.uploadBlobResponses.shift();
+      ): Promise<BlueskyUploadBlobResponse> => {
+        this.uploadBlobCalls.push({ accessJwt, blob, mimeType });
+        const response = this.uploadBlobResponses.shift();
         if (!response) {
           throw new Error('No uploadBlob response configured');
         }

--- a/packages/bluesky-api/src/api.facade-part3.test.ts
+++ b/packages/bluesky-api/src/api.facade-part3.test.ts
@@ -1,0 +1,265 @@
+import { BlueskyApi } from './api';
+import type { CreateLeafletDocumentInput, CreateLeafletPublicationInput } from './leaflet';
+import type {
+  BlueskyCreateDraftResponse,
+  BlueskyDraft,
+  BlueskyGetDraftsResponse,
+  BlueskyUploadBlobResponse,
+} from './types';
+
+type RequestOptions = {
+  method?: 'GET' | 'POST';
+  body?: Record<string, unknown> | FormData | Blob;
+  params?: Record<string, string | string[]>;
+  headers?: Record<string, string>;
+};
+
+type AuthCall = { endpoint: string; accessJwt: string; options: RequestOptions };
+type RequestCall = { endpoint: string; options: RequestOptions };
+type UploadBlobCall = { accessJwt: string; blob: Blob; mimeType: string };
+
+/**
+ * Same capturing harness as api.facade-part2.test.ts: the BlueskyApi facade
+ * delegates to private sub-module instances (this.drafts, this.leaflet, ...),
+ * so we replace each sub-module's protected request helpers with capturing
+ * functions sharing a single response queue and call log.
+ */
+class TestApi extends BlueskyApi {
+  public authCalls: AuthCall[] = [];
+  public requestCalls: RequestCall[] = [];
+  public uploadBlobCalls: UploadBlobCall[] = [];
+  public responses: unknown[] = [];
+  public uploadBlobResponses: BlueskyUploadBlobResponse[] = [];
+
+  constructor() {
+    super('https://pds.example');
+
+    const submoduleNames = [
+      'actors',
+      'auth',
+      'conversations',
+      'drafts',
+      'feeds',
+      'graph',
+      'grain',
+      'flashes',
+      'spark',
+      'poll',
+      'leaflet',
+      'notifications',
+      'search',
+      'repos',
+      'rpg',
+      'sifa',
+    ];
+
+    const store = this as unknown as Record<string, Record<string, unknown>>;
+
+    for (const name of submoduleNames) {
+      const submodule = store[name];
+      if (!submodule) continue;
+
+      submodule.makeAuthenticatedRequest = async <T>(
+        endpoint: string,
+        accessJwt: string,
+        options: RequestOptions = {},
+      ): Promise<T> => {
+        this.authCalls.push({ endpoint, accessJwt, options });
+        return (this.responses.shift() as T) ?? (undefined as T);
+      };
+
+      submodule.makeRequest = async <T>(
+        endpoint: string,
+        options: RequestOptions = {},
+      ): Promise<T> => {
+        this.requestCalls.push({ endpoint, options });
+        return (this.responses.shift() as T) ?? (undefined as T);
+      };
+
+      submodule.uploadBlob = async (
+        accessJwt: string,
+        blob: Blob,
+        mimeType: string,
+      ): Promise<BlueskyUploadBlobResponse> => {
+        this.uploadBlobCalls.push({ accessJwt, blob, mimeType });
+        const response = this.uploadBlobResponses.shift();
+        if (!response) {
+          throw new Error('No uploadBlob response configured');
+        }
+        return response;
+      };
+    }
+  }
+}
+
+describe('BlueskyApi facade (part 3)', () => {
+  describe('drafts', () => {
+    it('getDrafts forwards limit and cursor', async () => {
+      const api = new TestApi();
+      const response = { drafts: [], cursor: 'next' } as unknown as BlueskyGetDraftsResponse;
+      api.responses = [response];
+
+      const result = await api.getDrafts('jwt', { limit: 10, cursor: 'cursor-1' });
+
+      expect(result).toBe(response);
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.draft.getDrafts',
+        accessJwt: 'jwt',
+        options: { params: { limit: '10', cursor: 'cursor-1' } },
+      });
+    });
+
+    it('getDrafts sends empty params when no options are provided', async () => {
+      const api = new TestApi();
+      api.responses = [{ drafts: [] }];
+
+      await api.getDrafts('jwt');
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.draft.getDrafts',
+        accessJwt: 'jwt',
+        options: { params: {} },
+      });
+    });
+
+    it('createDraft posts the draft wrapped in a draft field', async () => {
+      const api = new TestApi();
+      const response = { id: '3lab' } as unknown as BlueskyCreateDraftResponse;
+      api.responses = [response];
+      const draft = { text: 'hello' } as unknown as BlueskyDraft;
+
+      const result = await api.createDraft('jwt', draft);
+
+      expect(result).toBe(response);
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.draft.createDraft',
+        accessJwt: 'jwt',
+        options: { method: 'POST', body: { draft } },
+      });
+    });
+
+    it('updateDraft posts the nested {id, draft} payload', async () => {
+      const api = new TestApi();
+      api.responses = [undefined];
+      const draft = { text: 'updated' } as unknown as BlueskyDraft;
+
+      await api.updateDraft('jwt', '3lab', draft);
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.draft.updateDraft',
+        accessJwt: 'jwt',
+        options: { method: 'POST', body: { draft: { id: '3lab', draft } } },
+      });
+    });
+
+    it('deleteDraft posts only the id', async () => {
+      const api = new TestApi();
+      api.responses = [undefined];
+
+      await api.deleteDraft('jwt', '3lab');
+
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.draft.deleteDraft',
+        accessJwt: 'jwt',
+        options: { method: 'POST', body: { id: '3lab' } },
+      });
+    });
+  });
+
+  describe('leaflet', () => {
+    it('findOrCreateLeafletPublication returns the first existing publication', async () => {
+      const api = new TestApi();
+      api.responses = [
+        {
+          records: [
+            { uri: 'at://did:example:me/pub.leaflet.publication/abc', cid: 'cid1', value: { name: 'Mine' } },
+          ],
+        },
+      ];
+      const defaults: CreateLeafletPublicationInput = { name: 'New pub' };
+
+      const result = await api.findOrCreateLeafletPublication('jwt', 'did:example:me', defaults);
+
+      expect(result).toEqual({
+        uri: 'at://did:example:me/pub.leaflet.publication/abc',
+        cid: 'cid1',
+        rkey: 'abc',
+      });
+      // Only the listRecords lookup should have run; no createRecord.
+      expect(api.authCalls).toHaveLength(1);
+      expect(api.authCalls[0]).toEqual({
+        endpoint: '/com.atproto.repo.listRecords',
+        accessJwt: 'jwt',
+        options: {
+          params: { repo: 'did:example:me', collection: 'pub.leaflet.publication', limit: '10' },
+        },
+      });
+    });
+
+    it('findOrCreateLeafletPublication creates a publication when none exist', async () => {
+      const api = new TestApi();
+      api.responses = [
+        { records: [] },
+        { uri: 'at://did:example:me/pub.leaflet.publication/new', cid: 'cid2' },
+      ];
+      const defaults: CreateLeafletPublicationInput = { name: 'New pub', description: 'desc' };
+
+      const result = await api.findOrCreateLeafletPublication('jwt', 'did:example:me', defaults);
+
+      expect(result).toEqual({
+        uri: 'at://did:example:me/pub.leaflet.publication/new',
+        cid: 'cid2',
+        rkey: 'new',
+      });
+      const createCall = api.authCalls[1];
+      expect(createCall.endpoint).toBe('/com.atproto.repo.createRecord');
+      expect(createCall.options.method).toBe('POST');
+      const body = createCall.options.body as { repo: string; collection: string; record: Record<string, unknown> };
+      expect(body.repo).toBe('did:example:me');
+      expect(body.collection).toBe('pub.leaflet.publication');
+      expect(body.record).toEqual({
+        $type: 'pub.leaflet.publication',
+        name: 'New pub',
+        description: 'desc',
+      });
+    });
+
+    it('createLeafletDocument builds a linearDocument with text and header blocks', async () => {
+      const api = new TestApi();
+      api.responses = [{ uri: 'at://did:example:me/pub.leaflet.document/doc1', cid: 'cid3' }];
+      const input: CreateLeafletDocumentInput = {
+        title: 'My doc',
+        body: '# Heading\n\nFirst paragraph.\n\nSecond paragraph.',
+        publicationUri: 'at://did:example:me/pub.leaflet.publication/abc',
+        author: 'did:example:me',
+      };
+
+      const result = await api.createLeafletDocument('jwt', 'did:example:me', input);
+
+      expect(result).toEqual({
+        uri: 'at://did:example:me/pub.leaflet.document/doc1',
+        cid: 'cid3',
+        rkey: 'doc1',
+      });
+      const call = api.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.repo.createRecord');
+      const body = call.options.body as { repo: string; collection: string; record: Record<string, unknown> };
+      expect(body.repo).toBe('did:example:me');
+      expect(body.collection).toBe('pub.leaflet.document');
+      expect(body.record).toMatchObject({
+        $type: 'pub.leaflet.document',
+        title: 'My doc',
+        author: 'did:example:me',
+        publication: 'at://did:example:me/pub.leaflet.publication/abc',
+      });
+      expect(typeof body.record.publishedAt).toBe('string');
+      const pages = body.record.pages as { $type: string; blocks: { block: Record<string, unknown> }[] }[];
+      expect(pages[0].$type).toBe('pub.leaflet.pages.linearDocument');
+      expect(pages[0].blocks).toEqual([
+        { block: { $type: 'pub.leaflet.blocks.header', level: 1, plaintext: 'Heading' } },
+        { block: { $type: 'pub.leaflet.blocks.text', plaintext: 'First paragraph.' } },
+        { block: { $type: 'pub.leaflet.blocks.text', plaintext: 'Second paragraph.' } },
+      ]);
+    });
+  });
+});

--- a/packages/bluesky-api/src/auth.coverage.test.ts
+++ b/packages/bluesky-api/src/auth.coverage.test.ts
@@ -1,0 +1,332 @@
+import { BlueskyAuth } from './auth';
+
+type RequestOptions = {
+  method?: 'GET' | 'POST';
+  body?: Record<string, unknown> | FormData | Blob;
+  params?: Record<string, string | string[]>;
+  headers?: Record<string, string>;
+};
+
+class TestAuth extends BlueskyAuth {
+  public authCalls: { endpoint: string; accessJwt: string; options: RequestOptions }[] = [];
+  public requestCalls: { endpoint: string; options: RequestOptions }[] = [];
+  public responses: unknown[] = [];
+
+  constructor() {
+    super('https://pds.example');
+  }
+
+  protected async makeAuthenticatedRequest<T>(
+    endpoint: string,
+    accessJwt: string,
+    options: RequestOptions = {},
+  ): Promise<T> {
+    this.authCalls.push({ endpoint, accessJwt, options });
+    return (this.responses.shift() as T) ?? (undefined as T);
+  }
+
+  protected async makeRequest<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
+    this.requestCalls.push({ endpoint, options });
+    return (this.responses.shift() as T) ?? (undefined as T);
+  }
+}
+
+describe('BlueskyAuth (coverage)', () => {
+  it('requestEmailConfirmation posts to the auth endpoint', async () => {
+    const auth = new TestAuth();
+    await auth.requestEmailConfirmation('jwt-1');
+
+    expect(auth.authCalls).toEqual([
+      {
+        endpoint: '/com.atproto.server.requestEmailConfirmation',
+        accessJwt: 'jwt-1',
+        options: { method: 'POST' },
+      },
+    ]);
+  });
+
+  it('confirmEmail posts the email and token', async () => {
+    const auth = new TestAuth();
+    await auth.confirmEmail('jwt-2', 'me@example.com', 'token-123');
+
+    expect(auth.authCalls[0]).toEqual({
+      endpoint: '/com.atproto.server.confirmEmail',
+      accessJwt: 'jwt-2',
+      options: { method: 'POST', body: { email: 'me@example.com', token: 'token-123' } },
+    });
+  });
+
+  it('createAccount includes the invite code when provided', async () => {
+    const auth = new TestAuth();
+    const session = { accessJwt: 'a', refreshJwt: 'r', handle: 'h', did: 'did:1' };
+    auth.responses = [session];
+
+    const result = await auth.createAccount({
+      email: 'me@example.com',
+      handle: 'me.bsky.social',
+      password: 'pw',
+      inviteCode: 'invite-1',
+    });
+
+    expect(result).toBe(session);
+    expect(auth.requestCalls[0]).toEqual({
+      endpoint: '/com.atproto.server.createAccount',
+      options: {
+        method: 'POST',
+        body: {
+          email: 'me@example.com',
+          handle: 'me.bsky.social',
+          password: 'pw',
+          inviteCode: 'invite-1',
+        },
+      },
+    });
+  });
+
+  it('createAccount omits the invite code when not provided', async () => {
+    const auth = new TestAuth();
+    await auth.createAccount({ email: 'me@example.com', handle: 'me.bsky.social', password: 'pw' });
+
+    expect(auth.requestCalls[0]?.options.body).toEqual({
+      email: 'me@example.com',
+      handle: 'me.bsky.social',
+      password: 'pw',
+    });
+  });
+
+  it('getServiceAuth sends aud, lxm, and a computed exp param', async () => {
+    const auth = new TestAuth();
+    auth.responses = [{ token: 'svc-token' }];
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+
+    const result = await auth.getServiceAuth('jwt-3', 'did:web:video', 'app.bsky.video.getUploadLimits');
+
+    expect(result).toEqual({ token: 'svc-token' });
+    const call = auth.authCalls[0];
+    expect(call?.endpoint).toBe('/com.atproto.server.getServiceAuth');
+    expect(call?.accessJwt).toBe('jwt-3');
+    // 1_000_000 / 1000 = 1000, + default 300s = 1300
+    expect(call?.options.params).toEqual({
+      aud: 'did:web:video',
+      lxm: 'app.bsky.video.getUploadLimits',
+      exp: '1300',
+    });
+
+    nowSpy.mockRestore();
+  });
+
+  it('getServiceAuth honors a custom expSeconds', async () => {
+    const auth = new TestAuth();
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(2_000_000);
+
+    await auth.getServiceAuth('jwt-4', 'aud', 'lxm', 120);
+
+    // 2_000_000 / 1000 = 2000, + 120 = 2120
+    expect(auth.authCalls[0]?.options.params?.exp).toBe('2120');
+
+    nowSpy.mockRestore();
+  });
+
+  it('getSession reads the current session', async () => {
+    const auth = new TestAuth();
+    const info = { handle: 'me.bsky.social', did: 'did:1', email: 'me@example.com' };
+    auth.responses = [info];
+
+    const result = await auth.getSession('jwt-5');
+
+    expect(result).toBe(info);
+    expect(auth.authCalls[0]).toEqual({
+      endpoint: '/com.atproto.server.getSession',
+      accessJwt: 'jwt-5',
+      options: {},
+    });
+  });
+
+  it('updateHandle posts the new handle', async () => {
+    const auth = new TestAuth();
+    await auth.updateHandle('jwt-6', 'new.bsky.social');
+
+    expect(auth.authCalls[0]).toEqual({
+      endpoint: '/com.atproto.identity.updateHandle',
+      accessJwt: 'jwt-6',
+      options: { method: 'POST', body: { handle: 'new.bsky.social' } },
+    });
+  });
+
+  it('requestEmailUpdate returns tokenRequired', async () => {
+    const auth = new TestAuth();
+    auth.responses = [{ tokenRequired: true }];
+
+    const result = await auth.requestEmailUpdate('jwt-7');
+
+    expect(result).toEqual({ tokenRequired: true });
+    expect(auth.authCalls[0]).toEqual({
+      endpoint: '/com.atproto.server.requestEmailUpdate',
+      accessJwt: 'jwt-7',
+      options: { method: 'POST' },
+    });
+  });
+
+  it('updateEmail includes the token when provided', async () => {
+    const auth = new TestAuth();
+    await auth.updateEmail('jwt-8', 'new@example.com', 'token-9');
+
+    expect(auth.authCalls[0]?.options.body).toEqual({ email: 'new@example.com', token: 'token-9' });
+  });
+
+  it('updateEmail omits the token when not provided', async () => {
+    const auth = new TestAuth();
+    await auth.updateEmail('jwt-9', 'new@example.com');
+
+    expect(auth.authCalls[0]?.options.body).toEqual({ email: 'new@example.com' });
+  });
+
+  it('requestPasswordReset posts the email unauthenticated', async () => {
+    const auth = new TestAuth();
+    await auth.requestPasswordReset('me@example.com');
+
+    expect(auth.requestCalls[0]).toEqual({
+      endpoint: '/com.atproto.server.requestPasswordReset',
+      options: { method: 'POST', body: { email: 'me@example.com' } },
+    });
+  });
+
+  it('deactivateAccount includes deleteAfter when provided', async () => {
+    const auth = new TestAuth();
+    await auth.deactivateAccount('jwt-10', '2026-01-01T00:00:00.000Z');
+
+    expect(auth.authCalls[0]?.options.body).toEqual({ deleteAfter: '2026-01-01T00:00:00.000Z' });
+  });
+
+  it('deactivateAccount sends an empty body when deleteAfter is omitted', async () => {
+    const auth = new TestAuth();
+    await auth.deactivateAccount('jwt-11');
+
+    expect(auth.authCalls[0]?.options.body).toEqual({});
+  });
+
+  it('requestAccountDelete posts to the auth endpoint', async () => {
+    const auth = new TestAuth();
+    await auth.requestAccountDelete('jwt-12');
+
+    expect(auth.authCalls[0]).toEqual({
+      endpoint: '/com.atproto.server.requestAccountDelete',
+      accessJwt: 'jwt-12',
+      options: { method: 'POST' },
+    });
+  });
+
+  it('deleteAccount posts did, password, and token unauthenticated', async () => {
+    const auth = new TestAuth();
+    await auth.deleteAccount('did:1', 'pw', 'token-13');
+
+    expect(auth.requestCalls[0]).toEqual({
+      endpoint: '/com.atproto.server.deleteAccount',
+      options: { method: 'POST', body: { did: 'did:1', password: 'pw', token: 'token-13' } },
+    });
+  });
+
+  it('listAppPasswords reads the app password list', async () => {
+    const auth = new TestAuth();
+    const list = { passwords: [{ name: 'cli', createdAt: '2026-01-01T00:00:00.000Z' }] };
+    auth.responses = [list];
+
+    const result = await auth.listAppPasswords('jwt-14');
+
+    expect(result).toBe(list);
+    expect(auth.authCalls[0]).toEqual({
+      endpoint: '/com.atproto.server.listAppPasswords',
+      accessJwt: 'jwt-14',
+      options: {},
+    });
+  });
+
+  it('createAppPassword posts the name and privileged flag', async () => {
+    const auth = new TestAuth();
+    const created = { name: 'cli', password: 'secret', createdAt: '2026-01-01T00:00:00.000Z' };
+    auth.responses = [created];
+
+    const result = await auth.createAppPassword('jwt-15', 'cli', true);
+
+    expect(result).toBe(created);
+    expect(auth.authCalls[0]).toEqual({
+      endpoint: '/com.atproto.server.createAppPassword',
+      accessJwt: 'jwt-15',
+      options: { method: 'POST', body: { name: 'cli', privileged: true } },
+    });
+  });
+
+  it('createAppPassword defaults privileged to false', async () => {
+    const auth = new TestAuth();
+    await auth.createAppPassword('jwt-16', 'cli');
+
+    expect(auth.authCalls[0]?.options.body).toEqual({ name: 'cli', privileged: false });
+  });
+
+  it('revokeAppPassword posts the name', async () => {
+    const auth = new TestAuth();
+    await auth.revokeAppPassword('jwt-17', 'cli');
+
+    expect(auth.authCalls[0]).toEqual({
+      endpoint: '/com.atproto.server.revokeAppPassword',
+      accessJwt: 'jwt-17',
+      options: { method: 'POST', body: { name: 'cli' } },
+    });
+  });
+
+  describe('exportRepo', () => {
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('returns the repo blob on success', async () => {
+      const auth = new TestAuth();
+      const blob = new Blob(['car-bytes']);
+      const fetchMock = jest.fn().mockResolvedValue({
+        ok: true,
+        blob: async () => blob,
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const result = await auth.exportRepo('jwt-18', 'did:plc:abc');
+
+      expect(result).toBe(blob);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(String(url)).toContain('/com.atproto.sync.getRepo');
+      expect(String(url)).toContain('did=did%3Aplc%3Aabc');
+      expect(init).toEqual({ headers: { Authorization: 'Bearer jwt-18' } });
+    });
+
+    it('throws with the status and body text when the response is not ok', async () => {
+      const auth = new TestAuth();
+      const fetchMock = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: async () => 'boom',
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(auth.exportRepo('jwt-19', 'did:plc:def')).rejects.toThrow(
+        'Failed to export repo: 500 boom',
+      );
+    });
+
+    it('tolerates a failing text() read on error', async () => {
+      const auth = new TestAuth();
+      const fetchMock = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 502,
+        text: async () => {
+          throw new Error('no body');
+        },
+      });
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      await expect(auth.exportRepo('jwt-20', 'did:plc:ghi')).rejects.toThrow(
+        'Failed to export repo: 502 ',
+      );
+    });
+  });
+});

--- a/packages/bluesky-api/src/client.coverage.test.ts
+++ b/packages/bluesky-api/src/client.coverage.test.ts
@@ -1,0 +1,626 @@
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+import {
+  BlueskyApiClient,
+  getRateLimitCooldownUntil,
+  isRateLimitError,
+  registerDpopSigner,
+  setAuthRefreshHandler,
+  unregisterDpopSigner,
+  type DpopSigner,
+} from './client';
+
+/**
+ * Supplementary coverage for the base HTTP client. This file does NOT edit the
+ * existing client.test.ts; it targets the internals that suite leaves
+ * untouched: the DPoP-signed code path, 429 / rate-limit cooldown bookkeeping,
+ * the fetch-rejection fallback cooldown, the empty-accessJwt guest path,
+ * empty-body parsing, and the standalone exported helpers.
+ */
+describe('BlueskyApiClient coverage supplement', () => {
+  const server = setupServer();
+
+  // Each suite section uses a distinct origin so module-level rate-limit and
+  // DPoP-nonce state (keyed by base URL / origin) does not leak across tests.
+  class TestClient extends BlueskyApiClient {
+    async callMakeRequest<T>(
+      endpoint: string,
+      options?: {
+        method?: 'GET' | 'POST';
+        headers?: Record<string, string>;
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+      },
+    ): Promise<T> {
+      return this.makeRequest<T>(endpoint, options);
+    }
+
+    async callMakeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options?: {
+        method?: 'GET' | 'POST';
+        headers?: Record<string, string>;
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+      },
+    ): Promise<T> {
+      return this.makeAuthenticatedRequest<T>(endpoint, accessJwt, options);
+    }
+
+    async callUploadBlob(accessJwt: string, blob: Blob, mimeType: string) {
+      return this.uploadBlob(accessJwt, blob, mimeType);
+    }
+  }
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+
+  afterEach(() => {
+    server.resetHandlers();
+    jest.restoreAllMocks();
+    jest.useRealTimers();
+    setAuthRefreshHandler(null);
+  });
+
+  afterAll(() => server.close());
+
+  describe('exported helpers', () => {
+    it('isRateLimitError narrows only 429-shaped errors', () => {
+      expect(isRateLimitError(Object.assign(new Error('x'), { status: 429 }))).toBe(true);
+      expect(isRateLimitError(Object.assign(new Error('x'), { status: 500 }))).toBe(false);
+      expect(isRateLimitError(null)).toBe(false);
+      expect(isRateLimitError(undefined)).toBe(false);
+      expect(isRateLimitError('not an error')).toBe(false);
+    });
+
+    it('getRateLimitCooldownUntil returns 0 for an untouched base URL', () => {
+      expect(getRateLimitCooldownUntil('https://fresh.example')).toBe(0);
+    });
+
+    it('register/unregisterDpopSigner are idempotent and reversible', () => {
+      const signer: DpopSigner = async () => 'proof';
+      // Registering then unregistering an arbitrary token should not throw and
+      // should leave no signer behind (verified indirectly via the DPoP tests).
+      expect(() => registerDpopSigner('helper-token', signer)).not.toThrow();
+      expect(() => registerDpopSigner('helper-token', signer)).not.toThrow();
+      expect(() => unregisterDpopSigner('helper-token')).not.toThrow();
+      expect(() => unregisterDpopSigner('never-registered')).not.toThrow();
+    });
+  });
+
+  describe('makeRequest internals', () => {
+    it('drops undefined and null query params while keeping defined ones', async () => {
+      let capturedUrl: string | null = null;
+      server.use(
+        http.get('https://mr.example/xrpc/q', async ({ request }) => {
+          capturedUrl = request.url;
+          return HttpResponse.json({});
+        }),
+      );
+
+      const client = new TestClient('https://mr.example');
+      await client.callMakeRequest('/q', {
+        params: {
+          keep: 'yes',
+          // Exercise the undefined / null skip branch in buildXrpcUrl.
+          drop: undefined as unknown as string,
+          alsoDrop: null as unknown as string,
+          // Array containing a null entry exercises the inner null skip.
+          arr: ['a', null as unknown as string, 'b'],
+        },
+      });
+
+      expect(capturedUrl).toBe('https://mr.example/xrpc/q?keep=yes&arr=a&arr=b');
+    });
+
+    it('returns undefined for an empty 200 body', async () => {
+      server.use(
+        http.post('https://mr.example/xrpc/empty', () => new HttpResponse(null, { status: 200 })),
+      );
+
+      const client = new TestClient('https://mr.example');
+      const result = await client.callMakeRequest('/empty', { method: 'POST' });
+      expect(result).toBeUndefined();
+    });
+
+    it('sends a Blob body without a JSON content type', async () => {
+      let capturedType: string | null = null;
+      server.use(
+        http.post('https://mr.example/xrpc/blob', async ({ request }) => {
+          capturedType = request.headers.get('content-type');
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      const client = new TestClient('https://mr.example');
+      await client.callMakeRequest('/blob', {
+        method: 'POST',
+        body: new Blob(['bytes'], { type: 'image/png' }),
+      });
+
+      expect(capturedType).not.toBe('application/json');
+    });
+
+    it('builds an error with status and errorCode from the JSON body', async () => {
+      server.use(
+        http.get('https://mr.example/xrpc/boom', () =>
+          HttpResponse.json({ error: 'InvalidRequest', message: 'nope' }, { status: 400 }),
+        ),
+      );
+
+      const client = new TestClient('https://mr.example');
+      await expect(client.callMakeRequest('/boom')).rejects.toMatchObject({
+        message: 'nope',
+        status: 400,
+        errorCode: 'InvalidRequest',
+      });
+    });
+
+    it('falls back to a status message when the error body is not JSON', async () => {
+      server.use(
+        http.get('https://mr.example/xrpc/html', () =>
+          new HttpResponse('<html>500</html>', {
+            status: 500,
+            headers: { 'content-type': 'text/html' },
+          }),
+        ),
+      );
+
+      const client = new TestClient('https://mr.example');
+      await expect(client.callMakeRequest('/html')).rejects.toMatchObject({
+        message: 'Request failed with status 500',
+        status: 500,
+      });
+    });
+  });
+
+  describe('429 rate-limit handling on makeRequest', () => {
+    it('parses RateLimit-Reset, sets a cooldown, and throws a 429 error', async () => {
+      jest.useFakeTimers();
+      const baseUrl = 'https://rl-reset.example';
+      const resetSeconds = Math.floor(Date.now() / 1000) + 60;
+      server.use(
+        http.get(`${baseUrl}/xrpc/limited`, () =>
+          HttpResponse.json(
+            { error: 'RateLimitExceeded', message: 'slow down' },
+            { status: 429, headers: { 'ratelimit-reset': String(resetSeconds) } },
+          ),
+        ),
+      );
+
+      const client = new TestClient(baseUrl);
+      const err = (await client.callMakeRequest('/limited').catch((e) => e)) as Error & {
+        retryAfterMs?: number;
+      };
+      expect(isRateLimitError(err)).toBe(true);
+      expect(err).toMatchObject({ status: 429, errorCode: 'RateLimitExceeded', message: 'slow down' });
+      expect(err.retryAfterMs).toBeGreaterThan(0);
+      // Cooldown should be roughly the reset timestamp in millis.
+      expect(getRateLimitCooldownUntil(baseUrl)).toBe(resetSeconds * 1000);
+      // Drain the cooldown timer so it does not linger as an open handle.
+      await jest.advanceTimersByTimeAsync(61_000);
+    });
+
+    it('applies the fallback cooldown when a 429 has no usable reset header', async () => {
+      jest.useFakeTimers();
+      const baseUrl = 'https://rl-noreset.example';
+      server.use(
+        http.get(`${baseUrl}/xrpc/limited`, () =>
+          // Non-numeric reset header exercises parseRateLimitReset's NaN guard.
+          HttpResponse.json({}, { status: 429, headers: { 'ratelimit-reset': 'not-a-number' } }),
+        ),
+      );
+
+      const before = Date.now();
+      const client = new TestClient(baseUrl);
+      const err = (await client.callMakeRequest('/limited').catch((e) => e)) as Error & {
+        retryAfterMs?: number;
+      };
+      expect(err).toMatchObject({ status: 429, message: 'Rate limited' });
+      // No reset means no retryAfterMs is attached.
+      expect(err.retryAfterMs).toBeUndefined();
+      const until = getRateLimitCooldownUntil(baseUrl);
+      expect(until).toBeGreaterThanOrEqual(before + 30_000 - 1000);
+      await jest.advanceTimersByTimeAsync(31_000);
+    });
+
+    it('awaits an active cooldown before issuing the next request', async () => {
+      jest.useFakeTimers();
+      const baseUrl = 'https://rl-await.example';
+      let hits = 0;
+      const resetSeconds = Math.floor(Date.now() / 1000) + 5;
+      server.use(
+        http.get(`${baseUrl}/xrpc/limited`, () => {
+          hits += 1;
+          if (hits === 1) {
+            return HttpResponse.json({}, {
+              status: 429,
+              headers: { 'ratelimit-reset': String(resetSeconds) },
+            });
+          }
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      const client = new TestClient(baseUrl);
+      await client.callMakeRequest('/limited').catch(() => undefined);
+      expect(getRateLimitCooldownUntil(baseUrl)).toBeGreaterThan(0);
+
+      // Second call should block on the cooldown promise; advancing time
+      // resolves it and clears the cooldown.
+      const pending = client.callMakeRequest<{ ok: boolean }>('/limited');
+      await jest.advanceTimersByTimeAsync(6000);
+      await expect(pending).resolves.toEqual({ ok: true });
+      expect(getRateLimitCooldownUntil(baseUrl)).toBe(0);
+    });
+  });
+
+  describe('fetch-rejection fallback cooldown', () => {
+    it('sets the fallback cooldown and re-throws when fetch rejects (unauthenticated)', async () => {
+      jest.useFakeTimers();
+      const baseUrl = 'https://fetchfail.example';
+      const fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockRejectedValue(new TypeError('Failed to fetch'));
+
+      const before = Date.now();
+      const client = new TestClient(baseUrl);
+      await expect(client.callMakeRequest('/x')).rejects.toThrow('Failed to fetch');
+      expect(getRateLimitCooldownUntil(baseUrl)).toBeGreaterThanOrEqual(before + 30_000 - 1000);
+      // Flush the fallback cooldown timer so it does not leak as an open handle.
+      await jest.advanceTimersByTimeAsync(31_000);
+      expect(getRateLimitCooldownUntil(baseUrl)).toBe(0);
+      fetchSpy.mockRestore();
+    });
+  });
+
+  describe('makeAuthenticatedRequest guest path', () => {
+    it('omits the Authorization header when accessJwt is empty', async () => {
+      let auth: string | null = 'unset';
+      server.use(
+        http.get('https://guest.example/xrpc/public', async ({ request }) => {
+          auth = request.headers.get('authorization');
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      const client = new TestClient('https://guest.example');
+      await expect(
+        client.callMakeAuthenticatedRequest<{ ok: boolean }>('/public', ''),
+      ).resolves.toEqual({ ok: true });
+      expect(auth).toBeNull();
+    });
+  });
+
+  describe('DPoP-signed code path', () => {
+    const DPOP_TOKEN = 'dpop-access-token';
+
+    afterEach(() => {
+      unregisterDpopSigner(DPOP_TOKEN);
+    });
+
+    it('sends Authorization: DPoP plus a proof and caches the server nonce', async () => {
+      const baseUrl = 'https://dpop.example';
+      const signerArgs: { method: string; url: string; nonce?: string }[] = [];
+      const signer: DpopSigner = jest.fn(async (params) => {
+        signerArgs.push(params);
+        return 'proof-1';
+      });
+      registerDpopSigner(DPOP_TOKEN, signer);
+
+      const seen: { auth: string | null; dpop: string | null }[] = [];
+      server.use(
+        http.post(`${baseUrl}/xrpc/app.bsky.feed.post`, async ({ request }) => {
+          seen.push({
+            auth: request.headers.get('authorization'),
+            dpop: request.headers.get('dpop'),
+          });
+          return HttpResponse.json({ uri: 'at://x' }, { headers: { 'DPoP-Nonce': 'server-nonce' } });
+        }),
+      );
+
+      const client = new TestClient(baseUrl, 'did:web:appview.example');
+      const result = await client.callMakeAuthenticatedRequest<{ uri: string }>(
+        '/app.bsky.feed.post',
+        DPOP_TOKEN,
+        { method: 'POST', body: { text: 'hi' } },
+      );
+
+      expect(result).toEqual({ uri: 'at://x' });
+      expect(seen[0]).toEqual({ auth: `DPoP ${DPOP_TOKEN}`, dpop: 'proof-1' });
+      expect(signer).toHaveBeenCalledTimes(1);
+      expect(signerArgs[0]).toMatchObject({
+        method: 'POST',
+        url: `${baseUrl}/xrpc/app.bsky.feed.post`,
+      });
+      // The proxy header should ride along on app.bsky.* DPoP requests too.
+      // (verified by the successful 200 from the handler scoped to that path)
+    });
+
+    it('retries once with the issued nonce on use_dpop_nonce, then succeeds', async () => {
+      const baseUrl = 'https://dpop-nonce.example';
+      const nonces: (string | undefined)[] = [];
+      const signer: DpopSigner = jest.fn(async ({ nonce }) => {
+        nonces.push(nonce);
+        return `proof-for-${nonce ?? 'none'}`;
+      });
+      registerDpopSigner(DPOP_TOKEN, signer);
+
+      let hits = 0;
+      server.use(
+        http.get(`${baseUrl}/xrpc/secure`, () => {
+          hits += 1;
+          if (hits === 1) {
+            return HttpResponse.json(
+              { error: 'use_dpop_nonce' },
+              { status: 401, headers: { 'DPoP-Nonce': 'fresh-nonce' } },
+            );
+          }
+          return HttpResponse.json({ ok: true }, { headers: { 'DPoP-Nonce': 'rotated-nonce' } });
+        }),
+      );
+
+      const client = new TestClient(baseUrl);
+      const result = await client.callMakeAuthenticatedRequest<{ ok: boolean }>('/secure', DPOP_TOKEN);
+
+      expect(result).toEqual({ ok: true });
+      expect(hits).toBe(2);
+      // First attempt had no cached nonce; retry used the server-issued one.
+      expect(nonces).toEqual([undefined, 'fresh-nonce']);
+    });
+
+    it('does not retry on a non-nonce 401 and surfaces the error', async () => {
+      const baseUrl = 'https://dpop-401.example';
+      registerDpopSigner(DPOP_TOKEN, async () => 'proof');
+
+      let hits = 0;
+      server.use(
+        http.get(`${baseUrl}/xrpc/secure`, () => {
+          hits += 1;
+          return HttpResponse.json(
+            { error: 'ExpiredToken', message: 'expired' },
+            { status: 401, headers: { 'DPoP-Nonce': 'n' } },
+          );
+        }),
+      );
+
+      const client = new TestClient(baseUrl);
+      // No refresh handler installed, so the 401 surfaces directly.
+      await expect(
+        client.callMakeAuthenticatedRequest('/secure', DPOP_TOKEN),
+      ).rejects.toMatchObject({ status: 401, errorCode: 'ExpiredToken' });
+      expect(hits).toBe(1);
+    });
+
+    it('throws a 429 from the DPoP path with reset bookkeeping', async () => {
+      jest.useFakeTimers();
+      const baseUrl = 'https://dpop-429.example';
+      registerDpopSigner(DPOP_TOKEN, async () => 'proof');
+      const resetSeconds = Math.floor(Date.now() / 1000) + 30;
+      server.use(
+        http.get(`${baseUrl}/xrpc/secure`, () =>
+          HttpResponse.json(
+            { error: 'RateLimitExceeded', message: 'too fast' },
+            { status: 429, headers: { 'ratelimit-reset': String(resetSeconds) } },
+          ),
+        ),
+      );
+
+      const client = new TestClient(baseUrl);
+      const err = await client.callMakeAuthenticatedRequest('/secure', DPOP_TOKEN).catch((e) => e);
+      expect(err).toMatchObject({ status: 429, errorCode: 'RateLimitExceeded' });
+      expect(getRateLimitCooldownUntil(baseUrl)).toBe(resetSeconds * 1000);
+      await jest.advanceTimersByTimeAsync(31_000);
+    });
+
+    it('returns undefined for an empty 200 body on the DPoP path', async () => {
+      const baseUrl = 'https://dpop-empty.example';
+      registerDpopSigner(DPOP_TOKEN, async () => 'proof');
+      server.use(
+        http.post(`${baseUrl}/xrpc/void`, () => new HttpResponse(null, { status: 200 })),
+      );
+
+      const client = new TestClient(baseUrl);
+      const result = await client.callMakeAuthenticatedRequest('/void', DPOP_TOKEN, {
+        method: 'POST',
+        body: { a: 1 },
+      });
+      expect(result).toBeUndefined();
+    });
+
+    it('applies the fallback cooldown when the DPoP fetch rejects', async () => {
+      jest.useFakeTimers();
+      const baseUrl = 'https://dpop-fetchfail.example';
+      registerDpopSigner(DPOP_TOKEN, async () => 'proof');
+      const fetchSpy = jest
+        .spyOn(globalThis, 'fetch')
+        .mockRejectedValue(new TypeError('network down'));
+
+      const before = Date.now();
+      const client = new TestClient(baseUrl);
+      await expect(
+        client.callMakeAuthenticatedRequest('/secure', DPOP_TOKEN),
+      ).rejects.toThrow('network down');
+      expect(getRateLimitCooldownUntil(baseUrl)).toBeGreaterThanOrEqual(before + 30_000 - 1000);
+      await jest.advanceTimersByTimeAsync(31_000);
+      expect(getRateLimitCooldownUntil(baseUrl)).toBe(0);
+      fetchSpy.mockRestore();
+    });
+
+    it('applies the fallback cooldown when the DPoP nonce-retry fetch rejects', async () => {
+      jest.useFakeTimers();
+      const baseUrl = 'https://dpop-retryfail.example';
+      registerDpopSigner(DPOP_TOKEN, async () => 'proof');
+
+      // First send succeeds at the network level but is a use_dpop_nonce 401;
+      // the retry send rejects, exercising the retry catch / fallback cooldown.
+      let calls = 0;
+      const fetchSpy = jest.spyOn(globalThis, 'fetch').mockImplementation(() => {
+        calls += 1;
+        if (calls === 1) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ error: 'use_dpop_nonce' }), {
+              status: 401,
+              headers: { 'DPoP-Nonce': 'n', 'content-type': 'application/json' },
+            }),
+          );
+        }
+        return Promise.reject(new TypeError('retry network down'));
+      });
+
+      const before = Date.now();
+      const client = new TestClient(baseUrl);
+      await expect(
+        client.callMakeAuthenticatedRequest('/secure', DPOP_TOKEN),
+      ).rejects.toThrow('retry network down');
+      expect(calls).toBe(2);
+      expect(getRateLimitCooldownUntil(baseUrl)).toBeGreaterThanOrEqual(before + 30_000 - 1000);
+      await jest.advanceTimersByTimeAsync(31_000);
+      fetchSpy.mockRestore();
+    });
+
+    it('treats an unparseable use_dpop_nonce body as not-a-nonce-error', async () => {
+      const baseUrl = 'https://dpop-badbody.example';
+      registerDpopSigner(DPOP_TOKEN, async () => 'proof');
+
+      // 401 carrying a DPoP-Nonce header but a non-JSON body: bodyIsUseDpopNonce
+      // hits its catch and returns false, so no retry happens and the 401
+      // surfaces unchanged.
+      let hits = 0;
+      server.use(
+        http.get(`${baseUrl}/xrpc/secure`, () => {
+          hits += 1;
+          return new HttpResponse('<<not json>>', {
+            status: 401,
+            headers: { 'DPoP-Nonce': 'n', 'content-type': 'text/plain' },
+          });
+        }),
+      );
+
+      const client = new TestClient(baseUrl);
+      await expect(
+        client.callMakeAuthenticatedRequest('/secure', DPOP_TOKEN),
+      ).rejects.toMatchObject({ status: 401 });
+      expect(hits).toBe(1);
+    });
+
+    it('throws a generic non-ok error (no JSON body) on the DPoP path', async () => {
+      const baseUrl = 'https://dpop-500.example';
+      registerDpopSigner(DPOP_TOKEN, async () => 'proof');
+      server.use(
+        http.get(`${baseUrl}/xrpc/secure`, () =>
+          new HttpResponse('boom', { status: 502, headers: { 'content-type': 'text/plain' } }),
+        ),
+      );
+
+      const client = new TestClient(baseUrl);
+      await expect(
+        client.callMakeAuthenticatedRequest('/secure', DPOP_TOKEN),
+      ).rejects.toMatchObject({ status: 502, message: 'Request failed with status 502' });
+    });
+  });
+
+  describe('auth refresh through the DPoP signer path', () => {
+    const OLD_TOKEN = 'old-dpop';
+    const NEW_TOKEN = 'new-dpop';
+
+    afterEach(() => {
+      unregisterDpopSigner(OLD_TOKEN);
+      unregisterDpopSigner(NEW_TOKEN);
+    });
+
+    it('refreshes an expired DPoP token and retries once with the rotated token', async () => {
+      const baseUrl = 'https://dpop-refresh.example';
+      registerDpopSigner(OLD_TOKEN, async () => 'old-proof');
+      registerDpopSigner(NEW_TOKEN, async () => 'new-proof');
+
+      const seenAuth: string[] = [];
+      let hits = 0;
+      server.use(
+        http.get(`${baseUrl}/xrpc/secure`, ({ request }) => {
+          hits += 1;
+          seenAuth.push(request.headers.get('authorization') ?? '');
+          if (hits === 1) {
+            return HttpResponse.json(
+              { error: 'ExpiredToken', message: 'expired' },
+              { status: 401, headers: { 'DPoP-Nonce': 'n' } },
+            );
+          }
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      // The handler re-registers the signer under the new token (as the real
+      // app does) and returns the rotated JWT.
+      const handler = jest.fn(async (old: string) => {
+        expect(old).toBe(OLD_TOKEN);
+        return NEW_TOKEN;
+      });
+      setAuthRefreshHandler(handler);
+
+      const client = new TestClient(baseUrl);
+      const result = await client.callMakeAuthenticatedRequest<{ ok: boolean }>(
+        '/secure',
+        OLD_TOKEN,
+      );
+
+      expect(result).toEqual({ ok: true });
+      expect(hits).toBe(2);
+      expect(seenAuth).toEqual([`DPoP ${OLD_TOKEN}`, `DPoP ${NEW_TOKEN}`]);
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('uploadBlob', () => {
+    it('rewraps a blob with arrayBuffer() and uploads via the authenticated path', async () => {
+      const baseUrl = 'https://upload.example';
+      let captured: { type: string | null; bytes: number } | null = null;
+      server.use(
+        http.post(`${baseUrl}/xrpc/com.atproto.repo.uploadBlob`, async ({ request }) => {
+          const buf = await request.arrayBuffer();
+          captured = { type: request.headers.get('content-type'), bytes: buf.byteLength };
+          return HttpResponse.json({ blob: { ref: { $link: 'cid' }, mimeType: 'image/png', size: buf.byteLength } });
+        }),
+      );
+
+      const client = new TestClient(baseUrl);
+      const blob = new Blob(['imagedata'], { type: 'application/octet-stream' });
+      const result = await client.callUploadBlob('token', blob, 'image/png');
+
+      expect(result.blob.ref.$link).toBe('cid');
+      expect(captured).not.toBeNull();
+      expect(captured!.type).toBe('image/png');
+      expect(captured!.bytes).toBe('imagedata'.length);
+    });
+
+    it('falls back to the original blob when arrayBuffer is unavailable', async () => {
+      const baseUrl = 'https://upload-noab.example';
+      let capturedType: string | null = null;
+      server.use(
+        http.post(`${baseUrl}/xrpc/com.atproto.repo.uploadBlob`, async ({ request }) => {
+          capturedType = request.headers.get('content-type');
+          await request.arrayBuffer();
+          return HttpResponse.json({ blob: { ref: { $link: 'cid2' }, mimeType: 'image/jpeg', size: 4 } });
+        }),
+      );
+
+      // Build a blob-like object lacking arrayBuffer to hit the RN fallback.
+      // Proxy to a real blob for everything except arrayBuffer so fetch can
+      // still serialize the body.
+      const realBlob = new Blob(['data'], { type: 'image/jpeg' });
+      const proxy = new Proxy(realBlob, {
+        get(target, prop, receiver) {
+          if (prop === 'arrayBuffer') return undefined;
+          const v = Reflect.get(target, prop, receiver);
+          return typeof v === 'function' ? v.bind(target) : v;
+        },
+      });
+
+      const client = new TestClient(baseUrl);
+      const result = await client.callUploadBlob('token', proxy as unknown as Blob, 'image/jpeg');
+      expect(result.blob.ref.$link).toBe('cid2');
+      expect(capturedType).toBe('image/jpeg');
+    });
+  });
+});

--- a/packages/bluesky-api/src/conversations.coverage.test.ts
+++ b/packages/bluesky-api/src/conversations.coverage.test.ts
@@ -1,0 +1,188 @@
+import { BlueskyConversations } from './conversations';
+import type { BlueskyConvoView } from './types';
+
+const CHAT_PROXY = 'did:web:api.bsky.chat#bsky_chat';
+
+type AuthOptions = {
+  method?: 'GET' | 'POST';
+  body?: Record<string, unknown> | FormData | Blob;
+  params?: Record<string, string | string[]>;
+  headers?: Record<string, string>;
+};
+
+describe('BlueskyConversations (coverage)', () => {
+  class TestConversations extends BlueskyConversations {
+    public authCalls: { endpoint: string; accessJwt: string; options: AuthOptions }[] = [];
+    public responses: unknown[] = [];
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: AuthOptions = {},
+    ): Promise<T> {
+      this.authCalls.push({ endpoint, accessJwt, options });
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+  }
+
+  const convo = { convo: { id: 'convo-1' } as BlueskyConvoView };
+
+  it('updateRead posts the convoId with the chat proxy header', async () => {
+    const client = new TestConversations();
+    client.responses = [undefined];
+
+    await client.updateRead('jwt', 'convo-1');
+
+    expect(client.authCalls).toHaveLength(1);
+    const call = client.authCalls[0];
+    expect(call.endpoint).toBe('/chat.bsky.convo.updateRead');
+    expect(call.accessJwt).toBe('jwt');
+    expect(call.options.method).toBe('POST');
+    expect(call.options.headers).toEqual({ 'atproto-proxy': CHAT_PROXY });
+    expect(call.options.body).toEqual({ convoId: 'convo-1' });
+  });
+
+  it('getConvoForMembers passes members as a params array', async () => {
+    const client = new TestConversations();
+    client.responses = [convo];
+
+    const result = await client.getConvoForMembers('jwt', ['did:a', 'did:b']);
+
+    expect(result).toEqual(convo);
+    const call = client.authCalls[0];
+    expect(call.endpoint).toBe('/chat.bsky.convo.getConvoForMembers');
+    expect(call.accessJwt).toBe('jwt');
+    expect(call.options.method).toBeUndefined();
+    expect(call.options.params).toEqual({ members: ['did:a', 'did:b'] });
+    expect(call.options.headers).toEqual({ 'atproto-proxy': CHAT_PROXY });
+  });
+
+  it('getConvo fetches a single convo by id', async () => {
+    const client = new TestConversations();
+    client.responses = [convo];
+
+    const result = await client.getConvo('jwt', 'convo-1');
+
+    expect(result).toEqual(convo);
+    const call = client.authCalls[0];
+    expect(call.endpoint).toBe('/chat.bsky.convo.getConvo');
+    expect(call.options.params).toEqual({ convoId: 'convo-1' });
+    expect(call.options.headers).toEqual({ 'atproto-proxy': CHAT_PROXY });
+  });
+
+  it('leaveConvo posts the convoId', async () => {
+    const client = new TestConversations();
+    client.responses = [{ convoId: 'convo-1', rev: 'rev-1' }];
+
+    const result = await client.leaveConvo('jwt', 'convo-1');
+
+    expect(result).toEqual({ convoId: 'convo-1', rev: 'rev-1' });
+    const call = client.authCalls[0];
+    expect(call.endpoint).toBe('/chat.bsky.convo.leaveConvo');
+    expect(call.options.method).toBe('POST');
+    expect(call.options.headers).toEqual({ 'atproto-proxy': CHAT_PROXY });
+    expect(call.options.body).toEqual({ convoId: 'convo-1' });
+  });
+
+  it('addMembers posts convoId and dids', async () => {
+    const client = new TestConversations();
+    client.responses = [convo];
+
+    const result = await client.addMembers('jwt', 'convo-1', ['did:a', 'did:b']);
+
+    expect(result).toEqual(convo);
+    const call = client.authCalls[0];
+    expect(call.endpoint).toBe('/chat.bsky.convo.addMembers');
+    expect(call.options.method).toBe('POST');
+    expect(call.options.headers).toEqual({ 'atproto-proxy': CHAT_PROXY });
+    expect(call.options.body).toEqual({ convoId: 'convo-1', dids: ['did:a', 'did:b'] });
+  });
+
+  it('removeMembers posts convoId and dids', async () => {
+    const client = new TestConversations();
+    client.responses = [convo];
+
+    const result = await client.removeMembers('jwt', 'convo-1', ['did:a']);
+
+    expect(result).toEqual(convo);
+    const call = client.authCalls[0];
+    expect(call.endpoint).toBe('/chat.bsky.convo.removeMembers');
+    expect(call.options.method).toBe('POST');
+    expect(call.options.headers).toEqual({ 'atproto-proxy': CHAT_PROXY });
+    expect(call.options.body).toEqual({ convoId: 'convo-1', dids: ['did:a'] });
+  });
+
+  it('updateConvoName posts convoId and name', async () => {
+    const client = new TestConversations();
+    client.responses = [convo];
+
+    const result = await client.updateConvoName('jwt', 'convo-1', 'New Name');
+
+    expect(result).toEqual(convo);
+    const call = client.authCalls[0];
+    expect(call.endpoint).toBe('/chat.bsky.convo.updateConvoName');
+    expect(call.options.method).toBe('POST');
+    expect(call.options.headers).toEqual({ 'atproto-proxy': CHAT_PROXY });
+    expect(call.options.body).toEqual({ convoId: 'convo-1', name: 'New Name' });
+  });
+
+  it('muteConvo posts the convoId', async () => {
+    const client = new TestConversations();
+    client.responses = [convo];
+
+    const result = await client.muteConvo('jwt', 'convo-1');
+
+    expect(result).toEqual(convo);
+    const call = client.authCalls[0];
+    expect(call.endpoint).toBe('/chat.bsky.convo.muteConvo');
+    expect(call.options.method).toBe('POST');
+    expect(call.options.headers).toEqual({ 'atproto-proxy': CHAT_PROXY });
+    expect(call.options.body).toEqual({ convoId: 'convo-1' });
+  });
+
+  it('unmuteConvo posts the convoId', async () => {
+    const client = new TestConversations();
+    client.responses = [convo];
+
+    const result = await client.unmuteConvo('jwt', 'convo-1');
+
+    expect(result).toEqual(convo);
+    const call = client.authCalls[0];
+    expect(call.endpoint).toBe('/chat.bsky.convo.unmuteConvo');
+    expect(call.options.method).toBe('POST');
+    expect(call.options.headers).toEqual({ 'atproto-proxy': CHAT_PROXY });
+    expect(call.options.body).toEqual({ convoId: 'convo-1' });
+  });
+
+  it('addReaction posts convoId, messageId and value', async () => {
+    const client = new TestConversations();
+    client.responses = [{ message: { id: 'msg-1' } }];
+
+    const result = await client.addReaction('jwt', 'convo-1', 'msg-1', '👍');
+
+    expect(result).toEqual({ message: { id: 'msg-1' } });
+    const call = client.authCalls[0];
+    expect(call.endpoint).toBe('/chat.bsky.convo.addReaction');
+    expect(call.options.method).toBe('POST');
+    expect(call.options.headers).toEqual({ 'atproto-proxy': CHAT_PROXY });
+    expect(call.options.body).toEqual({ convoId: 'convo-1', messageId: 'msg-1', value: '👍' });
+  });
+
+  it('removeReaction posts convoId, messageId and value', async () => {
+    const client = new TestConversations();
+    client.responses = [{ message: { id: 'msg-1' } }];
+
+    const result = await client.removeReaction('jwt', 'convo-1', 'msg-1', '👍');
+
+    expect(result).toEqual({ message: { id: 'msg-1' } });
+    const call = client.authCalls[0];
+    expect(call.endpoint).toBe('/chat.bsky.convo.removeReaction');
+    expect(call.options.method).toBe('POST');
+    expect(call.options.headers).toEqual({ 'atproto-proxy': CHAT_PROXY });
+    expect(call.options.body).toEqual({ convoId: 'convo-1', messageId: 'msg-1', value: '👍' });
+  });
+});

--- a/packages/bluesky-api/src/draft.test.ts
+++ b/packages/bluesky-api/src/draft.test.ts
@@ -1,0 +1,186 @@
+import { BlueskyDrafts } from './draft';
+import type {
+  BlueskyCreateDraftResponse,
+  BlueskyDraft,
+  BlueskyGetDraftsResponse,
+} from './types';
+
+describe('BlueskyDrafts', () => {
+  class TestDrafts extends BlueskyDrafts {
+    public authCalls: {
+      endpoint: string;
+      accessJwt: string;
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      };
+    }[] = [];
+
+    public requestCalls: {
+      endpoint: string;
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      };
+    }[] = [];
+
+    public responses: unknown[] = [];
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      this.authCalls.push({ endpoint, accessJwt, options });
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+
+    protected async makeRequest<T>(
+      endpoint: string,
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      this.requestCalls.push({ endpoint, options });
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+  }
+
+  const sampleDraft: BlueskyDraft = {
+    posts: [{ text: 'hello world' } as BlueskyDraft['posts'][number]],
+    langs: ['en'],
+  };
+
+  describe('getDrafts', () => {
+    it('lists drafts with no options and an empty params object', async () => {
+      const drafts = new TestDrafts();
+      const response = { drafts: [] } as BlueskyGetDraftsResponse;
+      drafts.responses = [response];
+
+      const result = await drafts.getDrafts('jwt');
+
+      expect(result).toBe(response);
+      expect(drafts.authCalls).toEqual([
+        {
+          endpoint: '/app.bsky.draft.getDrafts',
+          accessJwt: 'jwt',
+          options: { params: {} },
+        },
+      ]);
+    });
+
+    it('forwards the limit parameter as a string', async () => {
+      const drafts = new TestDrafts();
+      drafts.responses = [{ drafts: [] } as BlueskyGetDraftsResponse];
+
+      await drafts.getDrafts('jwt', { limit: 25 });
+
+      expect(drafts.authCalls[0].options.params).toEqual({ limit: '25' });
+    });
+
+    it('includes the limit even when it is zero', async () => {
+      const drafts = new TestDrafts();
+      drafts.responses = [{ drafts: [] } as BlueskyGetDraftsResponse];
+
+      await drafts.getDrafts('jwt', { limit: 0 });
+
+      expect(drafts.authCalls[0].options.params).toEqual({ limit: '0' });
+    });
+
+    it('forwards both limit and cursor', async () => {
+      const drafts = new TestDrafts();
+      drafts.responses = [{ drafts: [], cursor: 'next' } as BlueskyGetDraftsResponse];
+
+      await drafts.getDrafts('jwt', { limit: 10, cursor: 'cursor-abc' });
+
+      expect(drafts.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.draft.getDrafts',
+        accessJwt: 'jwt',
+        options: { params: { limit: '10', cursor: 'cursor-abc' } },
+      });
+    });
+
+    it('omits an empty-string cursor', async () => {
+      const drafts = new TestDrafts();
+      drafts.responses = [{ drafts: [] } as BlueskyGetDraftsResponse];
+
+      await drafts.getDrafts('jwt', { cursor: '' });
+
+      expect(drafts.authCalls[0].options.params).toEqual({});
+    });
+  });
+
+  describe('createDraft', () => {
+    it('posts the draft wrapped in a draft field and returns the assigned id', async () => {
+      const drafts = new TestDrafts();
+      const response = { id: 'tid-123' } as BlueskyCreateDraftResponse;
+      drafts.responses = [response];
+
+      const result = await drafts.createDraft('jwt', sampleDraft);
+
+      expect(result).toBe(response);
+      expect(drafts.authCalls).toEqual([
+        {
+          endpoint: '/app.bsky.draft.createDraft',
+          accessJwt: 'jwt',
+          options: { method: 'POST', body: { draft: sampleDraft } },
+        },
+      ]);
+    });
+  });
+
+  describe('updateDraft', () => {
+    it('posts a nested draft payload and resolves to undefined', async () => {
+      const drafts = new TestDrafts();
+      drafts.responses = [undefined];
+
+      const result = await drafts.updateDraft('jwt', 'tid-456', sampleDraft);
+
+      expect(result).toBeUndefined();
+      expect(drafts.authCalls).toEqual([
+        {
+          endpoint: '/app.bsky.draft.updateDraft',
+          accessJwt: 'jwt',
+          options: {
+            method: 'POST',
+            body: { draft: { id: 'tid-456', draft: sampleDraft } },
+          },
+        },
+      ]);
+    });
+  });
+
+  describe('deleteDraft', () => {
+    it('posts only the id and resolves to undefined', async () => {
+      const drafts = new TestDrafts();
+      drafts.responses = [undefined];
+
+      const result = await drafts.deleteDraft('jwt', 'tid-789');
+
+      expect(result).toBeUndefined();
+      expect(drafts.authCalls).toEqual([
+        {
+          endpoint: '/app.bsky.draft.deleteDraft',
+          accessJwt: 'jwt',
+          options: { method: 'POST', body: { id: 'tid-789' } },
+        },
+      ]);
+    });
+  });
+});

--- a/packages/bluesky-api/src/feeds.coverage.test.ts
+++ b/packages/bluesky-api/src/feeds.coverage.test.ts
@@ -1,0 +1,363 @@
+import { BlueskyFeeds } from './feeds';
+import type { BlueskyUploadBlobResponse } from './types';
+
+type RequestOptions = {
+  method?: 'GET' | 'POST';
+  body?: Record<string, unknown> | FormData | Blob;
+  params?: Record<string, string | string[]>;
+  headers?: Record<string, string>;
+};
+
+/**
+ * Covers the BlueskyFeeds methods not exercised by feeds.test.ts:
+ * getPosts, repostPost, unrepostPost, createReport, setThreadgate,
+ * setPostgate, and sendInteractions. Uses the same subclass-override
+ * pattern as feeds.test.ts — replacing the protected request helpers
+ * with capturing stubs that share a single response queue.
+ */
+class TestFeeds extends BlueskyFeeds {
+  public authCalls: { endpoint: string; accessJwt: string; options: RequestOptions }[] = [];
+  public responses: unknown[] = [];
+
+  constructor() {
+    super('https://pds.example');
+  }
+
+  protected async makeAuthenticatedRequest<T>(
+    endpoint: string,
+    accessJwt: string,
+    options: RequestOptions = {},
+  ): Promise<T> {
+    this.authCalls.push({ endpoint, accessJwt, options });
+    return (this.responses.shift() as T) ?? (undefined as T);
+  }
+}
+
+describe('BlueskyFeeds (coverage)', () => {
+  describe('getPosts', () => {
+    it('short-circuits to an empty page for an empty uri list', async () => {
+      const feeds = new TestFeeds();
+
+      const result = await feeds.getPosts('jwt', []);
+
+      expect(result).toEqual({ posts: [] });
+      expect(feeds.authCalls).toHaveLength(0);
+    });
+
+    it('forwards the (capped) uri list with the labeler header', async () => {
+      const feeds = new TestFeeds();
+      const response = { posts: [] };
+      feeds.responses = [response];
+
+      const result = await feeds.getPosts('jwt', ['at://post/1', 'at://post/2']);
+
+      expect(result).toBe(response);
+      const call = feeds.authCalls[0];
+      expect(call.endpoint).toBe('/app.bsky.feed.getPosts');
+      expect(call.options.params).toEqual({ uris: ['at://post/1', 'at://post/2'] });
+      expect(call.options.headers?.['atproto-accept-labelers']).toBe(
+        'did:plc:ar7c4by46qjdydhdevvrndac;redact',
+      );
+    });
+
+    it('caps the uri list at 25 entries', async () => {
+      const feeds = new TestFeeds();
+      feeds.responses = [{ posts: [] }];
+      const uris = Array.from({ length: 30 }, (_, i) => `at://post/${i}`);
+
+      await feeds.getPosts('jwt', uris);
+
+      const params = feeds.authCalls[0].options.params as { uris: string[] };
+      expect(params.uris).toHaveLength(25);
+    });
+  });
+
+  describe('repostPost / unrepostPost', () => {
+    it('repostPost creates a repost record', async () => {
+      const feeds = new TestFeeds();
+      const response = { uri: 'at://repost/1' };
+      feeds.responses = [response];
+
+      const result = await feeds.repostPost('jwt', 'at://post/5', 'cid123', 'did:example:me');
+
+      expect(result).toBe(response as never);
+      const call = feeds.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.repo.createRecord');
+      expect(call.options.method).toBe('POST');
+      expect(call.options.body).toMatchObject({
+        repo: 'did:example:me',
+        collection: 'app.bsky.feed.repost',
+        record: {
+          subject: { uri: 'at://post/5', cid: 'cid123' },
+          $type: 'app.bsky.feed.repost',
+        },
+      });
+      const record = (call.options.body as Record<string, unknown>).record as Record<string, unknown>;
+      expect(typeof record.createdAt).toBe('string');
+    });
+
+    it('unrepostPost deletes the repost record by rkey', async () => {
+      const feeds = new TestFeeds();
+      feeds.responses = [{ success: true }];
+
+      await feeds.unrepostPost('jwt', 'at://did:example:me/app.bsky.feed.repost/999', 'did:example:me');
+
+      expect(feeds.authCalls[0]).toEqual({
+        endpoint: '/com.atproto.repo.deleteRecord',
+        accessJwt: 'jwt',
+        options: {
+          method: 'POST',
+          body: { collection: 'app.bsky.feed.repost', repo: 'did:example:me', rkey: '999' },
+        },
+      });
+    });
+
+    it('unrepostPost throws when the repost URI has no rkey', async () => {
+      const feeds = new TestFeeds();
+
+      await expect(feeds.unrepostPost('jwt', '', 'did:example:me')).rejects.toThrow(
+        'Invalid repost URI: could not extract rkey',
+      );
+      expect(feeds.authCalls).toHaveLength(0);
+    });
+  });
+
+  describe('createReport', () => {
+    it('reports an account via repoRef without a labeler header', async () => {
+      const feeds = new TestFeeds();
+      feeds.responses = [{ id: 1 }];
+
+      await feeds.createReport('jwt', { did: 'did:example:bad' }, 'spam', 'because');
+
+      const call = feeds.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.moderation.createReport');
+      expect(call.options.method).toBe('POST');
+      expect(call.options.body).toEqual({
+        reasonType: 'com.atproto.moderation.defs#spam',
+        reason: 'because',
+        subject: { $type: 'com.atproto.admin.defs#repoRef', did: 'did:example:bad' },
+      });
+      expect(call.options.headers).toBeUndefined();
+    });
+
+    it('reports a post via strongRef and routes to a labeler', async () => {
+      const feeds = new TestFeeds();
+      feeds.responses = [{ id: 2 }];
+
+      await feeds.createReport(
+        'jwt',
+        { uri: 'at://post/1', cid: 'cid1' },
+        'violation',
+        undefined,
+        'did:example:labeler',
+      );
+
+      const call = feeds.authCalls[0];
+      expect(call.options.body).toMatchObject({
+        reasonType: 'com.atproto.moderation.defs#violation',
+        subject: { $type: 'com.atproto.repo.strongRef', uri: 'at://post/1', cid: 'cid1' },
+      });
+      expect(call.options.headers).toEqual({ 'atproto-proxy': 'did:example:labeler#atproto_labeler' });
+    });
+  });
+
+  describe('setThreadgate', () => {
+    it('writes a nobody record with an empty allow list', async () => {
+      const feeds = new TestFeeds();
+      feeds.responses = [{ uri: 'at://gate/1' }];
+
+      await feeds.setThreadgate('jwt', 'did:example:me', 'at://did:example:me/app.bsky.feed.post/abc', {
+        type: 'nobody',
+      });
+
+      const call = feeds.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.repo.putRecord');
+      const body = call.options.body as { repo: string; collection: string; rkey: string; record: Record<string, unknown> };
+      expect(body.repo).toBe('did:example:me');
+      expect(body.collection).toBe('app.bsky.feed.threadgate');
+      expect(body.rkey).toBe('abc');
+      expect(body.record.allow).toEqual([]);
+    });
+
+    it('maps limited rules to lexicon rule objects', async () => {
+      const feeds = new TestFeeds();
+      feeds.responses = [{ uri: 'at://gate/1' }];
+
+      await feeds.setThreadgate('jwt', 'did:example:me', 'at://did:example:me/app.bsky.feed.post/abc', {
+        type: 'limited',
+        mention: true,
+        following: true,
+        follower: true,
+        listUris: ['at://list/1'],
+      });
+
+      const body = feeds.authCalls[0].options.body as { record: Record<string, unknown> };
+      expect(body.record.allow).toEqual([
+        { $type: 'app.bsky.feed.threadgate#mentionRule' },
+        { $type: 'app.bsky.feed.threadgate#followingRule' },
+        { $type: 'app.bsky.feed.threadgate#followerRule' },
+        { $type: 'app.bsky.feed.threadgate#listRule', list: 'at://list/1' },
+      ]);
+    });
+
+    it('omits allow entirely for everyone', async () => {
+      const feeds = new TestFeeds();
+      feeds.responses = [{ uri: 'at://gate/1' }];
+
+      await feeds.setThreadgate('jwt', 'did:example:me', 'at://did:example:me/app.bsky.feed.post/abc', {
+        type: 'everyone',
+      });
+
+      const body = feeds.authCalls[0].options.body as { record: Record<string, unknown> };
+      expect(body.record).not.toHaveProperty('allow');
+    });
+
+    it('throws when the post URI has no rkey', async () => {
+      const feeds = new TestFeeds();
+
+      await expect(
+        feeds.setThreadgate('jwt', 'did:example:me', '', { type: 'everyone' }),
+      ).rejects.toThrow('Invalid post URI: ');
+      expect(feeds.authCalls).toHaveLength(0);
+    });
+  });
+
+  describe('setPostgate', () => {
+    it('disables quotes when allowQuote is false', async () => {
+      const feeds = new TestFeeds();
+      feeds.responses = [{ uri: 'at://postgate/1' }];
+
+      await feeds.setPostgate('jwt', 'did:example:me', 'at://did:example:me/app.bsky.feed.post/abc', {
+        allowQuote: false,
+      });
+
+      const call = feeds.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.repo.putRecord');
+      const body = call.options.body as { collection: string; rkey: string; record: Record<string, unknown> };
+      expect(body.collection).toBe('app.bsky.feed.postgate');
+      expect(body.rkey).toBe('abc');
+      expect(body.record.embeddingRules).toEqual([{ $type: 'app.bsky.feed.postgate#disableRule' }]);
+    });
+
+    it('leaves quotes enabled with an empty rule list', async () => {
+      const feeds = new TestFeeds();
+      feeds.responses = [{ uri: 'at://postgate/1' }];
+
+      await feeds.setPostgate('jwt', 'did:example:me', 'at://did:example:me/app.bsky.feed.post/abc', {
+        allowQuote: true,
+      });
+
+      const body = feeds.authCalls[0].options.body as { record: Record<string, unknown> };
+      expect(body.record.embeddingRules).toEqual([]);
+    });
+
+    it('throws when the post URI has no rkey', async () => {
+      const feeds = new TestFeeds();
+
+      await expect(feeds.setPostgate('jwt', 'did:example:me', '', { allowQuote: true })).rejects.toThrow(
+        'Invalid post URI: ',
+      );
+      expect(feeds.authCalls).toHaveLength(0);
+    });
+  });
+
+  describe('createPost embed branches', () => {
+    it('embeds a video when no media images are present', async () => {
+      const feeds = new TestFeeds();
+      feeds.responses = [{ uri: 'at://post/vid' }];
+
+      await feeds.createPost('jwt', 'did:example:me', {
+        text: 'A video',
+        video: {
+          blob: { ref: { $link: 'blob/vid' }, mimeType: 'video/mp4', size: 9999 },
+          alt: 'clip',
+          aspectRatio: { width: 16, height: 9 },
+        } as never,
+      });
+
+      const body = feeds.authCalls[0].options.body as { record: Record<string, unknown> };
+      expect(body.record.embed).toEqual({
+        $type: 'app.bsky.embed.video',
+        video: { ref: { $link: 'blob/vid' }, mimeType: 'video/mp4', size: 9999 },
+        alt: 'clip',
+        aspectRatio: { width: 16, height: 9 },
+      });
+    });
+
+    it('wraps a quote alone in a record embed', async () => {
+      const feeds = new TestFeeds();
+      feeds.responses = [{ uri: 'at://post/quote' }];
+
+      await feeds.createPost('jwt', 'did:example:me', {
+        text: 'Quoting',
+        quote: { uri: 'at://post/quoted', cid: 'cid-q' },
+      });
+
+      const body = feeds.authCalls[0].options.body as { record: Record<string, unknown> };
+      expect(body.record.embed).toEqual({
+        $type: 'app.bsky.embed.record',
+        record: { uri: 'at://post/quoted', cid: 'cid-q' },
+      });
+    });
+
+    it('wraps a quote plus media in a recordWithMedia embed', async () => {
+      const feeds = new TestFeeds();
+      feeds.responses = [{ uri: 'at://post/quote-media' }];
+      const uploadResult: BlueskyUploadBlobResponse = {
+        blob: { ref: { $link: 'blob/img' }, mimeType: 'image/png', size: 100 },
+      };
+      const uploadImageSpy = jest.spyOn(feeds, 'uploadImage').mockResolvedValue(uploadResult);
+
+      await feeds.createPost('jwt', 'did:example:me', {
+        text: 'Quote with image',
+        quote: { uri: 'at://post/quoted', cid: 'cid-q' },
+        images: [{ uri: 'file://img.png', mimeType: 'image/png', alt: 'pic' }],
+      });
+
+      const body = feeds.authCalls[0].options.body as { record: Record<string, unknown> };
+      expect(body.record.embed).toMatchObject({
+        $type: 'app.bsky.embed.recordWithMedia',
+        record: { $type: 'app.bsky.embed.record', record: { uri: 'at://post/quoted', cid: 'cid-q' } },
+        media: { $type: 'app.bsky.embed.images' },
+      });
+
+      uploadImageSpy.mockRestore();
+    });
+
+    it('embeds an external link when no other media or quote is set', async () => {
+      const feeds = new TestFeeds();
+      feeds.responses = [{ uri: 'at://post/ext' }];
+
+      await feeds.createPost('jwt', 'did:example:me', {
+        text: 'Link post',
+        externalEmbed: { uri: 'https://example.com', title: 'Example', description: 'A site' },
+      });
+
+      const body = feeds.authCalls[0].options.body as { record: Record<string, unknown> };
+      expect(body.record.embed).toEqual({
+        $type: 'app.bsky.embed.external',
+        external: { uri: 'https://example.com', title: 'Example', description: 'A site' },
+      });
+    });
+  });
+
+  describe('sendInteractions', () => {
+    it('proxies events to the feed generator', async () => {
+      const feeds = new TestFeeds();
+      feeds.responses = [{}];
+      const interactions = [{ event: 'app.bsky.feed.defs#requestMore', item: 'at://post/1' }];
+
+      await feeds.sendInteractions('jwt', 'did:example:fg', interactions);
+
+      expect(feeds.authCalls[0]).toEqual({
+        endpoint: '/app.bsky.feed.sendInteractions',
+        accessJwt: 'jwt',
+        options: {
+          method: 'POST',
+          body: { interactions },
+          headers: { 'atproto-proxy': 'did:example:fg#bsky_fg' },
+        },
+      });
+    });
+  });
+});

--- a/packages/bluesky-api/src/flashes.test.ts
+++ b/packages/bluesky-api/src/flashes.test.ts
@@ -1,0 +1,104 @@
+import { BlueskyFlashes } from './flashes';
+import type { FlashesStoryRecordsResponse } from './flashes';
+
+describe('BlueskyFlashes', () => {
+  class TestFlashes extends BlueskyFlashes {
+    public authCalls: {
+      endpoint: string;
+      accessJwt: string;
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      };
+    }[] = [];
+
+    public responses: unknown[] = [];
+    public errors: unknown[] = [];
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      this.authCalls.push({ endpoint, accessJwt, options });
+      if (this.errors.length > 0) {
+        throw this.errors.shift();
+      }
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+  }
+
+  it('lists story records with the default limit and no cursor', async () => {
+    const flashes = new TestFlashes();
+    const response = { records: [] } as FlashesStoryRecordsResponse;
+    flashes.responses = [response];
+
+    const result = await flashes.getActorStories('jwt', 'did:example:alice');
+
+    expect(result).toBe(response);
+    expect(flashes.authCalls).toEqual([
+      {
+        endpoint: '/com.atproto.repo.listRecords',
+        accessJwt: 'jwt',
+        options: {
+          params: {
+            repo: 'did:example:alice',
+            collection: 'blue.flashes.story.post',
+            limit: '50',
+          },
+        },
+      },
+    ]);
+  });
+
+  it('forwards a custom limit and cursor', async () => {
+    const flashes = new TestFlashes();
+    const response = { records: [], cursor: 'next' } as FlashesStoryRecordsResponse;
+    flashes.responses = [response];
+
+    const result = await flashes.getActorStories('jwt', 'did:example:bob', 10, 'cursor-1');
+
+    expect(result).toBe(response);
+    expect(flashes.authCalls[0]).toEqual({
+      endpoint: '/com.atproto.repo.listRecords',
+      accessJwt: 'jwt',
+      options: {
+        params: {
+          repo: 'did:example:bob',
+          collection: 'blue.flashes.story.post',
+          limit: '10',
+          cursor: 'cursor-1',
+        },
+      },
+    });
+  });
+
+  it('accepts an empty access token for the public read', async () => {
+    const flashes = new TestFlashes();
+    flashes.responses = [{ records: [] } as FlashesStoryRecordsResponse];
+
+    await flashes.getActorStories('', 'did:example:carol');
+
+    expect(flashes.authCalls[0].accessJwt).toBe('');
+  });
+
+  it('returns an empty result when the request fails', async () => {
+    const flashes = new TestFlashes();
+    flashes.errors = [new Error('boom')];
+
+    const result = await flashes.getActorStories('jwt', 'did:example:dave', 5, 'cursor-2');
+
+    expect(result).toEqual({ records: [], cursor: undefined });
+  });
+});

--- a/packages/bluesky-api/src/grain.test.ts
+++ b/packages/bluesky-api/src/grain.test.ts
@@ -1,0 +1,265 @@
+import {
+  BlueskyGrain,
+  buildGrainPhotoBlobUrl,
+  type GrainGalleryItemRecordsResponse,
+  type GrainGalleryRecordsResponse,
+  type GrainPhotoExifRecordsResponse,
+  type GrainPhotoRecordsResponse,
+} from './grain';
+
+describe('BlueskyGrain', () => {
+  class TestGrain extends BlueskyGrain {
+    public authCalls: {
+      endpoint: string;
+      accessJwt: string;
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      };
+    }[] = [];
+
+    public responses: unknown[] = [];
+    public throwOnNext = false;
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      this.authCalls.push({ endpoint, accessJwt, options });
+      if (this.throwOnNext) {
+        throw new Error('request failed');
+      }
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+  }
+
+  describe('getActorGalleries', () => {
+    it('lists gallery records with the default limit and no cursor', async () => {
+      const grain = new TestGrain();
+      const response = { records: [], cursor: undefined } as GrainGalleryRecordsResponse;
+      grain.responses = [response];
+
+      const result = await grain.getActorGalleries('jwt', 'did:example:alice');
+
+      expect(result).toBe(response);
+      expect(grain.authCalls).toEqual([
+        {
+          endpoint: '/com.atproto.repo.listRecords',
+          accessJwt: 'jwt',
+          options: {
+            params: {
+              repo: 'did:example:alice',
+              collection: 'social.grain.gallery',
+              limit: '50',
+            },
+          },
+        },
+      ]);
+    });
+
+    it('forwards a custom limit and cursor', async () => {
+      const grain = new TestGrain();
+      const response = { records: [], cursor: 'next' } as GrainGalleryRecordsResponse;
+      grain.responses = [response];
+
+      const result = await grain.getActorGalleries('jwt', 'did:example:alice', 10, 'cursor-1');
+
+      expect(result).toBe(response);
+      expect(grain.authCalls[0].options.params).toEqual({
+        repo: 'did:example:alice',
+        collection: 'social.grain.gallery',
+        limit: '10',
+        cursor: 'cursor-1',
+      });
+    });
+
+    it('returns an empty result when the request throws', async () => {
+      const grain = new TestGrain();
+      grain.throwOnNext = true;
+
+      const result = await grain.getActorGalleries('jwt', 'did:example:alice');
+
+      expect(result).toEqual({ records: [], cursor: undefined });
+    });
+  });
+
+  describe('getActorPhotos', () => {
+    it('lists photo records with the default limit and no cursor', async () => {
+      const grain = new TestGrain();
+      const response = { records: [], cursor: undefined } as GrainPhotoRecordsResponse;
+      grain.responses = [response];
+
+      const result = await grain.getActorPhotos('jwt', 'did:example:bob');
+
+      expect(result).toBe(response);
+      expect(grain.authCalls).toEqual([
+        {
+          endpoint: '/com.atproto.repo.listRecords',
+          accessJwt: 'jwt',
+          options: {
+            params: {
+              repo: 'did:example:bob',
+              collection: 'social.grain.photo',
+              limit: '50',
+            },
+          },
+        },
+      ]);
+    });
+
+    it('forwards a custom limit and cursor', async () => {
+      const grain = new TestGrain();
+      const response = { records: [], cursor: 'next' } as GrainPhotoRecordsResponse;
+      grain.responses = [response];
+
+      const result = await grain.getActorPhotos('jwt', 'did:example:bob', 25, 'cursor-2');
+
+      expect(result).toBe(response);
+      expect(grain.authCalls[0].options.params).toEqual({
+        repo: 'did:example:bob',
+        collection: 'social.grain.photo',
+        limit: '25',
+        cursor: 'cursor-2',
+      });
+    });
+
+    it('returns an empty result when the request throws', async () => {
+      const grain = new TestGrain();
+      grain.throwOnNext = true;
+
+      const result = await grain.getActorPhotos('jwt', 'did:example:bob');
+
+      expect(result).toEqual({ records: [], cursor: undefined });
+    });
+  });
+
+  describe('getActorGalleryItems', () => {
+    it('lists gallery item records with the default limit and no cursor', async () => {
+      const grain = new TestGrain();
+      const response = { records: [], cursor: undefined } as GrainGalleryItemRecordsResponse;
+      grain.responses = [response];
+
+      const result = await grain.getActorGalleryItems('jwt', 'did:example:carol');
+
+      expect(result).toBe(response);
+      expect(grain.authCalls).toEqual([
+        {
+          endpoint: '/com.atproto.repo.listRecords',
+          accessJwt: 'jwt',
+          options: {
+            params: {
+              repo: 'did:example:carol',
+              collection: 'social.grain.gallery.item',
+              limit: '100',
+            },
+          },
+        },
+      ]);
+    });
+
+    it('forwards a custom limit and cursor', async () => {
+      const grain = new TestGrain();
+      const response = { records: [], cursor: 'next' } as GrainGalleryItemRecordsResponse;
+      grain.responses = [response];
+
+      const result = await grain.getActorGalleryItems('jwt', 'did:example:carol', 5, 'cursor-3');
+
+      expect(result).toBe(response);
+      expect(grain.authCalls[0].options.params).toEqual({
+        repo: 'did:example:carol',
+        collection: 'social.grain.gallery.item',
+        limit: '5',
+        cursor: 'cursor-3',
+      });
+    });
+
+    it('returns an empty result when the request throws', async () => {
+      const grain = new TestGrain();
+      grain.throwOnNext = true;
+
+      const result = await grain.getActorGalleryItems('jwt', 'did:example:carol');
+
+      expect(result).toEqual({ records: [], cursor: undefined });
+    });
+  });
+
+  describe('getActorPhotoExif', () => {
+    it('lists exif records with the default limit and no cursor', async () => {
+      const grain = new TestGrain();
+      const response = { records: [], cursor: undefined } as GrainPhotoExifRecordsResponse;
+      grain.responses = [response];
+
+      const result = await grain.getActorPhotoExif('jwt', 'did:example:dave');
+
+      expect(result).toBe(response);
+      expect(grain.authCalls).toEqual([
+        {
+          endpoint: '/com.atproto.repo.listRecords',
+          accessJwt: 'jwt',
+          options: {
+            params: {
+              repo: 'did:example:dave',
+              collection: 'social.grain.photo.exif',
+              limit: '100',
+            },
+          },
+        },
+      ]);
+    });
+
+    it('forwards a custom limit and cursor', async () => {
+      const grain = new TestGrain();
+      const response = { records: [], cursor: 'next' } as GrainPhotoExifRecordsResponse;
+      grain.responses = [response];
+
+      const result = await grain.getActorPhotoExif('jwt', 'did:example:dave', 7, 'cursor-4');
+
+      expect(result).toBe(response);
+      expect(grain.authCalls[0].options.params).toEqual({
+        repo: 'did:example:dave',
+        collection: 'social.grain.photo.exif',
+        limit: '7',
+        cursor: 'cursor-4',
+      });
+    });
+
+    it('returns an empty result when the request throws', async () => {
+      const grain = new TestGrain();
+      grain.throwOnNext = true;
+
+      const result = await grain.getActorPhotoExif('jwt', 'did:example:dave');
+
+      expect(result).toEqual({ records: [], cursor: undefined });
+    });
+  });
+});
+
+describe('buildGrainPhotoBlobUrl', () => {
+  it('builds a PDS-direct getBlob URL with did and cid query params', () => {
+    const url = buildGrainPhotoBlobUrl('https://pds.example', 'did:plc:abc', 'bafycid');
+
+    expect(url).toBe(
+      'https://pds.example/xrpc/com.atproto.sync.getBlob?did=did%3Aplc%3Aabc&cid=bafycid',
+    );
+  });
+
+  it('url-encodes did and cid values that contain reserved characters', () => {
+    const url = buildGrainPhotoBlobUrl('https://pds.example', 'did:web:example.com#key', 'a+b/c=d');
+
+    expect(url).toBe(
+      'https://pds.example/xrpc/com.atproto.sync.getBlob?did=did%3Aweb%3Aexample.com%23key&cid=a%2Bb%2Fc%3Dd',
+    );
+  });
+});

--- a/packages/bluesky-api/src/graph.coverage.test.ts
+++ b/packages/bluesky-api/src/graph.coverage.test.ts
@@ -1,0 +1,385 @@
+import { BlueskyGraph } from './graph';
+import type {
+  BlueskyBlocksResponse,
+  BlueskyCreateRecordResponse,
+  BlueskyFollowRecordsResponse,
+  BlueskyFollowsResponse,
+  BlueskyListBlocksResponse,
+  BlueskyListMutesResponse,
+  BlueskyListResponse,
+  BlueskyListsResponse,
+  BlueskyMutesResponse,
+} from './types';
+
+describe('BlueskyGraph (coverage)', () => {
+  class TestGraph extends BlueskyGraph {
+    public calls: {
+      endpoint: string;
+      accessJwt: string;
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      };
+    }[] = [];
+
+    public responses: unknown[] = [];
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      this.calls.push({ endpoint, accessJwt, options });
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+  }
+
+  it('mutes and unmutes an actor list via dedicated endpoints', async () => {
+    const graph = new TestGraph();
+    graph.responses = [{ ok: 1 }, { ok: 2 }];
+
+    const muteResult = await graph.muteActorList('jwt', 'at://list/1');
+    const unmuteResult = await graph.unmuteActorList('jwt', 'at://list/1');
+
+    expect(muteResult).toEqual({ ok: 1 });
+    expect(unmuteResult).toEqual({ ok: 2 });
+
+    expect(graph.calls[0]).toEqual({
+      endpoint: '/app.bsky.graph.muteActorList',
+      accessJwt: 'jwt',
+      options: { method: 'POST', body: { list: 'at://list/1' } },
+    });
+    expect(graph.calls[1]).toEqual({
+      endpoint: '/app.bsky.graph.unmuteActorList',
+      accessJwt: 'jwt',
+      options: { method: 'POST', body: { list: 'at://list/1' } },
+    });
+  });
+
+  it('blocks an actor list by creating a listblock record', async () => {
+    const graph = new TestGraph();
+    const response = { uri: 'at://me/app.bsky.graph.listblock/1', cid: 'cid' } as BlueskyCreateRecordResponse;
+    graph.responses = [response];
+
+    const result = await graph.blockActorList('jwt', 'did:example:me', 'at://list/1');
+
+    expect(result).toEqual(response);
+    expect(graph.calls[0]).toMatchObject({
+      endpoint: '/com.atproto.repo.createRecord',
+      accessJwt: 'jwt',
+      options: {
+        method: 'POST',
+        body: {
+          repo: 'did:example:me',
+          collection: 'app.bsky.graph.listblock',
+          record: expect.objectContaining({
+            $type: 'app.bsky.graph.listblock',
+            subject: 'at://list/1',
+          }),
+        },
+      },
+    });
+    const body = graph.calls[0].options.body as { record: Record<string, unknown> };
+    expect(typeof body.record.createdAt).toBe('string');
+  });
+
+  it('unblocks an actor list by deleting the parsed listblock record', async () => {
+    const graph = new TestGraph();
+    graph.responses = [{ success: true }];
+
+    const result = await graph.unblockActorList(
+      'jwt',
+      'at://did:example:me/app.bsky.graph.listblock/abc',
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(graph.calls[0]).toEqual({
+      endpoint: '/com.atproto.repo.deleteRecord',
+      accessJwt: 'jwt',
+      options: {
+        method: 'POST',
+        body: {
+          repo: 'did:example:me',
+          collection: 'app.bsky.graph.listblock',
+          rkey: 'abc',
+        },
+      },
+    });
+  });
+
+  it('throws on an invalid AT URI when unblocking an actor list', async () => {
+    const graph = new TestGraph();
+    await expect(graph.unblockActorList('jwt', 'not-an-at-uri')).rejects.toThrow(
+      'Invalid AT URI: not-an-at-uri',
+    );
+  });
+
+  it('fetches mutes with default limit and no cursor', async () => {
+    const graph = new TestGraph();
+    const response = { mutes: [] } as unknown as BlueskyMutesResponse;
+    graph.responses = [response];
+
+    const result = await graph.getMutes('jwt');
+
+    expect(result).toEqual(response);
+    expect(graph.calls[0]).toEqual({
+      endpoint: '/app.bsky.graph.getMutes',
+      accessJwt: 'jwt',
+      options: { params: { limit: '50' } },
+    });
+  });
+
+  it('fetches mutes with explicit limit and cursor', async () => {
+    const graph = new TestGraph();
+    graph.responses = [{ mutes: [] }];
+
+    await graph.getMutes('jwt', 10, 'cur');
+
+    expect(graph.calls[0].options.params).toEqual({ limit: '10', cursor: 'cur' });
+  });
+
+  it('fetches blocks with default and explicit params', async () => {
+    const graph = new TestGraph();
+    const response = { blocks: [] } as unknown as BlueskyBlocksResponse;
+    graph.responses = [response, { blocks: [] }];
+
+    const result = await graph.getBlocks('jwt');
+    await graph.getBlocks('jwt', 5, 'next');
+
+    expect(result).toEqual(response);
+    expect(graph.calls[0]).toEqual({
+      endpoint: '/app.bsky.graph.getBlocks',
+      accessJwt: 'jwt',
+      options: { params: { limit: '50' } },
+    });
+    expect(graph.calls[1].options.params).toEqual({ limit: '5', cursor: 'next' });
+  });
+
+  it('fetches follows for an actor with default and explicit params', async () => {
+    const graph = new TestGraph();
+    const response = { follows: [] } as unknown as BlueskyFollowsResponse;
+    graph.responses = [response, { follows: [] }];
+
+    const result = await graph.getFollows('jwt', 'did:example:alice');
+    await graph.getFollows('jwt', 'did:example:alice', 25, 'page2');
+
+    expect(result).toEqual(response);
+    expect(graph.calls[0]).toEqual({
+      endpoint: '/app.bsky.graph.getFollows',
+      accessJwt: 'jwt',
+      options: { params: { actor: 'did:example:alice', limit: '100' } },
+    });
+    expect(graph.calls[1].options.params).toEqual({
+      actor: 'did:example:alice',
+      limit: '25',
+      cursor: 'page2',
+    });
+  });
+
+  it('lists raw follow records for a repo', async () => {
+    const graph = new TestGraph();
+    const response = { records: [] } as unknown as BlueskyFollowRecordsResponse;
+    graph.responses = [response, { records: [] }];
+
+    const result = await graph.listFollowRecords('jwt', 'did:example:me');
+    await graph.listFollowRecords('jwt', 'did:example:me', 50, 'cur');
+
+    expect(result).toEqual(response);
+    expect(graph.calls[0]).toEqual({
+      endpoint: '/com.atproto.repo.listRecords',
+      accessJwt: 'jwt',
+      options: {
+        params: {
+          repo: 'did:example:me',
+          collection: 'app.bsky.graph.follow',
+          limit: '100',
+        },
+      },
+    });
+    expect(graph.calls[1].options.params).toEqual({
+      repo: 'did:example:me',
+      collection: 'app.bsky.graph.follow',
+      limit: '50',
+      cursor: 'cur',
+    });
+  });
+
+  it('fetches list mutes with default and explicit params', async () => {
+    const graph = new TestGraph();
+    const response = { lists: [] } as unknown as BlueskyListMutesResponse;
+    graph.responses = [response, { lists: [] }];
+
+    const result = await graph.getListMutes('jwt');
+    await graph.getListMutes('jwt', 20, 'cur');
+
+    expect(result).toEqual(response);
+    expect(graph.calls[0]).toEqual({
+      endpoint: '/app.bsky.graph.getListMutes',
+      accessJwt: 'jwt',
+      options: { params: { limit: '50' } },
+    });
+    expect(graph.calls[1].options.params).toEqual({ limit: '20', cursor: 'cur' });
+  });
+
+  it('fetches list blocks with default and explicit params', async () => {
+    const graph = new TestGraph();
+    const response = { lists: [] } as unknown as BlueskyListBlocksResponse;
+    graph.responses = [response, { lists: [] }];
+
+    const result = await graph.getListBlocks('jwt');
+    await graph.getListBlocks('jwt', 15, 'cur');
+
+    expect(result).toEqual(response);
+    expect(graph.calls[0]).toEqual({
+      endpoint: '/app.bsky.graph.getListBlocks',
+      accessJwt: 'jwt',
+      options: { params: { limit: '50' } },
+    });
+    expect(graph.calls[1].options.params).toEqual({ limit: '15', cursor: 'cur' });
+  });
+
+  it('gets lists curated by an actor with default and explicit params', async () => {
+    const graph = new TestGraph();
+    const response = { lists: [] } as unknown as BlueskyListsResponse;
+    graph.responses = [response, { lists: [] }];
+
+    const result = await graph.getLists('jwt', 'did:example:alice');
+    await graph.getLists('jwt', 'did:example:alice', 30, 'cur');
+
+    expect(result).toEqual(response);
+    expect(graph.calls[0]).toEqual({
+      endpoint: '/app.bsky.graph.getLists',
+      accessJwt: 'jwt',
+      options: { params: { actor: 'did:example:alice', limit: '50' } },
+    });
+    expect(graph.calls[1].options.params).toEqual({
+      actor: 'did:example:alice',
+      limit: '30',
+      cursor: 'cur',
+    });
+  });
+
+  it('gets a single list view with default and explicit params', async () => {
+    const graph = new TestGraph();
+    const response = { list: {}, items: [] } as unknown as BlueskyListResponse;
+    graph.responses = [response, { list: {}, items: [] }];
+
+    const result = await graph.getList('jwt', 'at://list/1');
+    await graph.getList('jwt', 'at://list/1', 40, 'cur');
+
+    expect(result).toEqual(response);
+    expect(graph.calls[0]).toEqual({
+      endpoint: '/app.bsky.graph.getList',
+      accessJwt: 'jwt',
+      options: { params: { list: 'at://list/1', limit: '50' } },
+    });
+    expect(graph.calls[1].options.params).toEqual({
+      list: 'at://list/1',
+      limit: '40',
+      cursor: 'cur',
+    });
+  });
+
+  it('creates a list with a description', async () => {
+    const graph = new TestGraph();
+    const response = { uri: 'at://me/app.bsky.graph.list/1', cid: 'cid' } as BlueskyCreateRecordResponse;
+    graph.responses = [response];
+
+    const result = await graph.createList('jwt', 'did:example:me', {
+      name: 'Friends',
+      purpose: 'app.bsky.graph.defs#curatelist',
+      description: 'My pals',
+    });
+
+    expect(result).toEqual(response);
+    expect(graph.calls[0]).toMatchObject({
+      endpoint: '/com.atproto.repo.createRecord',
+      accessJwt: 'jwt',
+      options: {
+        method: 'POST',
+        body: {
+          repo: 'did:example:me',
+          collection: 'app.bsky.graph.list',
+          record: expect.objectContaining({
+            $type: 'app.bsky.graph.list',
+            name: 'Friends',
+            purpose: 'app.bsky.graph.defs#curatelist',
+            description: 'My pals',
+          }),
+        },
+      },
+    });
+    const body = graph.calls[0].options.body as { record: Record<string, unknown> };
+    expect(typeof body.record.createdAt).toBe('string');
+  });
+
+  it('creates a list without a description', async () => {
+    const graph = new TestGraph();
+    graph.responses = [{ uri: 'at://me/app.bsky.graph.list/2', cid: 'cid' }];
+
+    await graph.createList('jwt', 'did:example:me', {
+      name: 'Blocked',
+      purpose: 'app.bsky.graph.defs#modlist',
+    });
+
+    const body = graph.calls[0].options.body as { record: Record<string, unknown> };
+    expect(body.record.description).toBeUndefined();
+    expect(body.record.purpose).toBe('app.bsky.graph.defs#modlist');
+  });
+
+  it('adds an actor to a list by creating a listitem record', async () => {
+    const graph = new TestGraph();
+    const response = { uri: 'at://me/app.bsky.graph.listitem/1', cid: 'cid' } as BlueskyCreateRecordResponse;
+    graph.responses = [response];
+
+    const result = await graph.addToList('jwt', 'did:example:me', 'at://list/1', 'did:example:bob');
+
+    expect(result).toEqual(response);
+    expect(graph.calls[0]).toMatchObject({
+      endpoint: '/com.atproto.repo.createRecord',
+      accessJwt: 'jwt',
+      options: {
+        method: 'POST',
+        body: {
+          repo: 'did:example:me',
+          collection: 'app.bsky.graph.listitem',
+          record: expect.objectContaining({
+            $type: 'app.bsky.graph.listitem',
+            subject: 'did:example:bob',
+            list: 'at://list/1',
+          }),
+        },
+      },
+    });
+    const body = graph.calls[0].options.body as { record: Record<string, unknown> };
+    expect(typeof body.record.createdAt).toBe('string');
+  });
+
+  it('removes a list membership by deleting its listitem record', async () => {
+    const graph = new TestGraph();
+    graph.responses = [{ success: true }];
+
+    const result = await graph.removeFromList('jwt', 'at://me/app.bsky.graph.listitem/1');
+
+    expect(result).toEqual({ success: true });
+    expect(graph.calls[0]).toEqual({
+      endpoint: '/com.atproto.repo.deleteRecord',
+      accessJwt: 'jwt',
+      options: {
+        method: 'POST',
+        body: { uri: 'at://me/app.bsky.graph.listitem/1' },
+      },
+    });
+  });
+});

--- a/packages/bluesky-api/src/leaflet.test.ts
+++ b/packages/bluesky-api/src/leaflet.test.ts
@@ -1,0 +1,266 @@
+import { BlueskyLeaflet } from './leaflet';
+import type { LeafletPublicationRecord } from './leaflet';
+
+type RequestOptions = {
+  method?: 'GET' | 'POST';
+  body?: Record<string, unknown> | FormData | Blob;
+  params?: Record<string, string | string[]>;
+  headers?: Record<string, string>;
+};
+
+describe('BlueskyLeaflet', () => {
+  class TestLeaflet extends BlueskyLeaflet {
+    public authCalls: {
+      endpoint: string;
+      accessJwt: string;
+      options: RequestOptions;
+    }[] = [];
+
+    public requestCalls: {
+      endpoint: string;
+      options: RequestOptions;
+    }[] = [];
+
+    public responses: unknown[] = [];
+
+    /** When set, makeAuthenticatedRequest throws on the matching call index. */
+    public throwOnAuthCall: number | null = null;
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: RequestOptions = {},
+    ): Promise<T> {
+      const index = this.authCalls.length;
+      this.authCalls.push({ endpoint, accessJwt, options });
+      if (this.throwOnAuthCall === index) {
+        throw new Error('simulated failure');
+      }
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+
+    protected async makeRequest<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
+      this.requestCalls.push({ endpoint, options });
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+  }
+
+  describe('listPublications', () => {
+    it('returns the listRecords response with default limit', async () => {
+      const leaflet = new TestLeaflet();
+      const response = {
+        records: [{ uri: 'at://did/pub.leaflet.publication/abc', cid: 'cid1', value: {} }],
+        cursor: 'next',
+      };
+      leaflet.responses = [response];
+
+      const result = await leaflet.listPublications('jwt', 'did:example:me');
+
+      expect(result).toBe(response);
+      expect(leaflet.authCalls).toEqual([
+        {
+          endpoint: '/com.atproto.repo.listRecords',
+          accessJwt: 'jwt',
+          options: {
+            params: {
+              repo: 'did:example:me',
+              collection: 'pub.leaflet.publication',
+              limit: '10',
+            },
+          },
+        },
+      ]);
+    });
+
+    it('treats request failures as an empty record set', async () => {
+      const leaflet = new TestLeaflet();
+      leaflet.throwOnAuthCall = 0;
+
+      const result = await leaflet.listPublications('jwt', 'did:example:me');
+
+      expect(result).toEqual({ records: [] });
+      expect(leaflet.authCalls).toHaveLength(1);
+    });
+  });
+
+  describe('findOrCreatePublication', () => {
+    it('returns the first existing publication and derives the rkey from its uri', async () => {
+      const leaflet = new TestLeaflet();
+      const existing: { records: LeafletPublicationRecord[] } = {
+        records: [
+          { uri: 'at://did:example:me/pub.leaflet.publication/rkey-1', cid: 'cid-existing', value: { name: 'Mine' } },
+          { uri: 'at://did:example:me/pub.leaflet.publication/rkey-2', cid: 'cid-other', value: {} },
+        ],
+      };
+      leaflet.responses = [existing];
+
+      const result = await leaflet.findOrCreatePublication('jwt', 'did:example:me', { name: 'Default' });
+
+      expect(result).toEqual({
+        uri: 'at://did:example:me/pub.leaflet.publication/rkey-1',
+        cid: 'cid-existing',
+        rkey: 'rkey-1',
+      });
+      // Only listPublications should have been called; no createRecord.
+      expect(leaflet.authCalls).toHaveLength(1);
+      expect(leaflet.authCalls[0].endpoint).toBe('/com.atproto.repo.listRecords');
+    });
+
+    it('falls back to an empty rkey when the existing uri has no trailing segment', async () => {
+      const leaflet = new TestLeaflet();
+      const existing: { records: LeafletPublicationRecord[] } = {
+        records: [{ uri: '', cid: 'cid-existing', value: {} }],
+      };
+      leaflet.responses = [existing];
+
+      const result = await leaflet.findOrCreatePublication('jwt', 'did:example:me', { name: 'Default' });
+
+      expect(result).toEqual({ uri: '', cid: 'cid-existing', rkey: '' });
+    });
+
+    it('creates a new publication with description when none exists', async () => {
+      const leaflet = new TestLeaflet();
+      const listResponse = { records: [] };
+      const createResponse = { uri: 'at://did:example:me/pub.leaflet.publication/new-rkey', cid: 'cid-new' };
+      leaflet.responses = [listResponse, createResponse];
+
+      const result = await leaflet.findOrCreatePublication('jwt', 'did:example:me', {
+        name: 'My Pub',
+        description: 'A description',
+      });
+
+      expect(result).toEqual({
+        uri: 'at://did:example:me/pub.leaflet.publication/new-rkey',
+        cid: 'cid-new',
+        rkey: 'new-rkey',
+      });
+      expect(leaflet.authCalls).toHaveLength(2);
+      expect(leaflet.authCalls[1]).toEqual({
+        endpoint: '/com.atproto.repo.createRecord',
+        accessJwt: 'jwt',
+        options: {
+          method: 'POST',
+          body: {
+            repo: 'did:example:me',
+            collection: 'pub.leaflet.publication',
+            record: {
+              $type: 'pub.leaflet.publication',
+              name: 'My Pub',
+              description: 'A description',
+            },
+          },
+        },
+      });
+    });
+
+    it('omits the description field when no description is supplied', async () => {
+      const leaflet = new TestLeaflet();
+      const listResponse = { records: [] };
+      const createResponse = { uri: 'at://did:example:me/pub.leaflet.publication/r', cid: 'cid-new' };
+      leaflet.responses = [listResponse, createResponse];
+
+      await leaflet.findOrCreatePublication('jwt', 'did:example:me', { name: 'No Desc' });
+
+      const createBody = leaflet.authCalls[1].options.body as { record: Record<string, unknown> };
+      expect(createBody.record).toEqual({
+        $type: 'pub.leaflet.publication',
+        name: 'No Desc',
+      });
+      expect(createBody.record).not.toHaveProperty('description');
+    });
+
+    it('falls back to an empty rkey when the created uri has no trailing segment', async () => {
+      const leaflet = new TestLeaflet();
+      const listResponse = { records: [] };
+      const createResponse = { uri: '', cid: 'cid-new' };
+      leaflet.responses = [listResponse, createResponse];
+
+      const result = await leaflet.findOrCreatePublication('jwt', 'did:example:me', { name: 'X' });
+
+      expect(result).toEqual({ uri: '', cid: 'cid-new', rkey: '' });
+    });
+  });
+
+  describe('createDocument', () => {
+    it('ships paragraphs as text and header blocks and derives the rkey', async () => {
+      const leaflet = new TestLeaflet();
+      const createResponse = { uri: 'at://did:example:me/pub.leaflet.document/doc-rkey', cid: 'cid-doc' };
+      leaflet.responses = [createResponse];
+
+      const result = await leaflet.createDocument('jwt', 'did:example:me', {
+        title: 'My Title',
+        body: '# Heading One\n\nFirst paragraph.\n\n### Smaller heading\n\nSecond paragraph.',
+        publicationUri: 'at://did:example:me/pub.leaflet.publication/pub-rkey',
+        author: 'did:example:me',
+      });
+
+      expect(result).toEqual({
+        uri: 'at://did:example:me/pub.leaflet.document/doc-rkey',
+        cid: 'cid-doc',
+        rkey: 'doc-rkey',
+      });
+
+      expect(leaflet.authCalls).toHaveLength(1);
+      const call = leaflet.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.repo.createRecord');
+      expect(call.accessJwt).toBe('jwt');
+      expect(call.options.method).toBe('POST');
+
+      const body = call.options.body as { repo: string; collection: string; record: Record<string, unknown> };
+      expect(body.repo).toBe('did:example:me');
+      expect(body.collection).toBe('pub.leaflet.document');
+      expect(body.record).toMatchObject({
+        $type: 'pub.leaflet.document',
+        title: 'My Title',
+        author: 'did:example:me',
+        publication: 'at://did:example:me/pub.leaflet.publication/pub-rkey',
+      });
+      expect(typeof body.record.publishedAt).toBe('string');
+
+      const pages = body.record.pages as { $type: string; blocks: { block: Record<string, unknown> }[] }[];
+      expect(pages).toHaveLength(1);
+      expect(pages[0].$type).toBe('pub.leaflet.pages.linearDocument');
+      expect(pages[0].blocks).toEqual([
+        { block: { $type: 'pub.leaflet.blocks.header', level: 1, plaintext: 'Heading One' } },
+        { block: { $type: 'pub.leaflet.blocks.text', plaintext: 'First paragraph.' } },
+        { block: { $type: 'pub.leaflet.blocks.header', level: 3, plaintext: 'Smaller heading' } },
+        { block: { $type: 'pub.leaflet.blocks.text', plaintext: 'Second paragraph.' } },
+      ]);
+    });
+
+    it('produces an empty block list for whitespace-only bodies', async () => {
+      const leaflet = new TestLeaflet();
+      const createResponse = { uri: 'at://did/pub.leaflet.document/d', cid: 'cid-doc' };
+      leaflet.responses = [createResponse];
+
+      await leaflet.createDocument('jwt', 'did:example:me', {
+        title: 'Empty',
+        body: '   \n\n   \n\n  ',
+        publicationUri: 'at://pub',
+        author: 'did:example:me',
+      });
+
+      const body = leaflet.authCalls[0].options.body as { record: Record<string, unknown> };
+      const pages = body.record.pages as { blocks: unknown[] }[];
+      expect(pages[0].blocks).toEqual([]);
+    });
+
+    it('falls back to an empty rkey when the created uri has no trailing segment', async () => {
+      const leaflet = new TestLeaflet();
+      leaflet.responses = [{ uri: '', cid: 'cid-doc' }];
+
+      const result = await leaflet.createDocument('jwt', 'did:example:me', {
+        title: 'T',
+        body: 'plain text body',
+        publicationUri: 'at://pub',
+        author: 'did:example:me',
+      });
+
+      expect(result).toEqual({ uri: '', cid: 'cid-doc', rkey: '' });
+    });
+  });
+});

--- a/packages/bluesky-api/src/poll.test.ts
+++ b/packages/bluesky-api/src/poll.test.ts
@@ -1,0 +1,141 @@
+import { BlueskyPoll, type PollCreateRecordResponse } from './poll';
+
+describe('BlueskyPoll', () => {
+  class TestPoll extends BlueskyPoll {
+    public authCalls: {
+      endpoint: string;
+      accessJwt: string;
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      };
+    }[] = [];
+
+    public requestCalls: {
+      endpoint: string;
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      };
+    }[] = [];
+
+    public responses: unknown[] = [];
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      this.authCalls.push({ endpoint, accessJwt, options });
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+
+    protected async makeRequest<T>(
+      endpoint: string,
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      this.requestCalls.push({ endpoint, options });
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+  }
+
+  describe('createPoll', () => {
+    it('creates a tech.tokimeki.poll.poll record and returns the response', async () => {
+      const poll = new TestPoll();
+      const response: PollCreateRecordResponse = { uri: 'at://poll/1', cid: 'cidpoll' };
+      poll.responses = [response];
+
+      const result = await poll.createPoll('jwt', 'did:example:me', {
+        options: ['A', 'B', 'C'],
+        endsAt: '2026-06-01T00:00:00.000Z',
+      });
+
+      expect(result).toBe(response);
+      expect(poll.authCalls).toHaveLength(1);
+      const call = poll.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.repo.createRecord');
+      expect(call.accessJwt).toBe('jwt');
+      expect(call.options.method).toBe('POST');
+
+      const body = call.options.body as {
+        repo: string;
+        collection: string;
+        record: Record<string, unknown>;
+      };
+      expect(body.repo).toBe('did:example:me');
+      expect(body.collection).toBe('tech.tokimeki.poll.poll');
+      expect(body.record).toMatchObject({
+        $type: 'tech.tokimeki.poll.poll',
+        options: ['A', 'B', 'C'],
+        endsAt: '2026-06-01T00:00:00.000Z',
+      });
+      expect(typeof body.record.createdAt).toBe('string');
+      expect(body.record).not.toHaveProperty('subject');
+    });
+  });
+
+  describe('createVote', () => {
+    it('creates a tech.tokimeki.poll.vote record referencing the poll by strongRef', async () => {
+      const poll = new TestPoll();
+      const response: PollCreateRecordResponse = { uri: 'at://vote/1', cid: 'cidvote' };
+      poll.responses = [response];
+
+      const result = await poll.createVote('jwt', 'did:example:me', {
+        poll: { uri: 'at://poll/1', cid: 'cidpoll' },
+        optionIndex: 2,
+      });
+
+      expect(result).toBe(response);
+      expect(poll.authCalls).toHaveLength(1);
+      const call = poll.authCalls[0];
+      expect(call.endpoint).toBe('/com.atproto.repo.createRecord');
+      expect(call.accessJwt).toBe('jwt');
+      expect(call.options.method).toBe('POST');
+
+      const body = call.options.body as {
+        repo: string;
+        collection: string;
+        record: Record<string, unknown>;
+      };
+      expect(body.repo).toBe('did:example:me');
+      expect(body.collection).toBe('tech.tokimeki.poll.vote');
+      expect(body.record).toMatchObject({
+        $type: 'tech.tokimeki.poll.vote',
+        poll: { $type: 'com.atproto.repo.strongRef', uri: 'at://poll/1', cid: 'cidpoll' },
+        optionIndex: 2,
+      });
+      expect(typeof body.record.createdAt).toBe('string');
+    });
+
+    it('preserves optionIndex 0', async () => {
+      const poll = new TestPoll();
+      poll.responses = [{ uri: 'at://vote/2', cid: 'cidvote2' }];
+
+      await poll.createVote('jwt', 'did:example:me', {
+        poll: { uri: 'at://poll/2', cid: 'cidpoll2' },
+        optionIndex: 0,
+      });
+
+      const body = poll.authCalls[0].options.body as { record: Record<string, unknown> };
+      expect(body.record.optionIndex).toBe(0);
+    });
+  });
+});

--- a/packages/bluesky-api/src/repos.coverage.test.ts
+++ b/packages/bluesky-api/src/repos.coverage.test.ts
@@ -1,0 +1,294 @@
+import { BlueskyRepos, type AiPreferencesRecord } from './repos';
+import type { CreateReviewInput } from './types';
+
+type AuthCall = {
+  endpoint: string;
+  accessJwt: string;
+  options: {
+    method?: 'GET' | 'POST';
+    body?: Record<string, unknown> | FormData | Blob;
+    params?: Record<string, string | string[]>;
+    headers?: Record<string, string>;
+  };
+};
+
+describe('BlueskyRepos (coverage)', () => {
+  class TestRepos extends BlueskyRepos {
+    public calls: AuthCall[] = [];
+    public responses: unknown[] = [];
+    public errors: unknown[] = [];
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: AuthCall['options'] = {},
+    ): Promise<T> {
+      this.calls.push({ endpoint, accessJwt, options });
+      if (this.errors.length > 0) {
+        throw this.errors.shift();
+      }
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+  }
+
+  describe('getActorRecipes', () => {
+    it('fetches recipes and omits cursor when not provided', async () => {
+      const repos = new TestRepos();
+      repos.responses = [{ records: [] }];
+
+      const result = await repos.getActorRecipes('jwt', 'did:example:alice');
+
+      expect(result).toEqual({ records: [] });
+      expect(repos.calls[0]).toEqual({
+        endpoint: '/com.atproto.repo.listRecords',
+        accessJwt: 'jwt',
+        options: {
+          params: {
+            repo: 'did:example:alice',
+            collection: 'exchange.recipe.recipe',
+          },
+        },
+      });
+    });
+
+    it('includes cursor when provided', async () => {
+      const repos = new TestRepos();
+      repos.responses = [{ records: [], cursor: 'next' }];
+
+      await repos.getActorRecipes('jwt', 'alice.test', 10, 'cursor-1');
+
+      expect(repos.calls[0].options.params).toEqual({
+        repo: 'alice.test',
+        collection: 'exchange.recipe.recipe',
+        cursor: 'cursor-1',
+      });
+    });
+  });
+
+  describe('getActorLinkatBoards', () => {
+    it('fetches link boards with default limit and no cursor', async () => {
+      const repos = new TestRepos();
+      repos.responses = [{ records: [{ uri: 'at://board' }], cursor: undefined }];
+
+      const result = await repos.getActorLinkatBoards('jwt', 'did:example:alice');
+
+      expect(result).toEqual({ records: [{ uri: 'at://board' }], cursor: undefined });
+      expect(repos.calls[0]).toEqual({
+        endpoint: '/com.atproto.repo.listRecords',
+        accessJwt: 'jwt',
+        options: {
+          params: {
+            repo: 'did:example:alice',
+            collection: 'blue.linkat.board',
+            limit: '50',
+          },
+        },
+      });
+    });
+
+    it('includes cursor and custom limit when provided', async () => {
+      const repos = new TestRepos();
+      repos.responses = [{ records: [] }];
+
+      await repos.getActorLinkatBoards('jwt', 'alice.test', 20, 'cursor-1');
+
+      expect(repos.calls[0].options.params).toEqual({
+        repo: 'alice.test',
+        collection: 'blue.linkat.board',
+        limit: '20',
+        cursor: 'cursor-1',
+      });
+    });
+
+    it('returns an empty response when the request throws', async () => {
+      const repos = new TestRepos();
+      repos.errors = [new Error('collection not found')];
+
+      const result = await repos.getActorLinkatBoards('jwt', 'alice.test');
+
+      expect(result).toEqual({ records: [], cursor: undefined });
+    });
+  });
+
+  describe('createReview', () => {
+    const baseReview: CreateReviewInput = {
+      identifiers: { tmdbId: '123' },
+      creativeWorkType: 'movie',
+      rating: 5,
+    };
+
+    it('builds a minimal record without optional fields', async () => {
+      const repos = new TestRepos();
+      repos.responses = [{ uri: 'at://review', cid: 'cid1' }];
+
+      const result = await repos.createReview('jwt', 'did:example:alice', baseReview);
+
+      expect(result).toEqual({ uri: 'at://review', cid: 'cid1' });
+      const call = repos.calls[0];
+      expect(call.endpoint).toBe('/com.atproto.repo.createRecord');
+      expect(call.accessJwt).toBe('jwt');
+      expect(call.options.method).toBe('POST');
+
+      const body = call.options.body as { repo: string; collection: string; record: Record<string, unknown> };
+      expect(body.repo).toBe('did:example:alice');
+      expect(body.collection).toBe('social.popfeed.feed.review');
+      expect(body.record.$type).toBe('social.popfeed.feed.review');
+      expect(body.record.identifiers).toEqual(baseReview.identifiers);
+      expect(body.record.creativeWorkType).toBe('movie');
+      expect(body.record.rating).toBe(5);
+      expect(typeof body.record.createdAt).toBe('string');
+      // None of the optional fields should be present.
+      for (const key of [
+        'text',
+        'title',
+        'poster',
+        'tags',
+        'genres',
+        'mainCredit',
+        'mainCreditRole',
+        'isRevisit',
+        'containsSpoilers',
+        'releaseDate',
+        'posterUrl',
+      ]) {
+        expect(key in body.record).toBe(false);
+      }
+    });
+
+    it('includes every optional field when provided', async () => {
+      const repos = new TestRepos();
+      repos.responses = [{ uri: 'at://review', cid: 'cid2' }];
+
+      const poster = { $type: 'blob' as const, ref: { $link: 'blob-link' }, mimeType: 'image/jpeg', size: 1234 };
+      const review: CreateReviewInput = {
+        ...baseReview,
+        text: 'great',
+        title: 'A Title',
+        poster,
+        tags: ['tag1', 'tag2'],
+        genres: ['drama'],
+        mainCredit: 'Director Name',
+        mainCreditRole: 'director',
+        isRevisit: true,
+        containsSpoilers: false,
+        releaseDate: '2020-01-01',
+        posterUrl: 'https://example.com/poster.jpg',
+      };
+
+      await repos.createReview('jwt', 'did:example:alice', review);
+
+      const body = repos.calls[0].options.body as { record: Record<string, unknown> };
+      expect(body.record.text).toBe('great');
+      expect(body.record.title).toBe('A Title');
+      expect(body.record.poster).toEqual(poster);
+      expect(body.record.tags).toEqual(['tag1', 'tag2']);
+      expect(body.record.genres).toEqual(['drama']);
+      expect(body.record.mainCredit).toBe('Director Name');
+      expect(body.record.mainCreditRole).toBe('director');
+      expect(body.record.isRevisit).toBe(true);
+      expect(body.record.containsSpoilers).toBe(false);
+      expect(body.record.releaseDate).toBe('2020-01-01');
+      expect(body.record.posterUrl).toBe('https://example.com/poster.jpg');
+    });
+  });
+
+  describe('getAiPreferences', () => {
+    const record: AiPreferencesRecord = {
+      $type: 'community.lexicon.preference.ai',
+      preferences: {
+        embedding: { allow: true, updatedAt: '2020-01-01' },
+        inference: { allow: false, updatedAt: '2020-01-01' },
+        syntheticContent: { allow: true, updatedAt: '2020-01-01' },
+        training: { allow: false, updatedAt: '2020-01-01' },
+      },
+      scope: { $type: 'community.lexicon.preference.ai#globalScope' },
+      updatedAt: '2020-01-01',
+    };
+
+    it('returns the record value on success', async () => {
+      const repos = new TestRepos();
+      repos.responses = [{ uri: 'at://pref', cid: 'cid', value: record }];
+
+      const result = await repos.getAiPreferences('jwt', 'did:example:alice');
+
+      expect(result).toEqual(record);
+      expect(repos.calls[0]).toEqual({
+        endpoint: '/com.atproto.repo.getRecord',
+        accessJwt: 'jwt',
+        options: {
+          params: {
+            repo: 'did:example:alice',
+            collection: 'community.lexicon.preference.ai',
+            rkey: 'self',
+          },
+        },
+      });
+    });
+
+    it('returns null when the record is not found via errorCode', async () => {
+      const repos = new TestRepos();
+      repos.errors = [{ errorCode: 'RecordNotFound' }];
+
+      const result = await repos.getAiPreferences('jwt', 'did:example:alice');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the request fails with status 404', async () => {
+      const repos = new TestRepos();
+      repos.errors = [{ status: 404 }];
+
+      const result = await repos.getAiPreferences('jwt', 'did:example:alice');
+
+      expect(result).toBeNull();
+    });
+
+    it('rethrows other errors', async () => {
+      const repos = new TestRepos();
+      const err = { status: 500, errorCode: 'InternalError' };
+      repos.errors = [err];
+
+      await expect(repos.getAiPreferences('jwt', 'did:example:alice')).rejects.toBe(err);
+    });
+  });
+
+  describe('putAiPreferences', () => {
+    it('writes the record at rkey self', async () => {
+      const repos = new TestRepos();
+      repos.responses = [{ uri: 'at://pref', cid: 'cid' }];
+
+      const record: AiPreferencesRecord = {
+        $type: 'community.lexicon.preference.ai',
+        preferences: {
+          embedding: { allow: true, updatedAt: '2020-01-01' },
+          inference: { allow: true, updatedAt: '2020-01-01' },
+          syntheticContent: { allow: true, updatedAt: '2020-01-01' },
+          training: { allow: true, updatedAt: '2020-01-01' },
+        },
+        scope: { $type: 'community.lexicon.preference.ai#globalScope' },
+        updatedAt: '2020-01-01',
+      };
+
+      const result = await repos.putAiPreferences('jwt', 'did:example:alice', record);
+
+      expect(result).toEqual({ uri: 'at://pref', cid: 'cid' });
+      expect(repos.calls[0]).toEqual({
+        endpoint: '/com.atproto.repo.putRecord',
+        accessJwt: 'jwt',
+        options: {
+          method: 'POST',
+          body: {
+            repo: 'did:example:alice',
+            collection: 'community.lexicon.preference.ai',
+            rkey: 'self',
+            record,
+          },
+        },
+      });
+    });
+  });
+});

--- a/packages/bluesky-api/src/rpg.test.ts
+++ b/packages/bluesky-api/src/rpg.test.ts
@@ -1,0 +1,164 @@
+import {
+  BlueskyRpg,
+  buildRpgItemBlobUrl,
+  pickRpgItemImageCid,
+  type RpgItemRecord,
+  type RpgItemRecordsResponse,
+} from './rpg';
+
+type RequestOptions = {
+  method?: 'GET' | 'POST';
+  body?: Record<string, unknown> | FormData | Blob;
+  params?: Record<string, string | string[]>;
+  headers?: Record<string, string>;
+};
+
+describe('BlueskyRpg', () => {
+  class TestRpg extends BlueskyRpg {
+    public authCalls: {
+      endpoint: string;
+      accessJwt: string;
+      options: RequestOptions;
+    }[] = [];
+
+    public requestCalls: { endpoint: string; options: RequestOptions }[] = [];
+
+    public responses: unknown[] = [];
+    public shouldThrow = false;
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: RequestOptions = {},
+    ): Promise<T> {
+      this.authCalls.push({ endpoint, accessJwt, options });
+      if (this.shouldThrow) {
+        throw new Error('boom');
+      }
+      return this.responses.shift() as T;
+    }
+
+    protected async makeRequest<T>(endpoint: string, options: RequestOptions = {}): Promise<T> {
+      this.requestCalls.push({ endpoint, options });
+      return this.responses.shift() as T;
+    }
+  }
+
+  describe('getActorInventory', () => {
+    it('lists records with default limit and no cursor', async () => {
+      const rpg = new TestRpg();
+      const response: RpgItemRecordsResponse = { records: [], cursor: undefined };
+      rpg.responses = [response];
+
+      const result = await rpg.getActorInventory('jwt', 'did:example:alice');
+
+      expect(result).toBe(response);
+      expect(rpg.authCalls).toHaveLength(1);
+      expect(rpg.authCalls[0]).toEqual({
+        endpoint: '/com.atproto.repo.listRecords',
+        accessJwt: 'jwt',
+        options: {
+          params: {
+            repo: 'did:example:alice',
+            collection: 'equipment.rpg.item',
+            limit: '50',
+          },
+        },
+      });
+    });
+
+    it('forwards a custom limit and cursor when provided', async () => {
+      const rpg = new TestRpg();
+      const response: RpgItemRecordsResponse = { records: [], cursor: 'next' };
+      rpg.responses = [response];
+
+      const result = await rpg.getActorInventory('jwt', 'did:example:bob', 25, 'cursor-123');
+
+      expect(result).toBe(response);
+      expect(rpg.authCalls[0]).toEqual({
+        endpoint: '/com.atproto.repo.listRecords',
+        accessJwt: 'jwt',
+        options: {
+          params: {
+            repo: 'did:example:bob',
+            collection: 'equipment.rpg.item',
+            limit: '25',
+            cursor: 'cursor-123',
+          },
+        },
+      });
+    });
+
+    it('returns an empty response when the request throws', async () => {
+      const rpg = new TestRpg();
+      rpg.shouldThrow = true;
+
+      const result = await rpg.getActorInventory('jwt', 'did:example:carol');
+
+      expect(result).toEqual({ records: [], cursor: undefined });
+      expect(rpg.authCalls).toHaveLength(1);
+    });
+  });
+});
+
+describe('buildRpgItemBlobUrl', () => {
+  it('builds a PDS-direct getBlob URL with encoded did and cid', () => {
+    const url = buildRpgItemBlobUrl('https://pds.example', 'did:plc:abc', 'bafyCID');
+
+    expect(url).toBe(
+      'https://pds.example/xrpc/com.atproto.sync.getBlob?did=did%3Aplc%3Aabc&cid=bafyCID',
+    );
+  });
+});
+
+describe('pickRpgItemImageCid', () => {
+  const baseValue: RpgItemRecord['value'] = {
+    $type: 'equipment.rpg.item',
+    item: 'item-1',
+    title: 'Hat',
+    give: 'at://give/1',
+    provider: 'did:plc:provider',
+    acceptedAt: '2026-01-01T00:00:00.000Z',
+  };
+
+  it('prefers the icon cid when present', () => {
+    const item: RpgItemRecord = {
+      uri: 'at://item/1',
+      cid: 'cid1',
+      value: {
+        ...baseValue,
+        icon: { $type: 'blob', ref: { $link: 'icon-cid' }, mimeType: 'image/png', size: 1 },
+        asset: { $type: 'blob', ref: { $link: 'asset-cid' }, mimeType: 'image/png', size: 2 },
+      },
+    };
+
+    expect(pickRpgItemImageCid(item)).toBe('icon-cid');
+  });
+
+  it('falls back to the asset cid when no icon is present', () => {
+    const item: RpgItemRecord = {
+      uri: 'at://item/2',
+      cid: 'cid2',
+      value: {
+        ...baseValue,
+        asset: { $type: 'blob', ref: { $link: 'asset-cid' }, mimeType: 'image/png', size: 2 },
+      },
+    };
+
+    expect(pickRpgItemImageCid(item)).toBe('asset-cid');
+  });
+
+  it('returns null when neither icon nor asset is present', () => {
+    const item: RpgItemRecord = {
+      uri: 'at://item/3',
+      cid: 'cid3',
+      value: { ...baseValue },
+    };
+
+    expect(pickRpgItemImageCid(item)).toBeNull();
+  });
+});

--- a/packages/bluesky-api/src/sifa.test.ts
+++ b/packages/bluesky-api/src/sifa.test.ts
@@ -1,0 +1,298 @@
+import {
+  BlueskySifa,
+  buildSifaAvatarUrl,
+  humanizeSifaToken,
+} from './sifa';
+import type {
+  SifaEducationRecordsResponse,
+  SifaPositionRecordsResponse,
+  SifaSelfRecord,
+} from './sifa';
+
+describe('BlueskySifa', () => {
+  class TestSifa extends BlueskySifa {
+    public authCalls: {
+      endpoint: string;
+      accessJwt: string;
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      };
+    }[] = [];
+
+    public requestCalls: {
+      endpoint: string;
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      };
+    }[] = [];
+
+    public responses: unknown[] = [];
+    public errors: unknown[] = [];
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      this.authCalls.push({ endpoint, accessJwt, options });
+      if (this.errors.length > 0) {
+        throw this.errors.shift();
+      }
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+
+    protected async makeRequest<T>(
+      endpoint: string,
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      this.requestCalls.push({ endpoint, options });
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+  }
+
+  describe('getProfileSelf', () => {
+    it('reads the self record via getRecord', async () => {
+      const sifa = new TestSifa();
+      const record = {
+        uri: 'at://did:example:me/id.sifa.profile.self/self',
+        cid: 'cid1',
+        value: { $type: 'id.sifa.profile.self', createdAt: '2024-01-01' },
+      } as SifaSelfRecord;
+      sifa.responses = [record];
+
+      const result = await sifa.getProfileSelf('jwt', 'did:example:me');
+
+      expect(result).toBe(record);
+      expect(sifa.authCalls).toEqual([
+        {
+          endpoint: '/com.atproto.repo.getRecord',
+          accessJwt: 'jwt',
+          options: {
+            params: {
+              repo: 'did:example:me',
+              collection: 'id.sifa.profile.self',
+              rkey: 'self',
+            },
+          },
+        },
+      ]);
+    });
+
+    it('returns null when the record is not found (errorCode)', async () => {
+      const sifa = new TestSifa();
+      sifa.errors = [{ errorCode: 'RecordNotFound' }];
+
+      const result = await sifa.getProfileSelf('jwt', 'did:example:me');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when the request 404s (status)', async () => {
+      const sifa = new TestSifa();
+      sifa.errors = [{ status: 404 }];
+
+      const result = await sifa.getProfileSelf('jwt', 'did:example:me');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for any other failure (e.g. 401)', async () => {
+      const sifa = new TestSifa();
+      sifa.errors = [{ status: 401 }];
+
+      const result = await sifa.getProfileSelf('jwt', 'did:example:me');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getActorPositions', () => {
+    it('lists positions with the default limit and no cursor', async () => {
+      const sifa = new TestSifa();
+      const response = { records: [] } as SifaPositionRecordsResponse;
+      sifa.responses = [response];
+
+      const result = await sifa.getActorPositions('jwt', 'did:example:me');
+
+      expect(result).toBe(response);
+      expect(sifa.authCalls).toEqual([
+        {
+          endpoint: '/com.atproto.repo.listRecords',
+          accessJwt: 'jwt',
+          options: {
+            params: {
+              repo: 'did:example:me',
+              collection: 'id.sifa.profile.position',
+              limit: '50',
+            },
+          },
+        },
+      ]);
+    });
+
+    it('forwards a custom limit and cursor', async () => {
+      const sifa = new TestSifa();
+      const response = { records: [], cursor: 'next' } as SifaPositionRecordsResponse;
+      sifa.responses = [response];
+
+      const result = await sifa.getActorPositions('jwt', 'did:example:me', 10, 'cursor-1');
+
+      expect(result).toBe(response);
+      expect(sifa.authCalls[0]).toEqual({
+        endpoint: '/com.atproto.repo.listRecords',
+        accessJwt: 'jwt',
+        options: {
+          params: {
+            repo: 'did:example:me',
+            collection: 'id.sifa.profile.position',
+            limit: '10',
+            cursor: 'cursor-1',
+          },
+        },
+      });
+    });
+
+    it('returns an empty result set when the request fails', async () => {
+      const sifa = new TestSifa();
+      sifa.errors = [new Error('boom')];
+
+      const result = await sifa.getActorPositions('jwt', 'did:example:me');
+
+      expect(result).toEqual({ records: [], cursor: undefined });
+    });
+  });
+
+  describe('getActorEducation', () => {
+    it('lists education with the default limit and no cursor', async () => {
+      const sifa = new TestSifa();
+      const response = { records: [] } as SifaEducationRecordsResponse;
+      sifa.responses = [response];
+
+      const result = await sifa.getActorEducation('jwt', 'did:example:me');
+
+      expect(result).toBe(response);
+      expect(sifa.authCalls).toEqual([
+        {
+          endpoint: '/com.atproto.repo.listRecords',
+          accessJwt: 'jwt',
+          options: {
+            params: {
+              repo: 'did:example:me',
+              collection: 'id.sifa.profile.education',
+              limit: '50',
+            },
+          },
+        },
+      ]);
+    });
+
+    it('forwards a custom limit and cursor', async () => {
+      const sifa = new TestSifa();
+      const response = { records: [], cursor: 'next' } as SifaEducationRecordsResponse;
+      sifa.responses = [response];
+
+      const result = await sifa.getActorEducation('jwt', 'did:example:me', 5, 'cursor-2');
+
+      expect(result).toBe(response);
+      expect(sifa.authCalls[0]).toEqual({
+        endpoint: '/com.atproto.repo.listRecords',
+        accessJwt: 'jwt',
+        options: {
+          params: {
+            repo: 'did:example:me',
+            collection: 'id.sifa.profile.education',
+            limit: '5',
+            cursor: 'cursor-2',
+          },
+        },
+      });
+    });
+
+    it('returns an empty result set when the request fails', async () => {
+      const sifa = new TestSifa();
+      sifa.errors = [new Error('boom')];
+
+      const result = await sifa.getActorEducation('jwt', 'did:example:me');
+
+      expect(result).toEqual({ records: [], cursor: undefined });
+    });
+  });
+});
+
+describe('buildSifaAvatarUrl', () => {
+  it('builds a PDS-direct getBlob URL with encoded did and cid', () => {
+    const url = buildSifaAvatarUrl(
+      'https://pds.example',
+      'did:plc:abc',
+      'bafycid',
+    );
+
+    expect(url).toBe(
+      'https://pds.example/xrpc/com.atproto.sync.getBlob?did=did%3Aplc%3Aabc&cid=bafycid',
+    );
+  });
+
+  it('encodes characters that require escaping', () => {
+    const url = buildSifaAvatarUrl(
+      'https://pds.example',
+      'did:web:example.com/path',
+      'cid+with/special',
+    );
+
+    expect(url).toBe(
+      'https://pds.example/xrpc/com.atproto.sync.getBlob?did=did%3Aweb%3Aexample.com%2Fpath&cid=cid%2Bwith%2Fspecial',
+    );
+  });
+});
+
+describe('humanizeSifaToken', () => {
+  it('returns an empty string for undefined', () => {
+    expect(humanizeSifaToken(undefined)).toBe('');
+  });
+
+  it('returns an empty string for an empty string', () => {
+    expect(humanizeSifaToken('')).toBe('');
+  });
+
+  it('returns an empty string when only a fragment prefix is present', () => {
+    expect(humanizeSifaToken('id.sifa.defs#')).toBe('');
+  });
+
+  it('strips the NSID fragment prefix and splits camelCase', () => {
+    expect(humanizeSifaToken('id.sifa.defs#fullTime')).toBe('Full Time');
+  });
+
+  it('capitalises a bare single word with no fragment', () => {
+    expect(humanizeSifaToken('remote')).toBe('Remote');
+  });
+
+  it('handles multiple camelCase boundaries', () => {
+    expect(humanizeSifaToken('id.sifa.defs#openToContractWork')).toBe(
+      'Open To Contract Work',
+    );
+  });
+
+  it('leaves an already-capitalised single word unchanged in shape', () => {
+    expect(humanizeSifaToken('Hybrid')).toBe('Hybrid');
+  });
+});

--- a/packages/bluesky-api/src/sprk.test.ts
+++ b/packages/bluesky-api/src/sprk.test.ts
@@ -1,0 +1,104 @@
+import { BlueskySpark } from './sprk';
+import type { SprkStoryRecordsResponse } from './sprk';
+
+describe('BlueskySpark', () => {
+  class TestSpark extends BlueskySpark {
+    public authCalls: {
+      endpoint: string;
+      accessJwt: string;
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      };
+    }[] = [];
+
+    public responses: unknown[] = [];
+    public errors: unknown[] = [];
+
+    constructor() {
+      super('https://pds.example');
+    }
+
+    protected async makeAuthenticatedRequest<T>(
+      endpoint: string,
+      accessJwt: string,
+      options: {
+        method?: 'GET' | 'POST';
+        body?: Record<string, unknown> | FormData | Blob;
+        params?: Record<string, string | string[]>;
+        headers?: Record<string, string>;
+      } = {},
+    ): Promise<T> {
+      this.authCalls.push({ endpoint, accessJwt, options });
+      if (this.errors.length > 0) {
+        throw this.errors.shift();
+      }
+      return (this.responses.shift() as T) ?? (undefined as T);
+    }
+  }
+
+  it('lists story records with the default limit and no cursor', async () => {
+    const spark = new TestSpark();
+    const response = { records: [] } as SprkStoryRecordsResponse;
+    spark.responses = [response];
+
+    const result = await spark.getActorStories('jwt', 'did:example:alice');
+
+    expect(result).toBe(response);
+    expect(spark.authCalls).toEqual([
+      {
+        endpoint: '/com.atproto.repo.listRecords',
+        accessJwt: 'jwt',
+        options: {
+          params: {
+            repo: 'did:example:alice',
+            collection: 'so.sprk.story.post',
+            limit: '50',
+          },
+        },
+      },
+    ]);
+  });
+
+  it('forwards a custom limit and cursor', async () => {
+    const spark = new TestSpark();
+    const response = { records: [], cursor: 'next' } as SprkStoryRecordsResponse;
+    spark.responses = [response];
+
+    const result = await spark.getActorStories('jwt', 'did:example:bob', 10, 'cursor-1');
+
+    expect(result).toBe(response);
+    expect(spark.authCalls[0]).toEqual({
+      endpoint: '/com.atproto.repo.listRecords',
+      accessJwt: 'jwt',
+      options: {
+        params: {
+          repo: 'did:example:bob',
+          collection: 'so.sprk.story.post',
+          limit: '10',
+          cursor: 'cursor-1',
+        },
+      },
+    });
+  });
+
+  it('accepts an empty access token for the public read', async () => {
+    const spark = new TestSpark();
+    spark.responses = [{ records: [] } as SprkStoryRecordsResponse];
+
+    await spark.getActorStories('', 'did:example:carol');
+
+    expect(spark.authCalls[0].accessJwt).toBe('');
+  });
+
+  it('returns an empty result when the request fails', async () => {
+    const spark = new TestSpark();
+    spark.errors = [new Error('boom')];
+
+    const result = await spark.getActorStories('jwt', 'did:example:dave', 5, 'cursor-2');
+
+    expect(result).toEqual({ records: [], cursor: undefined });
+  });
+});

--- a/packages/bluesky-api/src/videoService.test.ts
+++ b/packages/bluesky-api/src/videoService.test.ts
@@ -1,0 +1,267 @@
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+import { getVideoJobStatus, uploadVideoToService } from './videoService';
+
+/**
+ * Minimal stand-in for the browser XMLHttpRequest used by
+ * uploadVideoToService. The node test environment has no XHR, so we
+ * install a controllable fake on globalThis. Tests drive it by reading
+ * the most-recently-constructed instance and invoking the lifecycle
+ * helpers (resolveLoad / fail / emitProgress).
+ */
+type Listener = (e?: unknown) => void;
+
+class MockXHR {
+  static instances: MockXHR[] = [];
+  static last(): MockXHR {
+    return MockXHR.instances[MockXHR.instances.length - 1];
+  }
+
+  public method?: string;
+  public url?: string;
+  public async?: boolean;
+  public requestHeaders: Record<string, string> = {};
+  public responseType = '';
+  public status = 0;
+  public responseText = '';
+  public sentBody: unknown;
+  public aborted = false;
+
+  private listeners: Record<string, Listener[]> = {};
+  public upload = {
+    listeners: {} as Record<string, Listener[]>,
+    addEventListener(type: string, cb: Listener) {
+      (this.listeners[type] ||= []).push(cb);
+    },
+    emit(type: string, e?: unknown) {
+      (this.listeners[type] || []).forEach((cb) => cb(e));
+    },
+  };
+
+  constructor() {
+    MockXHR.instances.push(this);
+  }
+
+  open(method: string, url: string, async: boolean) {
+    this.method = method;
+    this.url = url;
+    this.async = async;
+  }
+
+  setRequestHeader(key: string, value: string) {
+    this.requestHeaders[key] = value;
+  }
+
+  addEventListener(type: string, cb: Listener) {
+    (this.listeners[type] ||= []).push(cb);
+  }
+
+  private emit(type: string, e?: unknown) {
+    (this.listeners[type] || []).forEach((cb) => cb(e));
+  }
+
+  send(body: unknown) {
+    this.sentBody = body;
+  }
+
+  abort() {
+    this.aborted = true;
+    this.emit('abort');
+  }
+
+  // ---- test driver helpers ----
+  resolveLoad(status: number, responseText: string) {
+    this.status = status;
+    this.responseText = responseText;
+    this.emit('load');
+  }
+
+  emitError() {
+    this.emit('error');
+  }
+
+  emitUploadProgress(e: unknown) {
+    this.upload.emit('progress', e);
+  }
+}
+
+describe('uploadVideoToService', () => {
+  let originalXHR: unknown;
+
+  beforeEach(() => {
+    MockXHR.instances = [];
+    originalXHR = (globalThis as Record<string, unknown>).XMLHttpRequest;
+    (globalThis as Record<string, unknown>).XMLHttpRequest = MockXHR as unknown;
+  });
+
+  afterEach(() => {
+    (globalThis as Record<string, unknown>).XMLHttpRequest = originalXHR;
+  });
+
+  const blob = { size: 100 } as unknown as Blob;
+
+  it('opens a POST to the video service with did/name query params and auth headers, and resolves the parsed body', async () => {
+    const promise = uploadVideoToService('jwt-token', 'did:example:alice', blob, 'video/mp4', 'clip.mp4');
+
+    const xhr = MockXHR.last();
+    expect(xhr.method).toBe('POST');
+    expect(xhr.async).toBe(true);
+    const url = new URL(xhr.url!);
+    expect(url.origin + url.pathname).toBe('https://video.bsky.app/xrpc/app.bsky.video.uploadVideo');
+    expect(url.searchParams.get('did')).toBe('did:example:alice');
+    expect(url.searchParams.get('name')).toBe('clip.mp4');
+    expect(xhr.requestHeaders.Authorization).toBe('Bearer jwt-token');
+    expect(xhr.requestHeaders['Content-Type']).toBe('video/mp4');
+    expect(xhr.responseType).toBe('text');
+    expect(xhr.sentBody).toBe(blob);
+
+    const body = { jobStatus: { jobId: 'job-1', did: 'did:example:alice', state: 'JOB_STATE_CREATED' } };
+    xhr.resolveLoad(200, JSON.stringify(body));
+
+    await expect(promise).resolves.toEqual(body);
+  });
+
+  it('reports upload progress fractions via onProgress', async () => {
+    const onProgress = jest.fn();
+    const promise = uploadVideoToService('jwt', 'did:x', blob, 'video/mp4', 'f.mp4', { onProgress });
+
+    const xhr = MockXHR.last();
+    xhr.emitUploadProgress({ lengthComputable: true, total: 200, loaded: 50 });
+    xhr.emitUploadProgress({ lengthComputable: true, total: 200, loaded: 200 });
+    // Ignored: not computable or zero total.
+    xhr.emitUploadProgress({ lengthComputable: false, total: 200, loaded: 100 });
+    xhr.emitUploadProgress({ lengthComputable: true, total: 0, loaded: 0 });
+
+    expect(onProgress).toHaveBeenNthCalledWith(1, 0.25);
+    expect(onProgress).toHaveBeenNthCalledWith(2, 1);
+    expect(onProgress).toHaveBeenCalledTimes(2);
+
+    xhr.resolveLoad(200, JSON.stringify({ jobStatus: {} }));
+    await promise;
+  });
+
+  it('rejects when the success response is not valid JSON', async () => {
+    const promise = uploadVideoToService('jwt', 'did:x', blob, 'video/mp4', 'f.mp4');
+    MockXHR.last().resolveLoad(200, 'not-json');
+    await expect(promise).rejects.toBeInstanceOf(Error);
+  });
+
+  it('rejects with status, detail message, and errorCode on a JSON error response', async () => {
+    const promise = uploadVideoToService('jwt', 'did:x', blob, 'video/mp4', 'f.mp4');
+    MockXHR.last().resolveLoad(400, JSON.stringify({ error: 'InvalidRequest', message: 'bad video' }));
+
+    const err = (await promise.catch((e) => e)) as Error & { status: number; errorCode?: string };
+    expect(err.message).toBe('upload 400: bad video');
+    expect(err.status).toBe(400);
+    expect(err.errorCode).toBe('InvalidRequest');
+  });
+
+  it('falls back to error field then raw text then status when building the detail', async () => {
+    const onlyError = uploadVideoToService('jwt', 'did:x', blob, 'video/mp4', 'f.mp4');
+    MockXHR.last().resolveLoad(403, JSON.stringify({ error: 'Forbidden' }));
+    await expect(onlyError).rejects.toMatchObject({ message: 'upload 403: Forbidden', errorCode: 'Forbidden' });
+
+    const rawText = uploadVideoToService('jwt', 'did:x', blob, 'video/mp4', 'f.mp4');
+    MockXHR.last().resolveLoad(500, 'gateway exploded');
+    const rawErr = (await rawText.catch((e) => e)) as Error & { errorCode?: string };
+    expect(rawErr.message).toBe('upload 500: gateway exploded');
+    expect(rawErr.errorCode).toBeUndefined();
+
+    const emptyBody = uploadVideoToService('jwt', 'did:x', blob, 'video/mp4', 'f.mp4');
+    MockXHR.last().resolveLoad(503, '');
+    await expect(emptyBody).rejects.toMatchObject({ message: 'upload 503: status 503' });
+  });
+
+  it('rejects on network error', async () => {
+    const promise = uploadVideoToService('jwt', 'did:x', blob, 'video/mp4', 'f.mp4');
+    MockXHR.last().emitError();
+    await expect(promise).rejects.toThrow('Network error during video upload');
+  });
+
+  it('aborts immediately when an already-aborted signal is supplied and never sends', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const promise = uploadVideoToService('jwt', 'did:x', blob, 'video/mp4', 'f.mp4', {
+      signal: controller.signal,
+    });
+
+    const xhr = MockXHR.last();
+    expect(xhr.aborted).toBe(true);
+    expect(xhr.sentBody).toBeUndefined();
+    await expect(promise).rejects.toThrow('Video upload aborted');
+  });
+
+  it('aborts when the signal fires after send', async () => {
+    const controller = new AbortController();
+    const promise = uploadVideoToService('jwt', 'did:x', blob, 'video/mp4', 'f.mp4', {
+      signal: controller.signal,
+    });
+
+    const xhr = MockXHR.last();
+    expect(xhr.sentBody).toBe(blob);
+    controller.abort();
+    expect(xhr.aborted).toBe(true);
+    await expect(promise).rejects.toThrow('Video upload aborted');
+  });
+});
+
+describe('getVideoJobStatus', () => {
+  const server = setupServer();
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
+
+  it('returns the job status and url-encodes the jobId', async () => {
+    let capturedUrl: string | null = null;
+    let capturedAuth: string | null = null;
+    const payload = { jobStatus: { jobId: 'job/1', did: 'did:x', state: 'JOB_STATE_COMPLETED' } };
+
+    server.use(
+      http.get('https://video.bsky.app/xrpc/app.bsky.video.getJobStatus', ({ request }) => {
+        capturedUrl = request.url;
+        capturedAuth = request.headers.get('authorization');
+        return HttpResponse.json(payload);
+      }),
+    );
+
+    const result = await getVideoJobStatus('jwt-abc', 'job/1');
+
+    expect(result).toEqual(payload);
+    expect(capturedAuth).toBe('Bearer jwt-abc');
+    expect(capturedUrl).toContain('jobId=job%2F1');
+  });
+
+  it('throws with the body message, status, and errorCode on a JSON error', async () => {
+    server.use(
+      http.get('https://video.bsky.app/xrpc/app.bsky.video.getJobStatus', () =>
+        HttpResponse.json({ message: 'job not found', error: 'NotFound' }, { status: 404 }),
+      ),
+    );
+
+    const err = (await getVideoJobStatus('jwt', 'missing').catch((e) => e)) as Error & {
+      status: number;
+      errorCode?: string;
+    };
+    expect(err.message).toBe('job not found');
+    expect(err.status).toBe(404);
+    expect(err.errorCode).toBe('NotFound');
+  });
+
+  it('falls back to a status-based message when the error body is not JSON', async () => {
+    server.use(
+      http.get('https://video.bsky.app/xrpc/app.bsky.video.getJobStatus', () =>
+        HttpResponse.text('upstream failure', { status: 502 }),
+      ),
+    );
+
+    const err = (await getVideoJobStatus('jwt', 'job').catch((e) => e)) as Error & {
+      status: number;
+      errorCode?: string;
+    };
+    expect(err.message).toBe('Job status failed (502)');
+    expect(err.status).toBe(502);
+    expect(err.errorCode).toBeUndefined();
+  });
+});

--- a/packages/slingshot-api/src/api.test.ts
+++ b/packages/slingshot-api/src/api.test.ts
@@ -1,0 +1,182 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from '@jest/globals';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { SlingshotApi } from './api';
+import { SlingshotApiClient, DEFAULT_SLINGSHOT_BASE_URL, createSlingshotApi } from './index';
+
+const baseUrl = 'https://slingshot.test';
+const server = setupServer();
+
+beforeAll(() => {
+  server.listen({ onUnhandledRequest: 'error' });
+});
+
+afterEach(() => {
+  server.resetHandlers();
+});
+
+afterAll(() => {
+  server.close();
+});
+
+describe('SlingshotApi', () => {
+  const createApi = () => new SlingshotApi(baseUrl, { userAgent: 'akari-tests' });
+
+  it('fetches a record with repo/collection/rkey query params', async () => {
+    let requestedUrl: string | undefined;
+    server.use(
+      http.get(`${baseUrl}/xrpc/com.atproto.repo.getRecord`, ({ request }) => {
+        requestedUrl = request.url;
+        return HttpResponse.json({
+          uri: 'at://did:plc:abc/app.bsky.feed.post/123',
+          cid: 'bafycid',
+          value: { text: 'hello' },
+        });
+      }),
+    );
+
+    const result = await createApi().getRecord<{ text: string }>({
+      repo: 'did:plc:abc',
+      collection: 'app.bsky.feed.post',
+      rkey: '123',
+    });
+
+    expect(result.value.text).toBe('hello');
+    const url = new URL(requestedUrl ?? '');
+    expect(url.searchParams.get('repo')).toBe('did:plc:abc');
+    expect(url.searchParams.get('collection')).toBe('app.bsky.feed.post');
+    expect(url.searchParams.get('rkey')).toBe('123');
+  });
+
+  it('resolves a handle to a DID', async () => {
+    let requestedUrl: string | undefined;
+    server.use(
+      http.get(`${baseUrl}/xrpc/com.atproto.identity.resolveHandle`, ({ request }) => {
+        requestedUrl = request.url;
+        return HttpResponse.json({ did: 'did:plc:resolved' });
+      }),
+    );
+
+    const result = await createApi().resolveHandle('alice.test');
+
+    expect(result.did).toBe('did:plc:resolved');
+    expect(new URL(requestedUrl ?? '').searchParams.get('handle')).toBe('alice.test');
+  });
+
+  it('sends the Accept header and a custom User-Agent', async () => {
+    let accept: string | null = null;
+    let userAgent: string | null = null;
+    server.use(
+      http.get(`${baseUrl}/xrpc/com.atproto.identity.resolveHandle`, ({ request }) => {
+        accept = request.headers.get('accept');
+        userAgent = request.headers.get('user-agent');
+        return HttpResponse.json({ did: 'did:plc:x' });
+      }),
+    );
+
+    await createApi().resolveHandle('a.test');
+
+    expect(accept).toBe('application/json');
+    expect(userAgent).toBe('akari-tests');
+  });
+
+  it('merges custom default headers from options', async () => {
+    let custom: string | null = null;
+    server.use(
+      http.get(`${baseUrl}/xrpc/com.atproto.identity.resolveHandle`, ({ request }) => {
+        custom = request.headers.get('x-custom');
+        return HttpResponse.json({ did: 'did:plc:x' });
+      }),
+    );
+
+    const api = new SlingshotApi(baseUrl, { headers: { 'x-custom': 'value' } });
+    await api.resolveHandle('a.test');
+
+    expect(custom).toBe('value');
+  });
+
+  it('throws a descriptive error on a non-ok response', async () => {
+    server.use(
+      http.get(`${baseUrl}/xrpc/com.atproto.identity.resolveHandle`, () =>
+        HttpResponse.json({ error: 'NotFound' }, { status: 404, statusText: 'Not Found' }),
+      ),
+    );
+
+    await expect(createApi().resolveHandle('ghost.test')).rejects.toThrow(
+      /Slingshot request failed with status 404/,
+    );
+  });
+});
+
+describe('SlingshotApiClient base URL handling', () => {
+  class TestClient extends SlingshotApiClient {
+    fetchPath<T>(path: string, headers?: Record<string, string>) {
+      return this.get<T>(path, undefined, headers);
+    }
+  }
+
+  it('merges per-request headers over the defaults', async () => {
+    let custom: string | null = null;
+    server.use(
+      http.get(`${baseUrl}/ping`, ({ request }) => {
+        custom = request.headers.get('x-request');
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    const client = new TestClient(baseUrl);
+    await client.fetchPath('/ping', { 'x-request': 'per-call' });
+    expect(custom).toBe('per-call');
+  });
+
+  it('omits the status text suffix when it is empty', async () => {
+    server.use(
+      http.get(`${baseUrl}/ping`, () => new HttpResponse(null, { status: 500, statusText: '' })),
+    );
+    const client = new TestClient(baseUrl);
+    await expect(client.fetchPath('/ping')).rejects.toThrow(
+      'Slingshot request failed with status 500',
+    );
+  });
+
+  it('falls back to the default base URL when given a blank string', async () => {
+    server.use(
+      http.get(`${DEFAULT_SLINGSHOT_BASE_URL}/ping`, () => HttpResponse.json({ ok: true })),
+    );
+    const client = new TestClient('   ');
+    await expect(client.fetchPath('/ping')).resolves.toEqual({ ok: true });
+  });
+
+  it('strips trailing slashes from the base URL', async () => {
+    server.use(http.get(`${baseUrl}/ping`, () => HttpResponse.json({ ok: true })));
+    const client = new TestClient(`${baseUrl}///`);
+    await expect(client.fetchPath('/ping')).resolves.toEqual({ ok: true });
+  });
+
+  it('normalizes a path without a leading slash', async () => {
+    server.use(http.get(`${baseUrl}/ping`, () => HttpResponse.json({ ok: true })));
+    const client = new TestClient(baseUrl);
+    await expect(client.fetchPath('ping')).resolves.toEqual({ ok: true });
+  });
+});
+
+describe('createSlingshotApi', () => {
+  it('uses the default base URL when none is provided', async () => {
+    server.use(
+      http.get(`${DEFAULT_SLINGSHOT_BASE_URL}/xrpc/com.atproto.identity.resolveHandle`, () =>
+        HttpResponse.json({ did: 'did:plc:default' }),
+      ),
+    );
+    const api = createSlingshotApi();
+    await expect(api.resolveHandle('a.test')).resolves.toEqual({ did: 'did:plc:default' });
+  });
+
+  it('honors a custom base URL', async () => {
+    server.use(
+      http.get(`${baseUrl}/xrpc/com.atproto.identity.resolveHandle`, () =>
+        HttpResponse.json({ did: 'did:plc:custom' }),
+      ),
+    );
+    const api = createSlingshotApi({ baseUrl });
+    await expect(api.resolveHandle('a.test')).resolves.toEqual({ did: 'did:plc:custom' });
+  });
+});


### PR DESCRIPTION
## What

Adds tests for the two weakest API packages.

| Package | Before | After |
|---|---|---|
| `slingshot-api` | **0 tests** | 100% statements (12 tests) |
| `bluesky-api` | 73.9% stmts / 34% funcs | **99.8% stmts / 99% funcs** (450 tests) |

## bluesky-api detail

Brought the whole client library to near-full coverage following the package's established test pattern (subclass the client, override the protected `makeRequest`/`makeAuthenticatedRequest`/`uploadBlob` to capture endpoint/accessJwt/options and return canned responses; MSW where code calls `fetch` directly):

- **New module suites:** `grain`, `sifa`, `draft`, `leaflet`, `rpg`, `poll`, `videoService`, `flashes`, `sprk`
- **Base client (`client.ts`):** DPoP signing, rate-limit cooldown/429 handling, blob upload (incl. RN arrayBuffer fallback), URL/param building, error construction — MSW-based
- **Facade (`BlueskyApi`):** split across part1/2/3; it delegates to private sub-clients, so the harness stubs those
- **Extended existing suites:** `auth`, `graph`, `actors`, `conversations`, `repos`, `feeds`

## slingshot-api detail

Was entirely untested. Covers `SlingshotApi` (`getRecord`, `resolveHandle`), the `createSlingshotApi` factory, and base-client URL normalization / header merging / error handling via MSW.

## Notes

All new tests are pure-node (no network), using MSW or the subclass-capture pattern already in the repo. The few uncovered lines that remain are unreachable defensive fallbacks (e.g. `?? ''` after `String#split().pop()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lucid-softworks/codesmith/akari/pr/405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782661528&installation_id=136510994&pr_number=405&repository=lucid-softworks%2Fakari&return_to=https%3A%2F%2Fgithub.com%2Flucid-softworks%2Fakari%2Fpull%2F405&signature=417bf68ee7e88b7052defd244f4ada0ecb2beabb7e5c7f4ad8e720a3116b2867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->