### PR TITLE
test: add jest setup and coverage for the backend services

### DIFF
--- a/apps/activity-service/jest.config.cjs
+++ b/apps/activity-service/jest.config.cjs
@@ -1,0 +1,36 @@
+const baseTsconfig = require('./tsconfig.json');
+
+const jestTsconfig = {
+  ...baseTsconfig.compilerOptions,
+  types: [...new Set([...(baseTsconfig.compilerOptions?.types ?? []), 'jest', 'node'])],
+};
+
+const isGithubActions = Boolean(process.env.GITHUB_ACTIONS);
+
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  extensionsToTreatAsEsm: ['.ts'],
+  coverageProvider: 'v8',
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts', '!src/**/*.d.ts'],
+  coverageReporters: ['text', 'lcov', 'html'],
+  coverageDirectory: 'coverage',
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    '^.+\\.m?tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: jestTsconfig,
+      },
+    ],
+    'node_modules/.+\\.mjs$': '<rootDir>/../../scripts/jest-transform-mjs.cjs',
+  },
+  transformIgnorePatterns: ['node_modules/(?!.+\\.mjs$)'],
+  ...(isGithubActions ? { reporters: ['default', 'github-actions', ['jest-junit', { outputName: 'junit.xml' }]] } : {}),
+};

--- a/apps/activity-service/package.json
+++ b/apps/activity-service/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc --project tsconfig.json",
+    "build": "tsc --project tsconfig.build.json",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",

--- a/apps/activity-service/src/app.test.ts
+++ b/apps/activity-service/src/app.test.ts
@@ -1,0 +1,420 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+
+type NotificationPage = {
+  notifications: Array<{ indexedAt: string; reason?: string }>;
+  cursor?: string;
+};
+
+// Mocked instance methods, reassigned per-test.
+const listNotificationsMock =
+  jest.fn<(jwt: string, limit?: number, cursor?: string) => Promise<NotificationPage>>();
+const getProfileMock =
+  jest.fn<(jwt: string, did: string) => Promise<{ indexedAt?: string } | null | undefined>>();
+
+const constructorSpy = jest.fn<(pdsUrl: string) => void>();
+
+// ts-jest (ESM->CJS interop) hoists jest.mock above the static import below, so
+// the real network-backed BlueskyApi is never constructed.
+jest.mock('bluesky-api', () => ({
+  BlueskyApi: class {
+    constructor(pdsUrl: string) {
+      constructorSpy(pdsUrl);
+    }
+    listNotifications = listNotificationsMock;
+    getProfile = getProfileMock;
+  },
+}));
+
+// `.js` extension matches the source's ESM import convention.
+import activityApp from './app.js';
+
+type ActivitySummary = {
+  generatedAt: string;
+  periods: Record<string, Array<Record<string, number> & { date: string }>>;
+  totals: { likes: number; reposts: number; quotes: number; replies: number; total: number };
+  totalNotifications: number;
+};
+
+const ISO = (d: Date) => d.toISOString();
+
+function makeSessionCookie(data: Record<string, unknown>): string {
+  // Base64-encoded JSON, matching one of the formats parseSessionCookie accepts.
+  return Buffer.from(JSON.stringify(data), 'utf-8').toString('base64');
+}
+
+function singlePage(notifications: NotificationPage['notifications']): void {
+  listNotificationsMock.mockResolvedValue({ notifications, cursor: undefined });
+}
+
+beforeEach(() => {
+  listNotificationsMock.mockReset();
+  getProfileMock.mockReset();
+  constructorSpy.mockReset();
+  // Sensible defaults: one empty page so handlers don't loop forever.
+  singlePage([]);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('GET /health', () => {
+  it('returns ok status', async () => {
+    const res = await activityApp.request('/health');
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ status: 'ok' });
+  });
+});
+
+describe('authentication', () => {
+  it('returns 401 when no session or bearer token present', async () => {
+    const res = await activityApp.request('/activity');
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({
+      error: 'Missing session. Sign in again to continue.',
+    });
+    expect(constructorSpy).not.toHaveBeenCalled();
+  });
+
+  it('accepts a Bearer authorization header', async () => {
+    const res = await activityApp.request('/activity', {
+      headers: { authorization: 'Bearer my-token' },
+    });
+    expect(res.status).toBe(200);
+    expect(listNotificationsMock).toHaveBeenCalledWith('my-token', 100, undefined);
+  });
+
+  it('accepts a base64-encoded JSON session cookie (jwtToken)', async () => {
+    const cookie = makeSessionCookie({ jwtToken: 'cookie-jwt' });
+    const res = await activityApp.request('/activity', {
+      headers: { cookie: `session=${cookie}` },
+    });
+    expect(res.status).toBe(200);
+    expect(listNotificationsMock).toHaveBeenCalledWith('cookie-jwt', 100, undefined);
+  });
+
+  it('accepts a plain JSON (non-base64) session cookie via accessJwt', async () => {
+    const raw = JSON.stringify({ accessJwt: 'plain-jwt' });
+    const res = await activityApp.request('/activity', {
+      headers: { cookie: `session=${encodeURIComponent(raw)}` },
+    });
+    expect(res.status).toBe(200);
+    expect(listNotificationsMock).toHaveBeenCalledWith('plain-jwt', 100, undefined);
+  });
+
+  it('falls back to the `token` field of the session', async () => {
+    const cookie = makeSessionCookie({ token: 'token-field' });
+    const res = await activityApp.request('/activity', {
+      headers: { cookie: `session=${cookie}` },
+    });
+    expect(res.status).toBe(200);
+    expect(listNotificationsMock).toHaveBeenCalledWith('token-field', 100, undefined);
+  });
+
+  it('treats an unparseable session cookie as no session (401)', async () => {
+    const res = await activityApp.request('/activity', {
+      headers: { cookie: 'session=%%%not-json-not-base64%%%' },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('PDS URL resolution', () => {
+  const auth = { authorization: 'Bearer t' };
+
+  it('defaults to https://bsky.social', async () => {
+    await activityApp.request('/activity', { headers: auth });
+    expect(constructorSpy).toHaveBeenCalledWith('https://bsky.social');
+  });
+
+  it('uses the pdsUrl query parameter and strips trailing /xrpc', async () => {
+    await activityApp.request('/activity?pdsUrl=https://pds.example/xrpc', { headers: auth });
+    expect(constructorSpy).toHaveBeenCalledWith('https://pds.example');
+  });
+
+  it('strips a trailing slash from the x-pds-url header', async () => {
+    await activityApp.request('/activity', {
+      headers: { ...auth, 'x-pds-url': 'https://pds.example/' },
+    });
+    expect(constructorSpy).toHaveBeenCalledWith('https://pds.example');
+  });
+
+  it('uses the pdsUrl from the session when no query/header provided', async () => {
+    const cookie = makeSessionCookie({ jwtToken: 't', pdsUrl: 'https://session.pds' });
+    await activityApp.request('/activity', { headers: { cookie: `session=${cookie}` } });
+    expect(constructorSpy).toHaveBeenCalledWith('https://session.pds');
+  });
+
+  it('falls back to default when pdsUrl is blank/whitespace', async () => {
+    await activityApp.request('/activity?pdsUrl=%20%20', { headers: auth });
+    expect(constructorSpy).toHaveBeenCalledWith('https://bsky.social');
+  });
+});
+
+describe('notification pagination', () => {
+  const auth = { authorization: 'Bearer t' };
+
+  it('follows cursors across pages and stops when cursor is absent', async () => {
+    listNotificationsMock
+      .mockResolvedValueOnce({
+        notifications: [{ indexedAt: ISO(new Date()), reason: 'like' }],
+        cursor: 'c1',
+      })
+      .mockResolvedValueOnce({
+        notifications: [{ indexedAt: ISO(new Date()), reason: 'repost' }],
+        cursor: undefined,
+      });
+
+    const res = await activityApp.request('/activity', { headers: auth });
+    const body = (await res.json()) as ActivitySummary;
+    expect(body.totalNotifications).toBe(2);
+    expect(listNotificationsMock).toHaveBeenCalledTimes(2);
+    expect(listNotificationsMock).toHaveBeenLastCalledWith('t', 100, 'c1');
+  });
+
+  it('stops when the same cursor repeats (avoids infinite loop)', async () => {
+    listNotificationsMock.mockResolvedValue({
+      notifications: [{ indexedAt: ISO(new Date()), reason: 'like' }],
+      cursor: 'same',
+    });
+
+    const res = await activityApp.request('/activity', { headers: auth });
+    const body = (await res.json()) as ActivitySummary;
+    // First page accepted, then loop continues once (cursor not yet seen), second
+    // page returns the same cursor which is now in seenCursors -> break.
+    expect(listNotificationsMock).toHaveBeenCalledTimes(2);
+    expect(body.totalNotifications).toBe(2);
+  });
+
+  it('stops when a page returns zero notifications even with a cursor', async () => {
+    listNotificationsMock.mockResolvedValueOnce({ notifications: [], cursor: 'c1' });
+    const res = await activityApp.request('/activity', { headers: auth });
+    const body = (await res.json()) as ActivitySummary;
+    expect(listNotificationsMock).toHaveBeenCalledTimes(1);
+    expect(body.totalNotifications).toBe(0);
+  });
+});
+
+describe('activity aggregation and totals', () => {
+  const auth = { authorization: 'Bearer t' };
+
+  it('counts each reason type and an unknown reason into total only', async () => {
+    const now = new Date();
+    singlePage([
+      { indexedAt: ISO(now), reason: 'like' },
+      { indexedAt: ISO(now), reason: 'like' },
+      { indexedAt: ISO(now), reason: 'repost' },
+      { indexedAt: ISO(now), reason: 'quote' },
+      { indexedAt: ISO(now), reason: 'reply' },
+      { indexedAt: ISO(now), reason: 'follow' }, // unknown -> total only
+    ]);
+
+    const res = await activityApp.request('/activity', { headers: auth });
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+    const body = (await res.json()) as ActivitySummary;
+    expect(body.totals).toEqual({ likes: 2, reposts: 1, quotes: 1, replies: 1, total: 6 });
+    expect(body.totalNotifications).toBe(6);
+    expect(typeof body.generatedAt).toBe('string');
+  });
+
+  it('produces the full set of period buckets with expected lengths', async () => {
+    singlePage([{ indexedAt: ISO(new Date()), reason: 'like' }]);
+    const res = await activityApp.request('/activity', { headers: auth });
+    const body = (await res.json()) as ActivitySummary;
+
+    expect(Object.keys(body.periods).sort()).toEqual(['all', 'day', 'month', 'week', 'year']);
+    expect(body.periods.day).toHaveLength(24);
+    expect(body.periods.week).toHaveLength(7);
+    expect(body.periods.month).toHaveLength(30);
+    expect(body.periods.year).toHaveLength(12);
+    expect(body.periods.all.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('ignores notifications older than a period window', async () => {
+    const old = new Date(Date.now() - 1000 * 60 * 60 * 24 * 400); // > 1 year
+    singlePage([{ indexedAt: ISO(old), reason: 'like' }]);
+    const res = await activityApp.request('/activity', { headers: auth });
+    const body = (await res.json()) as ActivitySummary;
+
+    const dayTotal = body.periods.day.reduce((s, b) => s + b.total, 0);
+    const yearTotal = body.periods.year.reduce((s, b) => s + b.total, 0);
+    expect(dayTotal).toBe(0);
+    expect(yearTotal).toBe(0);
+    // But still counted in overall totals.
+    expect(body.totals.total).toBe(1);
+  });
+
+  it('skips notifications with an invalid indexedAt date', async () => {
+    singlePage([
+      { indexedAt: 'not-a-date', reason: 'like' },
+      { indexedAt: ISO(new Date()), reason: 'like' },
+    ]);
+    const res = await activityApp.request('/activity', { headers: auth });
+    const body = (await res.json()) as ActivitySummary;
+    // totals still increments for both (summariseTotals doesn't validate dates).
+    expect(body.totals.total).toBe(2);
+    const dayTotal = body.periods.day.reduce((s, b) => s + b.total, 0);
+    expect(dayTotal).toBe(1);
+  });
+
+  it('groups the all-time period by year for accounts older than 3 years', async () => {
+    const fiveYearsAgo = new Date(Date.now() - 1000 * 60 * 60 * 24 * 365 * 5);
+    getProfileMock.mockResolvedValue({ indexedAt: ISO(fiveYearsAgo) });
+    singlePage([{ indexedAt: ISO(new Date()), reason: 'like' }]);
+
+    const res = await activityApp.request('/activity?did=did:example:alice', { headers: auth });
+    const body = (await res.json()) as ActivitySummary;
+    // Year keys are 4-digit strings; month keys contain a dash.
+    expect(body.periods.all.length).toBeGreaterThanOrEqual(5);
+    expect(body.periods.all.every((b) => /^\d{4}$/.test(b.date))).toBe(true);
+  });
+
+  it('groups the all-time period by month for newer accounts', async () => {
+    singlePage([{ indexedAt: ISO(new Date()), reason: 'like' }]);
+    const res = await activityApp.request('/activity', { headers: auth });
+    const body = (await res.json()) as ActivitySummary;
+    expect(body.periods.all.every((b) => /^\d{4}-\d{2}$/.test(b.date))).toBe(true);
+  });
+
+  it('clamps a future account-creation date back to now (all-time period)', async () => {
+    // Profile reports a creation date in the future -> start is reset to now.
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 24 * 30);
+    getProfileMock.mockResolvedValue({ indexedAt: ISO(future) });
+    singlePage([{ indexedAt: ISO(new Date()), reason: 'like' }]);
+
+    const res = await activityApp.request('/activity?did=did:example:future', { headers: auth });
+    const body = (await res.json()) as ActivitySummary;
+    expect(res.status).toBe(200);
+    // Only a single (current) bucket should remain.
+    expect(body.periods.all).toHaveLength(1);
+  });
+
+  it('skips invalid-dated notifications inside the all-time bucketing loop', async () => {
+    getProfileMock.mockResolvedValue({ indexedAt: ISO(new Date('2022-01-01T00:00:00Z')) });
+    singlePage([
+      { indexedAt: 'garbage', reason: 'like' },
+      { indexedAt: ISO(new Date()), reason: 'reply' },
+    ]);
+    const res = await activityApp.request('/activity?did=did:example:mixed', { headers: auth });
+    const body = (await res.json()) as ActivitySummary;
+    const allTotal = body.periods.all.reduce((s, b) => s + b.total, 0);
+    // Only the valid-dated notification lands in an all-time bucket.
+    expect(allTotal).toBe(1);
+    expect(body.totals.total).toBe(2);
+  });
+
+  it('drops all-time notifications that fall outside the generated bucket range', async () => {
+    // Account created recently -> monthly buckets only span the last ~few months,
+    // but a notification timestamp older than the account-creation start still
+    // gets included in the window via the earliest-timestamp extension. To hit the
+    // "no matching bucket" path we use a year far in the future for the reason key
+    // while keeping the start clamped: a notification dated well before any key.
+    getProfileMock.mockResolvedValue({ indexedAt: ISO(new Date()) });
+    singlePage([
+      { indexedAt: ISO(new Date()), reason: 'like' },
+      // Dated in the future relative to `now`; no bucket key was generated for it.
+      { indexedAt: ISO(new Date(Date.now() + 1000 * 60 * 60 * 24 * 400)), reason: 'repost' },
+    ]);
+    const res = await activityApp.request('/activity?did=did:example:oob', { headers: auth });
+    const body = (await res.json()) as ActivitySummary;
+    const allTotal = body.periods.all.reduce((s, b) => s + b.total, 0);
+    // Future notification has no bucket -> excluded from all-time aggregation.
+    expect(allTotal).toBe(1);
+    expect(body.totals.total).toBe(2);
+  });
+
+  it('uses earliest notification timestamp to extend the all-time window', async () => {
+    const old = new Date(Date.now() - 1000 * 60 * 60 * 24 * 200);
+    singlePage([
+      { indexedAt: ISO(old), reason: 'like' },
+      { indexedAt: ISO(new Date()), reason: 'reply' },
+    ]);
+    const res = await activityApp.request('/activity', { headers: auth });
+    const body = (await res.json()) as ActivitySummary;
+    const allTotal = body.periods.all.reduce((s, b) => s + b.total, 0);
+    expect(allTotal).toBe(2);
+  });
+
+  it('extends the window when a notification predates the profile creation date', async () => {
+    // Profile says the account was created a year ago, but there is an older
+    // notification -> earliestTimestamp is pushed back to the notification time.
+    const profileStart = new Date(Date.now() - 1000 * 60 * 60 * 24 * 365);
+    getProfileMock.mockResolvedValue({ indexedAt: ISO(profileStart) });
+    const older = new Date(Date.now() - 1000 * 60 * 60 * 24 * 500);
+    singlePage([
+      { indexedAt: ISO(older), reason: 'like' },
+      { indexedAt: ISO(new Date()), reason: 'reply' },
+    ]);
+    const res = await activityApp.request('/activity?did=did:example:old', { headers: auth });
+    const body = (await res.json()) as ActivitySummary;
+    const allTotal = body.periods.all.reduce((s, b) => s + b.total, 0);
+    expect(allTotal).toBe(2);
+  });
+});
+
+describe('account creation date resolution', () => {
+  const auth = { authorization: 'Bearer t' };
+
+  it('uses the profile indexedAt when a did + profile are available', async () => {
+    getProfileMock.mockResolvedValue({ indexedAt: ISO(new Date('2020-01-01T00:00:00Z')) });
+    singlePage([{ indexedAt: ISO(new Date()), reason: 'like' }]);
+    const res = await activityApp.request('/activity?did=did:example:alice', { headers: auth });
+    expect(res.status).toBe(200);
+    expect(getProfileMock).toHaveBeenCalledWith('t', 'did:example:alice');
+  });
+
+  it('falls back to notification timestamps when getProfile throws', async () => {
+    getProfileMock.mockRejectedValue(new Error('profile down'));
+    singlePage([{ indexedAt: ISO(new Date()), reason: 'like' }]);
+    const res = await activityApp.request('/activity', {
+      headers: { ...auth, 'x-did': 'did:example:bob' },
+    });
+    expect(res.status).toBe(200);
+    expect(getProfileMock).toHaveBeenCalledWith('t', 'did:example:bob');
+  });
+
+  it('handles a profile that has no indexedAt field', async () => {
+    getProfileMock.mockResolvedValue({});
+    singlePage([{ indexedAt: ISO(new Date()), reason: 'like' }]);
+    const res = await activityApp.request('/activity?did=did:example:carol', { headers: auth });
+    expect(res.status).toBe(200);
+  });
+
+  it('defaults to now when there are no notifications and no did', async () => {
+    singlePage([]);
+    const res = await activityApp.request('/activity', { headers: auth });
+    const body = (await res.json()) as ActivitySummary;
+    expect(res.status).toBe(200);
+    expect(body.totalNotifications).toBe(0);
+    // all-time still has at least one bucket for the current month.
+    expect(body.periods.all.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('error handling', () => {
+  it('returns 502 when fetching notifications fails', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    listNotificationsMock.mockRejectedValue(new Error('network down'));
+
+    const res = await activityApp.request('/activity', {
+      headers: { authorization: 'Bearer t' },
+    });
+    expect(res.status).toBe(502);
+    await expect(res.json()).resolves.toEqual({
+      error: 'Unable to load Bluesky activity at this time.',
+    });
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});
+
+describe('root route', () => {
+  it('the root path also serves the activity handler', async () => {
+    singlePage([{ indexedAt: ISO(new Date()), reason: 'like' }]);
+    const res = await activityApp.request('/', {
+      headers: { authorization: 'Bearer t' },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ActivitySummary;
+    expect(body.totals.total).toBe(1);
+  });
+});

--- a/apps/activity-service/tsconfig.build.json
+++ b/apps/activity-service/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/apps/firehose-notifier/jest.config.cjs
+++ b/apps/firehose-notifier/jest.config.cjs
@@ -1,0 +1,36 @@
+const baseTsconfig = require('./tsconfig.json');
+
+const jestTsconfig = {
+  ...baseTsconfig.compilerOptions,
+  types: [...new Set([...(baseTsconfig.compilerOptions?.types ?? []), 'jest', 'node'])],
+};
+
+const isGithubActions = Boolean(process.env.GITHUB_ACTIONS);
+
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  extensionsToTreatAsEsm: ['.ts'],
+  coverageProvider: 'v8',
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts', '!src/**/*.d.ts'],
+  coverageReporters: ['text', 'lcov', 'html'],
+  coverageDirectory: 'coverage',
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    '^.+\\.m?tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: jestTsconfig,
+      },
+    ],
+    'node_modules/.+\\.mjs$': '<rootDir>/../../scripts/jest-transform-mjs.cjs',
+  },
+  transformIgnorePatterns: ['node_modules/(?!.+\\.mjs$)'],
+  ...(isGithubActions ? { reporters: ['default', 'github-actions', ['jest-junit', { outputName: 'junit.xml' }]] } : {}),
+};

--- a/apps/firehose-notifier/package.json
+++ b/apps/firehose-notifier/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc --project tsconfig.json",
+    "build": "tsc --project tsconfig.build.json",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",

--- a/apps/firehose-notifier/src/config.test.ts
+++ b/apps/firehose-notifier/src/config.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { loadConfig } from './config.js';
+
+const REGISTRY_VARS = [
+  'AKARI_NOTIFIER_REGISTRY_URL',
+  'AKARI_NOTIFIER_REGISTRY_TOKEN',
+  'AKARI_NOTIFIER_REGISTRY_REFRESH_MS',
+  'AKARI_EXPO_ACCESS_TOKEN',
+] as const;
+
+describe('loadConfig', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const key of REGISTRY_VARS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of REGISTRY_VARS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+  });
+
+  it('throws when the registry url is missing', () => {
+    expect(() => loadConfig()).toThrow('AKARI_NOTIFIER_REGISTRY_URL is required.');
+  });
+
+  it('throws when the registry url is blank', () => {
+    process.env.AKARI_NOTIFIER_REGISTRY_URL = '   ';
+    expect(() => loadConfig()).toThrow('AKARI_NOTIFIER_REGISTRY_URL is required.');
+  });
+
+  it('throws when the refresh interval is not a number', () => {
+    process.env.AKARI_NOTIFIER_REGISTRY_URL = 'https://registry.example';
+    process.env.AKARI_NOTIFIER_REGISTRY_REFRESH_MS = 'abc';
+    expect(() => loadConfig()).toThrow(
+      'AKARI_NOTIFIER_REGISTRY_REFRESH_MS must be a positive integer representing milliseconds.',
+    );
+  });
+
+  it('throws when the refresh interval is zero or negative', () => {
+    process.env.AKARI_NOTIFIER_REGISTRY_URL = 'https://registry.example';
+    process.env.AKARI_NOTIFIER_REGISTRY_REFRESH_MS = '0';
+    expect(() => loadConfig()).toThrow(
+      'AKARI_NOTIFIER_REGISTRY_REFRESH_MS must be a positive integer representing milliseconds.',
+    );
+
+    process.env.AKARI_NOTIFIER_REGISTRY_REFRESH_MS = '-5';
+    expect(() => loadConfig()).toThrow(
+      'AKARI_NOTIFIER_REGISTRY_REFRESH_MS must be a positive integer representing milliseconds.',
+    );
+  });
+
+  it('loads a minimal valid config (url only)', () => {
+    process.env.AKARI_NOTIFIER_REGISTRY_URL = '  https://registry.example  ';
+    const config = loadConfig();
+    expect(config).toEqual({
+      expoAccessToken: undefined,
+      registry: {
+        endpoint: 'https://registry.example',
+        bearerToken: undefined,
+        refreshIntervalMs: undefined,
+      },
+    });
+  });
+
+  it('loads a full valid config with all options trimmed', () => {
+    process.env.AKARI_NOTIFIER_REGISTRY_URL = 'https://registry.example';
+    process.env.AKARI_NOTIFIER_REGISTRY_TOKEN = '  secret-token  ';
+    process.env.AKARI_NOTIFIER_REGISTRY_REFRESH_MS = ' 60000 ';
+    process.env.AKARI_EXPO_ACCESS_TOKEN = '  expo-token  ';
+
+    const config = loadConfig();
+    expect(config).toEqual({
+      expoAccessToken: 'expo-token',
+      registry: {
+        endpoint: 'https://registry.example',
+        bearerToken: 'secret-token',
+        refreshIntervalMs: 60000,
+      },
+    });
+  });
+});

--- a/apps/firehose-notifier/src/dids.test.ts
+++ b/apps/firehose-notifier/src/dids.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from '@jest/globals';
+import { normaliseDid, didFromUri } from './dids.js';
+
+describe('normaliseDid', () => {
+  it('returns null for undefined', () => {
+    expect(normaliseDid(undefined)).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(normaliseDid('')).toBeNull();
+  });
+
+  it('returns null for a whitespace-only string', () => {
+    expect(normaliseDid('   ')).toBeNull();
+  });
+
+  it('trims and lowercases the value', () => {
+    expect(normaliseDid('  DID:PLC:ABC  ')).toBe('did:plc:abc');
+  });
+});
+
+describe('didFromUri', () => {
+  it('returns null for undefined', () => {
+    expect(didFromUri(undefined)).toBeNull();
+  });
+
+  it('returns null when the uri does not start with at://', () => {
+    expect(didFromUri('https://example.com/foo')).toBeNull();
+  });
+
+  it('extracts and normalises the did from an at:// uri', () => {
+    expect(didFromUri('at://DID:PLC:ABC/app.bsky.feed.post/rkey')).toBe('did:plc:abc');
+  });
+
+  it('handles an at:// uri with only a did and no trailing path', () => {
+    expect(didFromUri('at://did:plc:abc')).toBe('did:plc:abc');
+  });
+
+  it('returns null when the at:// uri has an empty did segment', () => {
+    expect(didFromUri('at:///app.bsky.feed.post')).toBeNull();
+  });
+});

--- a/apps/firehose-notifier/src/firehose.test.ts
+++ b/apps/firehose-notifier/src/firehose.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import type { Subscription } from './types.js';
+
+type Handler = (event: unknown) => void;
+
+const mockJetstreamInstances: MockJetstream[] = [];
+
+class MockJetstream {
+  public readonly onHandlers = new Map<string, Handler>();
+  public readonly createHandlers = new Map<string, Handler>();
+  public started = false;
+  public closed = false;
+  public readonly options: unknown;
+
+  constructor(options: unknown) {
+    this.options = options;
+    mockJetstreamInstances.push(this);
+  }
+
+  on(event: string, handler: Handler) {
+    this.onHandlers.set(event, handler);
+  }
+
+  onCreate(collection: string, handler: Handler) {
+    this.createHandlers.set(collection, handler);
+  }
+
+  start() {
+    this.started = true;
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+
+jest.mock('@skyware/jetstream', () => ({
+  Jetstream: MockJetstream,
+}));
+
+import { FirehoseNotifier } from './firehose.js';
+
+function makeStore(subs: Subscription[]) {
+  const map = new Map<string, Subscription>();
+  for (const sub of subs) {
+    map.set(sub.did.toLowerCase(), sub);
+  }
+  return {
+    get: jest.fn((did: string | null) => (did ? map.get(did.toLowerCase()) : undefined)),
+    start: jest.fn(),
+    stop: jest.fn(),
+  };
+}
+
+type SentMessage = { title: string; body: string };
+
+function makeNotifier() {
+  return {
+    send: jest.fn<(subscription: Subscription, message: SentMessage) => Promise<void>>(
+      async () => {},
+    ),
+  };
+}
+
+describe('FirehoseNotifier', () => {
+  let jetstream: MockJetstream;
+
+  beforeEach(() => {
+    mockJetstreamInstances.length = 0;
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function build(subs: Subscription[]) {
+    const store = makeStore(subs);
+    const notifier = makeNotifier();
+    const service = new FirehoseNotifier(notifier as never, store as never);
+    service.start();
+    jetstream = mockJetstreamInstances[mockJetstreamInstances.length - 1];
+    return { service, store, notifier };
+  }
+
+  it('configures jetstream with the watched collections and registers handlers on start', () => {
+    const { service } = build([]);
+    expect((jetstream.options as { wantedCollections: string[] }).wantedCollections).toEqual([
+      'app.bsky.graph.follow',
+      'app.bsky.feed.like',
+      'app.bsky.feed.post',
+      'app.bsky.feed.repost',
+    ]);
+    expect(jetstream.started).toBe(true);
+    expect(jetstream.onHandlers.has('open')).toBe(true);
+    expect(jetstream.onHandlers.has('close')).toBe(true);
+    expect(jetstream.onHandlers.has('error')).toBe(true);
+    expect(jetstream.createHandlers.size).toBe(4);
+
+    // lifecycle log handlers run without error
+    jetstream.onHandlers.get('open')!(undefined);
+    jetstream.onHandlers.get('close')!(undefined);
+    jetstream.onHandlers.get('error')!(new Error('boom'));
+    jetstream.onHandlers.get('error')!('plain string error');
+
+    service.stop();
+    expect(jetstream.closed).toBe(true);
+  });
+
+  // FOLLOW
+  it('notifies the followed subscriber on a follow event', async () => {
+    const { store, notifier } = build([{ did: 'did:plc:target', tokens: ['t'] }]);
+    const handler = jetstream.createHandlers.get('app.bsky.graph.follow')!;
+    handler({ did: 'did:plc:follower', commit: { record: { subject: 'did:plc:target' } } });
+    await Promise.resolve();
+
+    expect(store.get).toHaveBeenCalledWith('did:plc:target');
+    expect(notifier.send).toHaveBeenCalledTimes(1);
+    const [, msg] = notifier.send.mock.calls[0];
+    expect(msg.title).toBe('New follower');
+    expect(msg.body).toContain('did:plc:follower');
+  });
+
+  it('ignores a follow event when there is no matching subscription', async () => {
+    const { notifier } = build([]);
+    jetstream.createHandlers.get('app.bsky.graph.follow')!({
+      did: 'did:plc:follower',
+      commit: { record: { subject: 'did:plc:nobody' } },
+    });
+    await Promise.resolve();
+    expect(notifier.send).not.toHaveBeenCalled();
+  });
+
+  it('ignores a self-follow event', async () => {
+    const { notifier } = build([{ did: 'did:plc:self', tokens: ['t'] }]);
+    jetstream.createHandlers.get('app.bsky.graph.follow')!({
+      did: 'did:plc:self',
+      commit: { record: { subject: 'did:plc:self' } },
+    });
+    await Promise.resolve();
+    expect(notifier.send).not.toHaveBeenCalled();
+  });
+
+  // LIKE
+  it('notifies on a like event', async () => {
+    const { notifier } = build([{ did: 'did:plc:author', tokens: ['t'] }]);
+    jetstream.createHandlers.get('app.bsky.feed.like')!({
+      did: 'did:plc:liker',
+      commit: { record: { subject: { uri: 'at://did:plc:author/app.bsky.feed.post/x', cid: 'cid1' } } },
+    });
+    await Promise.resolve();
+    const [, msg] = notifier.send.mock.calls[0];
+    expect(msg.title).toBe('New like');
+  });
+
+  it('ignores a self-like event', async () => {
+    const { notifier } = build([{ did: 'did:plc:author', tokens: ['t'] }]);
+    jetstream.createHandlers.get('app.bsky.feed.like')!({
+      did: 'did:plc:author',
+      commit: { record: { subject: { uri: 'at://did:plc:author/app.bsky.feed.post/x', cid: 'c' } } },
+    });
+    await Promise.resolve();
+    expect(notifier.send).not.toHaveBeenCalled();
+  });
+
+  it('ignores a like for an unknown subject', async () => {
+    const { notifier } = build([]);
+    jetstream.createHandlers.get('app.bsky.feed.like')!({
+      did: 'did:plc:liker',
+      commit: { record: { subject: { uri: 'at://did:plc:other/app.bsky.feed.post/x', cid: 'c' } } },
+    });
+    await Promise.resolve();
+    expect(notifier.send).not.toHaveBeenCalled();
+  });
+
+  // REPOST
+  it('notifies on a repost event', async () => {
+    const { notifier } = build([{ did: 'did:plc:author', tokens: ['t'] }]);
+    jetstream.createHandlers.get('app.bsky.feed.repost')!({
+      did: 'did:plc:reposter',
+      commit: { record: { subject: { uri: 'at://did:plc:author/app.bsky.feed.post/x', cid: 'c' } } },
+    });
+    await Promise.resolve();
+    const [, msg] = notifier.send.mock.calls[0];
+    expect(msg.title).toBe('New repost');
+  });
+
+  it('ignores a self-repost and unknown-subject repost', async () => {
+    const { notifier } = build([{ did: 'did:plc:author', tokens: ['t'] }]);
+    jetstream.createHandlers.get('app.bsky.feed.repost')!({
+      did: 'did:plc:author',
+      commit: { record: { subject: { uri: 'at://did:plc:author/app.bsky.feed.post/x', cid: 'c' } } },
+    });
+    jetstream.createHandlers.get('app.bsky.feed.repost')!({
+      did: 'did:plc:reposter',
+      commit: { record: { subject: { uri: 'at://did:plc:unknown/app.bsky.feed.post/x', cid: 'c' } } },
+    });
+    await Promise.resolve();
+    expect(notifier.send).not.toHaveBeenCalled();
+  });
+
+  // REPLY (post)
+  it('ignores a post event that is not a reply', async () => {
+    const { notifier } = build([{ did: 'did:plc:author', tokens: ['t'] }]);
+    jetstream.createHandlers.get('app.bsky.feed.post')!({
+      did: 'did:plc:replier',
+      commit: { collection: 'app.bsky.feed.post', rkey: 'r1', record: { text: 'hi' } },
+    });
+    await Promise.resolve();
+    expect(notifier.send).not.toHaveBeenCalled();
+  });
+
+  it('notifies the parent and root of a reply (deduped) with a text snippet', async () => {
+    const { notifier } = build([
+      { did: 'did:plc:parent', tokens: ['t'] },
+      { did: 'did:plc:root', tokens: ['t'] },
+    ]);
+    jetstream.createHandlers.get('app.bsky.feed.post')!({
+      did: 'did:plc:replier',
+      commit: {
+        collection: 'app.bsky.feed.post',
+        rkey: 'r1',
+        record: {
+          text: 'hello there',
+          reply: {
+            parent: { uri: 'at://did:plc:parent/app.bsky.feed.post/p', cid: 'c' },
+            root: { uri: 'at://did:plc:root/app.bsky.feed.post/rt', cid: 'c' },
+          },
+        },
+      },
+    });
+    await Promise.resolve();
+    expect(notifier.send).toHaveBeenCalledTimes(2);
+    const [, msg] = notifier.send.mock.calls[0];
+    expect(msg.title).toBe('New reply');
+    expect(msg.body).toContain('hello there');
+  });
+
+  it('truncates long reply text in the notification body', async () => {
+    const { notifier } = build([{ did: 'did:plc:parent', tokens: ['t'] }]);
+    const longText = 'a'.repeat(200);
+    jetstream.createHandlers.get('app.bsky.feed.post')!({
+      did: 'did:plc:replier',
+      commit: {
+        collection: 'app.bsky.feed.post',
+        rkey: 'r1',
+        record: {
+          text: longText,
+          reply: { parent: { uri: 'at://did:plc:parent/app.bsky.feed.post/p', cid: 'c' } },
+        },
+      },
+    });
+    await Promise.resolve();
+    const [, msg] = notifier.send.mock.calls[0];
+    expect(msg.body).toContain('…');
+    expect(msg.body.length).toBeLessThan(longText.length + 50);
+  });
+
+  it('uses the fallback body when a reply has no text', async () => {
+    const { notifier } = build([{ did: 'did:plc:parent', tokens: ['t'] }]);
+    jetstream.createHandlers.get('app.bsky.feed.post')!({
+      did: 'did:plc:replier',
+      commit: {
+        collection: 'app.bsky.feed.post',
+        rkey: 'r1',
+        record: {
+          reply: { parent: { uri: 'at://did:plc:parent/app.bsky.feed.post/p', cid: 'c' } },
+        },
+      },
+    });
+    await Promise.resolve();
+    const [, msg] = notifier.send.mock.calls[0];
+    expect(msg.body).toBe('did:plc:replier replied to your post');
+  });
+
+  it('skips a self-reply', async () => {
+    const { notifier } = build([{ did: 'did:plc:author', tokens: ['t'] }]);
+    jetstream.createHandlers.get('app.bsky.feed.post')!({
+      did: 'did:plc:author',
+      commit: {
+        collection: 'app.bsky.feed.post',
+        rkey: 'r1',
+        record: {
+          text: 'self reply',
+          reply: { parent: { uri: 'at://did:plc:author/app.bsky.feed.post/p', cid: 'c' } },
+        },
+      },
+    });
+    await Promise.resolve();
+    expect(notifier.send).not.toHaveBeenCalled();
+  });
+
+  it('ignores a reply whose targets have no subscription', async () => {
+    const { notifier } = build([]);
+    jetstream.createHandlers.get('app.bsky.feed.post')!({
+      did: 'did:plc:replier',
+      commit: {
+        collection: 'app.bsky.feed.post',
+        rkey: 'r1',
+        record: {
+          text: 'hi',
+          reply: { parent: { uri: 'at://did:plc:nobody/app.bsky.feed.post/p', cid: 'c' } },
+        },
+      },
+    });
+    await Promise.resolve();
+    expect(notifier.send).not.toHaveBeenCalled();
+  });
+});

--- a/apps/firehose-notifier/src/logger.test.ts
+++ b/apps/firehose-notifier/src/logger.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+
+const ORIGINAL_LEVEL = process.env.AKARI_NOTIFIER_LOG_LEVEL;
+
+async function loadLogger(level?: string) {
+  jest.resetModules();
+  if (level === undefined) {
+    delete process.env.AKARI_NOTIFIER_LOG_LEVEL;
+  } else {
+    process.env.AKARI_NOTIFIER_LOG_LEVEL = level;
+  }
+  const mod = await import('./logger.js');
+  return mod.logger;
+}
+
+describe('logger', () => {
+  let debugSpy: ReturnType<typeof jest.spyOn>;
+  let infoSpy: ReturnType<typeof jest.spyOn>;
+  let warnSpy: ReturnType<typeof jest.spyOn>;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    if (ORIGINAL_LEVEL === undefined) {
+      delete process.env.AKARI_NOTIFIER_LOG_LEVEL;
+    } else {
+      process.env.AKARI_NOTIFIER_LOG_LEVEL = ORIGINAL_LEVEL;
+    }
+  });
+
+  it('defaults to info level (debug suppressed, info+ emitted)', async () => {
+    const logger = await loadLogger(undefined);
+    logger.debug('d');
+    logger.info('i');
+    logger.warn('w');
+    logger.error('e');
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits debug when level is debug', async () => {
+    const logger = await loadLogger('debug');
+    logger.debug('d');
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses info/warn when level is error', async () => {
+    const logger = await loadLogger('error');
+    logger.debug('d');
+    logger.info('i');
+    logger.warn('w');
+    logger.error('e');
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to info for an invalid level value', async () => {
+    const logger = await loadLogger('not-a-level');
+    logger.debug('d');
+    logger.info('i');
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the metadata argument through when provided', async () => {
+    const logger = await loadLogger('debug');
+    const meta = { foo: 'bar' };
+    logger.info('msg', meta);
+    expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('[info] msg'), meta);
+  });
+
+  it("passes '' as the metadata placeholder when omitted", async () => {
+    const logger = await loadLogger('debug');
+    logger.warn('msg');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('[warn] msg'), '');
+  });
+});

--- a/apps/firehose-notifier/src/notifier.test.ts
+++ b/apps/firehose-notifier/src/notifier.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+
+const mockChunkPushNotifications = jest.fn<(messages: unknown[]) => unknown[][]>();
+const mockSendPushNotificationsAsync = jest.fn<(chunk: unknown[]) => Promise<unknown[]>>();
+const mockIsExpoPushToken = jest.fn<(token: unknown) => boolean>();
+const mockExpoConstructor = jest.fn<(options?: unknown) => void>();
+
+jest.mock('expo-server-sdk', () => {
+  class Expo {
+    chunkPushNotifications = mockChunkPushNotifications;
+    sendPushNotificationsAsync = mockSendPushNotificationsAsync;
+    static isExpoPushToken = mockIsExpoPushToken;
+
+    constructor(options?: unknown) {
+      mockExpoConstructor(options);
+    }
+  }
+  return { Expo };
+});
+
+import { ExpoNotifier } from './notifier.js';
+
+const subscription = { did: 'did:plc:abc', tokens: ['valid-1', 'invalid', 'valid-2'] };
+const message = {
+  title: 'New like',
+  body: 'someone liked your post',
+  data: { reason: 'like' as const, actorDid: 'did:plc:other' },
+};
+
+describe('ExpoNotifier', () => {
+  let infoSpy: ReturnType<typeof jest.spyOn>;
+  let warnSpy: ReturnType<typeof jest.spyOn>;
+  let errorSpy: ReturnType<typeof jest.spyOn>;
+
+  beforeEach(() => {
+    mockChunkPushNotifications.mockReset();
+    mockSendPushNotificationsAsync.mockReset();
+    mockIsExpoPushToken.mockReset();
+    mockExpoConstructor.mockReset();
+    infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('passes the access token to the Expo constructor', () => {
+    new ExpoNotifier('my-token');
+    expect(mockExpoConstructor).toHaveBeenCalledWith({ accessToken: 'my-token' });
+  });
+
+  it('filters invalid tokens, builds payloads, chunks, sends and logs ok tickets', async () => {
+    mockIsExpoPushToken.mockImplementation((token: unknown) => token !== 'invalid');
+    const payloadChunk = [{ to: 'valid-1' }, { to: 'valid-2' }];
+    mockChunkPushNotifications.mockReturnValue([payloadChunk]);
+    mockSendPushNotificationsAsync.mockResolvedValue([
+      { status: 'ok', id: 'ticket-1' },
+      { status: 'error', message: 'bad token', details: { error: 'DeviceNotRegistered' } },
+    ]);
+
+    const notifier = new ExpoNotifier();
+    await notifier.send(subscription, message);
+
+    // the invalid token was warned about
+    expect(warnSpy).toHaveBeenCalled();
+    // payloads only built for the 2 valid tokens
+    const builtPayloads = mockChunkPushNotifications.mock.calls[0][0] as Array<{ to: string }>;
+    expect(builtPayloads.map((p) => p.to)).toEqual(['valid-1', 'valid-2']);
+    expect(builtPayloads[0]).toMatchObject({
+      sound: 'default',
+      title: message.title,
+      body: message.body,
+      data: message.data,
+    });
+    expect(mockSendPushNotificationsAsync).toHaveBeenCalledWith(payloadChunk);
+    // one ok ticket logged as info, one error ticket logged as error
+    expect(infoSpy).toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('returns early and warns when there are no valid tokens', async () => {
+    mockIsExpoPushToken.mockReturnValue(false);
+    const notifier = new ExpoNotifier();
+    await notifier.send(subscription, message);
+
+    expect(mockChunkPushNotifications).not.toHaveBeenCalled();
+    expect(mockSendPushNotificationsAsync).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('logs an error when sending a chunk throws (Error instance)', async () => {
+    mockIsExpoPushToken.mockReturnValue(true);
+    mockChunkPushNotifications.mockReturnValue([[{ to: 'valid-1' }]]);
+    mockSendPushNotificationsAsync.mockRejectedValue(new Error('boom'));
+
+    const notifier = new ExpoNotifier();
+    await notifier.send({ did: 'did:plc:abc', tokens: ['valid-1'] }, message);
+
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('logs an error when sending a chunk throws a non-Error', async () => {
+    mockIsExpoPushToken.mockReturnValue(true);
+    mockChunkPushNotifications.mockReturnValue([[{ to: 'valid-1' }]]);
+    mockSendPushNotificationsAsync.mockRejectedValue('string failure');
+
+    const notifier = new ExpoNotifier();
+    await notifier.send({ did: 'did:plc:abc', tokens: ['valid-1'] }, message);
+
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/firehose-notifier/src/subscription-store.test.ts
+++ b/apps/firehose-notifier/src/subscription-store.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+import { SubscriptionStore } from './subscription-store.js';
+import type { NotifierRegistryConfig } from './types.js';
+
+const ENDPOINT = 'https://registry.example/subscriptions';
+
+function jsonResponse(body: unknown, init?: { ok?: boolean; status?: number; statusText?: string }) {
+  return {
+    ok: init?.ok ?? true,
+    status: init?.status ?? 200,
+    statusText: init?.statusText ?? 'OK',
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('SubscriptionStore', () => {
+  let fetchMock: jest.Mock<(input: unknown, init?: unknown) => Promise<Response>>;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    fetchMock = jest.fn<(input: unknown, init?: unknown) => Promise<Response>>();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    jest.spyOn(console, 'info').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+    global.fetch = originalFetch;
+  });
+
+  it('loads subscriptions on start and resolves them by normalised did', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse([{ did: 'DID:PLC:ABC', tokens: ['t1'] }]),
+    );
+
+    const store = new SubscriptionStore({ endpoint: ENDPOINT });
+    await store.start();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(store.get('did:plc:abc')).toEqual({ did: 'DID:PLC:ABC', tokens: ['t1'] });
+    // lookup is case-insensitive via normalisation
+    expect(store.get('DID:PLC:ABC')).toEqual({ did: 'DID:PLC:ABC', tokens: ['t1'] });
+    store.stop();
+  });
+
+  it('sends the bearer token header when configured', async () => {
+    fetchMock.mockResolvedValue(jsonResponse([{ did: 'did:plc:a', tokens: ['t'] }]));
+    const config: NotifierRegistryConfig = { endpoint: ENDPOINT, bearerToken: 'sekret' };
+    const store = new SubscriptionStore(config);
+    await store.start();
+
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((options.headers as Record<string, string>).Authorization).toBe('Bearer sekret');
+    expect((options.headers as Record<string, string>)['content-type']).toBe('application/json');
+    store.stop();
+  });
+
+  it('omits the Authorization header when no bearer token is set', async () => {
+    fetchMock.mockResolvedValue(jsonResponse([{ did: 'did:plc:a', tokens: ['t'] }]));
+    const store = new SubscriptionStore({ endpoint: ENDPOINT });
+    await store.start();
+
+    const [, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((options.headers as Record<string, string>).Authorization).toBeUndefined();
+    store.stop();
+  });
+
+  it('throws on start when the registry responds with a non-ok status', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(null, { ok: false, status: 500, statusText: 'Server Error' }),
+    );
+    const store = new SubscriptionStore({ endpoint: ENDPOINT });
+    await expect(store.start()).rejects.toThrow(
+      'Registry request failed with status 500 Server Error',
+    );
+  });
+
+  it('throws on start when the payload fails to parse', async () => {
+    fetchMock.mockResolvedValue(jsonResponse([{ did: '', tokens: [] }]));
+    const store = new SubscriptionStore({ endpoint: ENDPOINT });
+    await expect(store.start()).rejects.toThrow('missing a valid did');
+  });
+
+  it('wraps a non-Error rejection into an Error on start', async () => {
+    fetchMock.mockRejectedValue('network down');
+    const store = new SubscriptionStore({ endpoint: ENDPOINT });
+    await expect(store.start()).rejects.toThrow('Failed to load subscription registry.');
+  });
+
+  it('does not throw on a background refresh failure and keeps prior data', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse([{ did: 'did:plc:a', tokens: ['t1'] }]))
+      .mockRejectedValueOnce(new Error('temporary failure'));
+
+    const store = new SubscriptionStore({ endpoint: ENDPOINT, refreshIntervalMs: 30_000 });
+    await store.start();
+    expect(store.get('did:plc:a')).toBeDefined();
+
+    // trigger the interval-based refresh which fails
+    await jest.advanceTimersByTimeAsync(30_000);
+
+    // background failure should not clear existing subscriptions
+    expect(store.get('did:plc:a')).toBeDefined();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    store.stop();
+  });
+
+  it('refreshes subscriptions on the interval and applies new data', async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse([{ did: 'did:plc:a', tokens: ['t1'] }]))
+      .mockResolvedValueOnce(jsonResponse([{ did: 'did:plc:b', tokens: ['t2'] }]));
+
+    const store = new SubscriptionStore({ endpoint: ENDPOINT, refreshIntervalMs: 45_000 });
+    await store.start();
+    expect(store.get('did:plc:a')).toBeDefined();
+
+    await jest.advanceTimersByTimeAsync(45_000);
+
+    expect(store.get('did:plc:b')).toBeDefined();
+    expect(store.get('did:plc:a')).toBeUndefined();
+    store.stop();
+  });
+
+  it('get returns undefined for a null/empty did', () => {
+    const store = new SubscriptionStore({ endpoint: ENDPOINT });
+    expect(store.get(null)).toBeUndefined();
+    expect(store.get('')).toBeUndefined();
+  });
+
+  it('stop is safe to call when no timer is running', () => {
+    const store = new SubscriptionStore({ endpoint: ENDPOINT });
+    expect(() => store.stop()).not.toThrow();
+  });
+});

--- a/apps/firehose-notifier/src/subscription-utils.test.ts
+++ b/apps/firehose-notifier/src/subscription-utils.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from '@jest/globals';
+import { parseSubscriptionPayload } from './subscription-utils.js';
+
+describe('parseSubscriptionPayload', () => {
+  it('throws when the payload is not an array', () => {
+    expect(() => parseSubscriptionPayload({}, 'Ctx')).toThrow('Ctx must be an array.');
+    expect(() => parseSubscriptionPayload(null, 'Ctx')).toThrow('Ctx must be an array.');
+    expect(() => parseSubscriptionPayload('nope', 'Ctx')).toThrow('Ctx must be an array.');
+  });
+
+  it('throws when an entry is not an object', () => {
+    expect(() => parseSubscriptionPayload(['x'], 'Ctx')).toThrow(
+      'Ctx entry at index 0 must be an object.',
+    );
+  });
+
+  it('throws when an entry is null', () => {
+    expect(() => parseSubscriptionPayload([null], 'Ctx')).toThrow(
+      'Ctx entry at index 0 must be an object.',
+    );
+  });
+
+  it('throws when the did is missing', () => {
+    expect(() => parseSubscriptionPayload([{ tokens: ['a'] }], 'Ctx')).toThrow(
+      'Ctx entry at index 0 is missing a valid did.',
+    );
+  });
+
+  it('throws when the did is blank or whitespace', () => {
+    expect(() => parseSubscriptionPayload([{ did: '   ', tokens: ['a'] }], 'Ctx')).toThrow(
+      'Ctx entry at index 0 is missing a valid did.',
+    );
+  });
+
+  it('throws when the did is not a string', () => {
+    expect(() => parseSubscriptionPayload([{ did: 123, tokens: ['a'] }], 'Ctx')).toThrow(
+      'Ctx entry at index 0 is missing a valid did.',
+    );
+  });
+
+  it('throws when there are no tokens at all', () => {
+    expect(() => parseSubscriptionPayload([{ did: 'did:plc:abc' }], 'Ctx')).toThrow(
+      'Ctx entry at index 0 must include at least one Expo push token.',
+    );
+  });
+
+  it('throws when tokens is present but empty', () => {
+    expect(() => parseSubscriptionPayload([{ did: 'did:plc:abc', tokens: [] }], 'Ctx')).toThrow(
+      'Ctx entry at index 0 must include at least one Expo push token.',
+    );
+  });
+
+  it('throws when tokens contains only blank/non-string entries', () => {
+    expect(() =>
+      parseSubscriptionPayload([{ did: 'did:plc:abc', tokens: ['  ', 42, null] }], 'Ctx'),
+    ).toThrow('Ctx entry at index 0 must include at least one Expo push token.');
+  });
+
+  it('parses a valid entry with tokens', () => {
+    const result = parseSubscriptionPayload([{ did: 'did:plc:abc', tokens: ['t1', 't2'] }], 'Ctx');
+    expect(result).toEqual([{ did: 'did:plc:abc', tokens: ['t1', 't2'] }]);
+  });
+
+  it('trims the did and filters/trims tokens', () => {
+    const result = parseSubscriptionPayload(
+      [{ did: '  did:plc:abc  ', tokens: [' t1 ', '', '  ', 't2'] }],
+      'Ctx',
+    );
+    expect(result).toEqual([{ did: 'did:plc:abc', tokens: ['t1', 't2'] }]);
+  });
+
+  it('falls back to expoPushTokens when tokens is absent', () => {
+    const result = parseSubscriptionPayload(
+      [{ did: 'did:plc:abc', expoPushTokens: ['e1', 'e2'] }],
+      'Ctx',
+    );
+    expect(result).toEqual([{ did: 'did:plc:abc', tokens: ['e1', 'e2'] }]);
+  });
+
+  it('prefers tokens over expoPushTokens when both present and tokens is a valid array', () => {
+    const result = parseSubscriptionPayload(
+      [{ did: 'did:plc:abc', tokens: ['t1'], expoPushTokens: ['e1'] }],
+      'Ctx',
+    );
+    expect(result).toEqual([{ did: 'did:plc:abc', tokens: ['t1'] }]);
+  });
+
+  it('falls back to expoPushTokens when tokens is present but not an array', () => {
+    const result = parseSubscriptionPayload(
+      [{ did: 'did:plc:abc', tokens: 'not-an-array', expoPushTokens: ['e1'] }],
+      'Ctx',
+    );
+    expect(result).toEqual([{ did: 'did:plc:abc', tokens: ['e1'] }]);
+  });
+
+  it('parses multiple entries and reports the correct failing index', () => {
+    expect(() =>
+      parseSubscriptionPayload(
+        [
+          { did: 'did:plc:a', tokens: ['t'] },
+          { did: '', tokens: ['t'] },
+        ],
+        'Ctx',
+      ),
+    ).toThrow('Ctx entry at index 1 is missing a valid did.');
+  });
+
+  it('returns an empty array for an empty payload', () => {
+    expect(parseSubscriptionPayload([], 'Ctx')).toEqual([]);
+  });
+});

--- a/apps/firehose-notifier/tsconfig.build.json
+++ b/apps/firehose-notifier/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/apps/notifier-registry/jest.config.cjs
+++ b/apps/notifier-registry/jest.config.cjs
@@ -1,0 +1,36 @@
+const baseTsconfig = require('./tsconfig.json');
+
+const jestTsconfig = {
+  ...baseTsconfig.compilerOptions,
+  types: [...new Set([...(baseTsconfig.compilerOptions?.types ?? []), 'jest', 'node'])],
+};
+
+const isGithubActions = Boolean(process.env.GITHUB_ACTIONS);
+
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  extensionsToTreatAsEsm: ['.ts'],
+  coverageProvider: 'v8',
+  collectCoverage: true,
+  collectCoverageFrom: ['src/**/*.ts', '!src/**/*.test.ts', '!src/**/*.d.ts'],
+  coverageReporters: ['text', 'lcov', 'html'],
+  coverageDirectory: 'coverage',
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    '^.+\\.m?tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: jestTsconfig,
+      },
+    ],
+    'node_modules/.+\\.mjs$': '<rootDir>/../../scripts/jest-transform-mjs.cjs',
+  },
+  transformIgnorePatterns: ['node_modules/(?!.+\\.mjs$)'],
+  ...(isGithubActions ? { reporters: ['default', 'github-actions', ['jest-junit', { outputName: 'junit.xml' }]] } : {}),
+};

--- a/apps/notifier-registry/package.json
+++ b/apps/notifier-registry/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "tsc --project tsconfig.json",
+    "build": "tsc --project tsconfig.build.json",
+    "test": "jest",
+    "test:coverage": "jest --coverage",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",

--- a/apps/notifier-registry/src/config.test.ts
+++ b/apps/notifier-registry/src/config.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+import { loadConfig } from './config.js';
+
+const ENV_KEYS = [
+  'AKARI_REGISTRY_HOST',
+  'AKARI_REGISTRY_PORT',
+  'AKARI_REGISTRY_DATA_FILE',
+  'AKARI_REGISTRY_ADMIN_TOKEN',
+  'AKARI_REGISTRY_CLIENT_TOKEN',
+] as const;
+
+describe('loadConfig', () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = savedEnv[key];
+      }
+    }
+  });
+
+  it('returns defaults when no env vars are set', () => {
+    const config = loadConfig();
+    expect(config).toEqual({
+      host: '0.0.0.0',
+      port: 3001,
+      dataFile: undefined,
+      adminToken: undefined,
+      clientToken: undefined,
+    });
+  });
+
+  it('parses all env vars on the happy path', () => {
+    process.env.AKARI_REGISTRY_HOST = '127.0.0.1';
+    process.env.AKARI_REGISTRY_PORT = '8080';
+    process.env.AKARI_REGISTRY_DATA_FILE = '/tmp/data.json';
+    process.env.AKARI_REGISTRY_ADMIN_TOKEN = 'admin-secret';
+    process.env.AKARI_REGISTRY_CLIENT_TOKEN = 'client-secret';
+
+    expect(loadConfig()).toEqual({
+      host: '127.0.0.1',
+      port: 8080,
+      dataFile: '/tmp/data.json',
+      adminToken: 'admin-secret',
+      clientToken: 'client-secret',
+    });
+  });
+
+  it('trims whitespace from string values', () => {
+    process.env.AKARI_REGISTRY_HOST = '  example.com  ';
+    process.env.AKARI_REGISTRY_DATA_FILE = '  /tmp/x.json  ';
+    process.env.AKARI_REGISTRY_ADMIN_TOKEN = '  a  ';
+    process.env.AKARI_REGISTRY_CLIENT_TOKEN = '  c  ';
+
+    const config = loadConfig();
+    expect(config.host).toBe('example.com');
+    expect(config.dataFile).toBe('/tmp/x.json');
+    expect(config.adminToken).toBe('a');
+    expect(config.clientToken).toBe('c');
+  });
+
+  it('falls back to default host when host is only whitespace', () => {
+    process.env.AKARI_REGISTRY_HOST = '   ';
+    expect(loadConfig().host).toBe('0.0.0.0');
+  });
+
+  it('treats whitespace-only optional values as undefined', () => {
+    process.env.AKARI_REGISTRY_DATA_FILE = '   ';
+    process.env.AKARI_REGISTRY_ADMIN_TOKEN = '   ';
+    process.env.AKARI_REGISTRY_CLIENT_TOKEN = '   ';
+
+    const config = loadConfig();
+    expect(config.dataFile).toBeUndefined();
+    expect(config.adminToken).toBeUndefined();
+    expect(config.clientToken).toBeUndefined();
+  });
+
+  it('uses the default port when port is unset or empty', () => {
+    expect(loadConfig().port).toBe(3001);
+    process.env.AKARI_REGISTRY_PORT = '';
+    expect(loadConfig().port).toBe(3001);
+  });
+
+  it('throws when port is not a number', () => {
+    process.env.AKARI_REGISTRY_PORT = 'abc';
+    expect(() => loadConfig()).toThrow('AKARI_REGISTRY_PORT must be a positive integer.');
+  });
+
+  it('throws when port is zero', () => {
+    process.env.AKARI_REGISTRY_PORT = '0';
+    expect(() => loadConfig()).toThrow('AKARI_REGISTRY_PORT must be a positive integer.');
+  });
+
+  it('throws when port is negative', () => {
+    process.env.AKARI_REGISTRY_PORT = '-5';
+    expect(() => loadConfig()).toThrow('AKARI_REGISTRY_PORT must be a positive integer.');
+  });
+
+  it('parses a port with trailing non-numeric chars via parseInt radix 10', () => {
+    process.env.AKARI_REGISTRY_PORT = '4000abc';
+    expect(loadConfig().port).toBe(4000);
+  });
+});

--- a/apps/notifier-registry/src/logger.test.ts
+++ b/apps/notifier-registry/src/logger.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+
+// minLevel is computed once at module-evaluation time from the env var, so we
+// re-import the module under jest.isolateModulesAsync after mutating the env.
+async function loadLogger(level?: string) {
+  const saved = process.env.AKARI_REGISTRY_LOG_LEVEL;
+  if (level === undefined) {
+    delete process.env.AKARI_REGISTRY_LOG_LEVEL;
+  } else {
+    process.env.AKARI_REGISTRY_LOG_LEVEL = level;
+  }
+
+  let mod!: typeof import('./logger.js');
+  await jest.isolateModulesAsync(async () => {
+    mod = await import('./logger.js');
+  });
+
+  if (saved === undefined) {
+    delete process.env.AKARI_REGISTRY_LOG_LEVEL;
+  } else {
+    process.env.AKARI_REGISTRY_LOG_LEVEL = saved;
+  }
+  return mod.logger;
+}
+
+let debugSpy: ReturnType<typeof jest.spyOn>;
+let infoSpy: ReturnType<typeof jest.spyOn>;
+let warnSpy: ReturnType<typeof jest.spyOn>;
+let errorSpy: ReturnType<typeof jest.spyOn>;
+
+beforeEach(() => {
+  debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
+  infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('logger at default (info) level', () => {
+  it('suppresses debug but emits info, warn, and error', async () => {
+    const logger = await loadLogger();
+    logger.debug('d');
+    logger.info('i');
+    logger.warn('w');
+    logger.error('e');
+
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes the level tag and message in the output', async () => {
+    const logger = await loadLogger();
+    logger.info('hello', { a: 1 });
+    const firstArg = infoSpy.mock.calls[0][0] as string;
+    expect(firstArg).toContain('[info]');
+    expect(firstArg).toContain('hello');
+    expect(infoSpy.mock.calls[0][1]).toEqual({ a: 1 });
+  });
+
+  it('passes an empty string when no metadata is provided', async () => {
+    const logger = await loadLogger();
+    logger.error('oops');
+    expect(errorSpy.mock.calls[0][1]).toBe('');
+  });
+});
+
+describe('logger at debug level', () => {
+  it('emits all levels', async () => {
+    const logger = await loadLogger('debug');
+    logger.debug('d');
+    logger.info('i');
+    logger.warn('w');
+    logger.error('e');
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('logger at error level', () => {
+  it('suppresses everything below error', async () => {
+    const logger = await loadLogger('error');
+    logger.debug('d');
+    logger.info('i');
+    logger.warn('w');
+    logger.error('e');
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('logger with an invalid level', () => {
+  it('falls back to info', async () => {
+    const logger = await loadLogger('verbose-nonsense');
+    logger.debug('d');
+    logger.info('i');
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('lowercases the configured level', async () => {
+    const logger = await loadLogger('WARN');
+    logger.info('i');
+    logger.warn('w');
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/notifier-registry/src/server.test.ts
+++ b/apps/notifier-registry/src/server.test.ts
@@ -1,0 +1,402 @@
+import { describe, it, expect, jest, beforeEach, afterEach } from '@jest/globals';
+
+import type { IncomingMessage, Server, ServerResponse } from 'node:http';
+
+import { createRegistryServer } from './server.js';
+import { SubscriptionStore } from './subscription-store.js';
+import type { RegistryConfig } from './types.js';
+
+// createRegistryServer wraps http.createServer; we never call .listen(), so no
+// socket is opened. The request handler is pulled off the (unstarted) server's
+// 'request' listeners and driven directly with fake req/res objects.
+
+type FakeResponse = ServerResponse & {
+  statusCode: number;
+  headers: Record<string, string>;
+  body: string | undefined;
+  ended: boolean;
+};
+
+function makeResponse(): FakeResponse {
+  const res = {
+    statusCode: 0,
+    headers: {} as Record<string, string>,
+    body: undefined as string | undefined,
+    ended: false,
+    setHeader(name: string, value: string) {
+      this.headers[name.toLowerCase()] = value;
+    },
+    writeHead(status: number) {
+      this.statusCode = status;
+      return this;
+    },
+    end(chunk?: string) {
+      this.body = chunk;
+      this.ended = true;
+      return this;
+    },
+  };
+  return res as unknown as FakeResponse;
+}
+
+type RequestOptions = {
+  method: string;
+  url?: string | undefined;
+  headers?: Record<string, string | undefined>;
+  body?: unknown;
+  rawBody?: string;
+  defaultUrl?: boolean;
+};
+
+function makeRequest(options: RequestOptions): IncomingMessage {
+  const { method, headers = {}, body, rawBody, defaultUrl = true } = options;
+  const url = 'url' in options ? options.url : defaultUrl ? '/subscriptions' : undefined;
+
+  let payloadString: string | undefined;
+  if (rawBody !== undefined) {
+    payloadString = rawBody;
+  } else if (body !== undefined) {
+    payloadString = JSON.stringify(body);
+  }
+
+  const req = {
+    method,
+    url: url ?? '/subscriptions',
+    headers: { host: 'localhost', ...headers },
+    async *[Symbol.asyncIterator]() {
+      if (payloadString !== undefined) {
+        yield Buffer.from(payloadString, 'utf8');
+      }
+    },
+  };
+
+  return req as unknown as IncomingMessage;
+}
+
+const servers: Server[] = [];
+
+function getHandler(config: RegistryConfig, store: InstanceType<typeof SubscriptionStore>) {
+  const server = createRegistryServer(config, store);
+  servers.push(server);
+  const listeners = server.listeners('request');
+  return listeners[0] as (req: IncomingMessage, res: ServerResponse) => Promise<void>;
+}
+
+async function invoke(config: RegistryConfig, store: InstanceType<typeof SubscriptionStore>, req: IncomingMessage) {
+  const handler = getHandler(config, store);
+  const res = makeResponse();
+  await handler(req, res);
+  return res;
+}
+
+const baseConfig: RegistryConfig = {
+  host: '0.0.0.0',
+  port: 3001,
+};
+
+const validBody = {
+  did: 'did:plc:abc',
+  expoPushToken: 'ExpoToken[xyz]',
+  platform: 'ios',
+};
+
+beforeEach(() => {
+  jest.spyOn(console, 'info').mockImplementation(() => {});
+  jest.spyOn(console, 'warn').mockImplementation(() => {});
+  jest.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  for (const server of servers.splice(0)) {
+    server.close();
+  }
+});
+
+describe('createRegistryServer wiring', () => {
+  it('returns an http server with a request handler', () => {
+    const server = createRegistryServer(baseConfig, new SubscriptionStore());
+    servers.push(server);
+    expect(typeof server.listen).toBe('function');
+    expect(server.listeners('request')).toHaveLength(1);
+  });
+});
+
+describe('CORS and OPTIONS', () => {
+  it('sets CORS headers using the request origin', async () => {
+    const res = await invoke(
+      baseConfig,
+      new SubscriptionStore(),
+      makeRequest({ method: 'OPTIONS', headers: { origin: 'https://app.example' } }),
+    );
+    expect(res.headers['access-control-allow-origin']).toBe('https://app.example');
+    expect(res.headers['access-control-allow-methods']).toBe('GET,POST,DELETE,OPTIONS');
+    expect(res.headers['access-control-allow-headers']).toBe('Content-Type, Authorization');
+    expect(res.statusCode).toBe(204);
+    expect(res.ended).toBe(true);
+  });
+
+  it('falls back to wildcard origin when none provided', async () => {
+    const res = await invoke(baseConfig, new SubscriptionStore(), makeRequest({ method: 'OPTIONS' }));
+    expect(res.headers['access-control-allow-origin']).toBe('*');
+  });
+});
+
+describe('GET /subscriptions', () => {
+  it('returns the stored subscriptions', async () => {
+    const store = new SubscriptionStore();
+    await store.register(validBody);
+    const res = await invoke(baseConfig, store, makeRequest({ method: 'GET' }));
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body!)).toEqual([{ did: 'did:plc:abc', tokens: ['ExpoToken[xyz]'] }]);
+  });
+
+  it('returns 401 when admin token is set and missing', async () => {
+    const res = await invoke(
+      { ...baseConfig, adminToken: 'secret' },
+      new SubscriptionStore(),
+      makeRequest({ method: 'GET' }),
+    );
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body!)).toEqual({ error: 'Invalid or missing authorization token.' });
+  });
+
+  it('returns 401 when admin token is wrong', async () => {
+    const res = await invoke(
+      { ...baseConfig, adminToken: 'secret' },
+      new SubscriptionStore(),
+      makeRequest({ method: 'GET', headers: { authorization: 'Bearer wrong' } }),
+    );
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('succeeds with the correct admin bearer token', async () => {
+    const res = await invoke(
+      { ...baseConfig, adminToken: 'secret' },
+      new SubscriptionStore(),
+      makeRequest({ method: 'GET', headers: { authorization: 'Bearer secret' } }),
+    );
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body!)).toEqual([]);
+  });
+
+  it('trims whitespace around the provided bearer token', async () => {
+    const res = await invoke(
+      { ...baseConfig, adminToken: 'secret' },
+      new SubscriptionStore(),
+      makeRequest({ method: 'GET', headers: { authorization: 'Bearer   secret  ' } }),
+    );
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('returns 401 when the authorization header lacks the Bearer prefix', async () => {
+    const res = await invoke(
+      { ...baseConfig, adminToken: 'secret' },
+      new SubscriptionStore(),
+      makeRequest({ method: 'GET', headers: { authorization: 'secret' } }),
+    );
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('POST /subscriptions', () => {
+  it('registers a subscription and returns the total tokens', async () => {
+    const store = new SubscriptionStore();
+    const res = await invoke(baseConfig, store, makeRequest({ method: 'POST', body: validBody }));
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body!)).toEqual({ success: true, totalTokens: 1 });
+    expect(store.getAll()).toEqual([{ did: 'did:plc:abc', tokens: ['ExpoToken[xyz]'] }]);
+  });
+
+  it('accepts an optional devicePushToken', async () => {
+    const store = new SubscriptionStore();
+    const res = await invoke(
+      baseConfig,
+      store,
+      makeRequest({ method: 'POST', body: { ...validBody, devicePushToken: 'device-1' } }),
+    );
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('enforces the client token', async () => {
+    const res = await invoke(
+      { ...baseConfig, clientToken: 'client-secret' },
+      new SubscriptionStore(),
+      makeRequest({ method: 'POST', body: validBody }),
+    );
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('succeeds with the correct client token', async () => {
+    const res = await invoke(
+      { ...baseConfig, clientToken: 'client-secret' },
+      new SubscriptionStore(),
+      makeRequest({ method: 'POST', body: validBody, headers: { authorization: 'Bearer client-secret' } }),
+    );
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('returns 400 when the did is missing', async () => {
+    const res = await invoke(
+      baseConfig,
+      new SubscriptionStore(),
+      makeRequest({ method: 'POST', body: { expoPushToken: 'x', platform: 'ios' } }),
+    );
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body!)).toEqual({ error: 'Request body must include a did.' });
+  });
+
+  it('returns 400 when the expo token is missing', async () => {
+    const res = await invoke(
+      baseConfig,
+      new SubscriptionStore(),
+      makeRequest({ method: 'POST', body: { did: 'did:plc:abc', platform: 'ios' } }),
+    );
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body!)).toEqual({ error: 'Request body must include an Expo push token.' });
+  });
+
+  it('returns 400 when the platform is missing', async () => {
+    const res = await invoke(
+      baseConfig,
+      new SubscriptionStore(),
+      makeRequest({ method: 'POST', body: { did: 'did:plc:abc', expoPushToken: 'x' } }),
+    );
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body!)).toEqual({ error: 'Request body must include a platform.' });
+  });
+
+  it('ignores non-string fields and reports them as missing', async () => {
+    const res = await invoke(
+      baseConfig,
+      new SubscriptionStore(),
+      makeRequest({ method: 'POST', body: { did: 123, expoPushToken: 'x', platform: 'ios' } }),
+    );
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body!)).toEqual({ error: 'Request body must include a did.' });
+  });
+
+  it('drops a non-string devicePushToken without error', async () => {
+    const res = await invoke(
+      baseConfig,
+      new SubscriptionStore(),
+      makeRequest({ method: 'POST', body: { ...validBody, devicePushToken: 123 } }),
+    );
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('returns 400 when the body is not an object', async () => {
+    const res = await invoke(
+      baseConfig,
+      new SubscriptionStore(),
+      makeRequest({ method: 'POST', rawBody: '"a string"' }),
+    );
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body!)).toEqual({ error: 'Request body must be an object.' });
+  });
+
+  it('returns 400 for invalid JSON', async () => {
+    const res = await invoke(
+      baseConfig,
+      new SubscriptionStore(),
+      makeRequest({ method: 'POST', rawBody: '{not json' }),
+    );
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body!).error).toMatch(/Failed to parse request body:/);
+  });
+
+  it('treats an empty body as an empty object (missing did)', async () => {
+    const res = await invoke(baseConfig, new SubscriptionStore(), makeRequest({ method: 'POST' }));
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body!)).toEqual({ error: 'Request body must include a did.' });
+  });
+});
+
+describe('DELETE /subscriptions', () => {
+  it('removes a subscription and reports success', async () => {
+    const store = new SubscriptionStore();
+    await store.register(validBody);
+    const res = await invoke(baseConfig, store, makeRequest({ method: 'DELETE', body: validBody }));
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body!)).toEqual({ success: true, totalTokens: 0 });
+    expect(store.getAll()).toEqual([]);
+  });
+
+  it('reports success:false when the token was not registered', async () => {
+    const store = new SubscriptionStore();
+    const res = await invoke(baseConfig, store, makeRequest({ method: 'DELETE', body: validBody }));
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body!)).toEqual({ success: false, totalTokens: 0 });
+  });
+
+  it('enforces the client token', async () => {
+    const res = await invoke(
+      { ...baseConfig, clientToken: 'client-secret' },
+      new SubscriptionStore(),
+      makeRequest({ method: 'DELETE', body: validBody }),
+    );
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 400 on an invalid payload', async () => {
+    const res = await invoke(
+      baseConfig,
+      new SubscriptionStore(),
+      makeRequest({ method: 'DELETE', body: { platform: 'ios' } }),
+    );
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe('unknown routes', () => {
+  it('returns 404 for an unknown path', async () => {
+    const res = await invoke(baseConfig, new SubscriptionStore(), makeRequest({ method: 'GET', url: '/unknown' }));
+    expect(res.statusCode).toBe(404);
+    expect(JSON.parse(res.body!)).toEqual({ error: 'Not found.' });
+  });
+
+  it('returns 404 for an unsupported method on /subscriptions', async () => {
+    const res = await invoke(baseConfig, new SubscriptionStore(), makeRequest({ method: 'PUT' }));
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('handles a request with no url (empty pathname)', async () => {
+    const req = {
+      method: 'GET',
+      url: undefined,
+      headers: { host: 'localhost' },
+      async *[Symbol.asyncIterator]() {},
+    } as unknown as IncomingMessage;
+    const res = await invoke(baseConfig, new SubscriptionStore(), req);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('handles a request missing the host header', async () => {
+    const req = {
+      method: 'GET',
+      url: '/unknown',
+      headers: {},
+      async *[Symbol.asyncIterator]() {},
+    } as unknown as IncomingMessage;
+    const res = await invoke(baseConfig, new SubscriptionStore(), req);
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe('error handling', () => {
+  it('returns 400 when the store throws', async () => {
+    const store = new SubscriptionStore();
+    jest.spyOn(store, 'register').mockRejectedValue(new Error('boom'));
+    const res = await invoke(baseConfig, store, makeRequest({ method: 'POST', body: validBody }));
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body!)).toEqual({ error: 'boom' });
+  });
+
+  it('falls back to a generic message for non-Error throws', async () => {
+    const store = new SubscriptionStore();
+    jest.spyOn(store, 'register').mockRejectedValue('weird');
+    const res = await invoke(baseConfig, store, makeRequest({ method: 'POST', body: validBody }));
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body!)).toEqual({ error: 'Unexpected error.' });
+  });
+});

--- a/apps/notifier-registry/src/subscription-store.test.ts
+++ b/apps/notifier-registry/src/subscription-store.test.ts
@@ -1,0 +1,261 @@
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+// Node builtin ESM modules cannot be reliably mocked via unstable_mockModule
+// in this ts-jest ESM setup, so persistence is exercised against an isolated
+// temp directory that is created and removed per test. No production paths or
+// network are touched.
+
+import { SubscriptionStore } from './subscription-store.js';
+
+const basePayload = {
+  did: 'did:plc:abc',
+  expoPushToken: 'ExpoToken[xyz]',
+  platform: 'ios',
+} as const;
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'notifier-registry-'));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+const dataFile = () => join(tempDir, 'data.json');
+
+describe('SubscriptionStore.register', () => {
+  it('adds a new token for a new did', async () => {
+    const store = new SubscriptionStore();
+    const result = await store.register({ ...basePayload });
+    expect(result).toEqual({ isNewToken: true, totalTokens: 1 });
+    expect(store.getAll()).toEqual([{ did: 'did:plc:abc', tokens: ['ExpoToken[xyz]'] }]);
+  });
+
+  it('normalises the did to lowercase and trims', async () => {
+    const store = new SubscriptionStore();
+    await store.register({ ...basePayload, did: '  DID:PLC:ABC  ' });
+    expect(store.getAll()[0].did).toBe('did:plc:abc');
+  });
+
+  it('trims the token but preserves case', async () => {
+    const store = new SubscriptionStore();
+    await store.register({ ...basePayload, expoPushToken: '  ExpoToken[XYZ]  ' });
+    expect(store.getAll()[0].tokens).toEqual(['ExpoToken[XYZ]']);
+  });
+
+  it('dedups identical tokens for the same did', async () => {
+    const store = new SubscriptionStore();
+    await store.register({ ...basePayload });
+    const result = await store.register({ ...basePayload });
+    expect(result).toEqual({ isNewToken: false, totalTokens: 1 });
+    expect(store.getAll()[0].tokens).toEqual(['ExpoToken[xyz]']);
+  });
+
+  it('appends additional distinct tokens for the same did', async () => {
+    const store = new SubscriptionStore();
+    await store.register({ ...basePayload, expoPushToken: 'token-1' });
+    const result = await store.register({ ...basePayload, expoPushToken: 'token-2' });
+    expect(result).toEqual({ isNewToken: true, totalTokens: 2 });
+    expect(store.getAll()[0].tokens.sort()).toEqual(['token-1', 'token-2']);
+  });
+
+  it('throws when did is missing or empty', async () => {
+    const store = new SubscriptionStore();
+    await expect(store.register({ ...basePayload, did: '   ' })).rejects.toThrow('A valid did is required.');
+  });
+
+  it('throws when token is missing or empty', async () => {
+    const store = new SubscriptionStore();
+    await expect(store.register({ ...basePayload, expoPushToken: '   ' })).rejects.toThrow(
+      'A valid Expo push token is required.',
+    );
+  });
+
+  it('does not write a file when no data file is configured', async () => {
+    const store = new SubscriptionStore();
+    await store.register({ ...basePayload });
+    // nothing to assert on disk; absence of throw and correct in-memory state suffice
+    expect(store.getAll()).toHaveLength(1);
+  });
+
+  it('persists to disk when a data file is configured', async () => {
+    const store = new SubscriptionStore(dataFile());
+    await store.register({ ...basePayload });
+    const written = await readFile(dataFile(), 'utf8');
+    expect(JSON.parse(written)).toEqual([{ did: 'did:plc:abc', tokens: ['ExpoToken[xyz]'] }]);
+    expect(written.endsWith('\n')).toBe(true);
+  });
+});
+
+describe('SubscriptionStore.unregister', () => {
+  it('removes an existing token and deletes the did when empty', async () => {
+    const store = new SubscriptionStore();
+    await store.register({ ...basePayload });
+    const result = await store.unregister({ ...basePayload });
+    expect(result).toEqual({ removed: true, totalTokens: 0 });
+    expect(store.getAll()).toEqual([]);
+  });
+
+  it('keeps the did when other tokens remain', async () => {
+    const store = new SubscriptionStore();
+    await store.register({ ...basePayload, expoPushToken: 'token-1' });
+    await store.register({ ...basePayload, expoPushToken: 'token-2' });
+    const result = await store.unregister({ ...basePayload, expoPushToken: 'token-1' });
+    expect(result).toEqual({ removed: true, totalTokens: 1 });
+    expect(store.getAll()[0].tokens).toEqual(['token-2']);
+  });
+
+  it('returns removed:false for an unknown did', async () => {
+    const store = new SubscriptionStore();
+    const result = await store.unregister({ ...basePayload, did: 'did:plc:unknown' });
+    expect(result).toEqual({ removed: false, totalTokens: 0 });
+  });
+
+  it('returns removed:false when the token is not present for a known did', async () => {
+    const store = new SubscriptionStore();
+    await store.register({ ...basePayload, expoPushToken: 'token-1' });
+    const result = await store.unregister({ ...basePayload, expoPushToken: 'token-missing' });
+    expect(result).toEqual({ removed: false, totalTokens: 1 });
+  });
+
+  it('throws when did is invalid', async () => {
+    const store = new SubscriptionStore();
+    await expect(store.unregister({ ...basePayload, did: '  ' })).rejects.toThrow('A valid did is required.');
+  });
+
+  it('throws when token is invalid', async () => {
+    const store = new SubscriptionStore();
+    await expect(store.unregister({ ...basePayload, expoPushToken: '  ' })).rejects.toThrow(
+      'A valid Expo push token is required.',
+    );
+  });
+
+  it('does not change the file when nothing was removed', async () => {
+    const store = new SubscriptionStore(dataFile());
+    await store.register({ ...basePayload, expoPushToken: 'token-1' });
+    const before = await readFile(dataFile(), 'utf8');
+    await store.unregister({ ...basePayload, expoPushToken: 'token-missing' });
+    const after = await readFile(dataFile(), 'utf8');
+    expect(after).toBe(before);
+  });
+
+  it('persists after a successful removal', async () => {
+    const store = new SubscriptionStore(dataFile());
+    await store.register({ ...basePayload, expoPushToken: 'token-1' });
+    await store.register({ ...basePayload, expoPushToken: 'token-2' });
+    await store.unregister({ ...basePayload, expoPushToken: 'token-1' });
+    const written = await readFile(dataFile(), 'utf8');
+    expect(JSON.parse(written)).toEqual([{ did: 'did:plc:abc', tokens: ['token-2'] }]);
+  });
+});
+
+describe('SubscriptionStore.getAll', () => {
+  it('returns records sorted by did', async () => {
+    const store = new SubscriptionStore();
+    await store.register({ ...basePayload, did: 'did:plc:zebra' });
+    await store.register({ ...basePayload, did: 'did:plc:apple' });
+    expect(store.getAll().map((r) => r.did)).toEqual(['did:plc:apple', 'did:plc:zebra']);
+  });
+
+  it('returns an empty array for a fresh store', () => {
+    expect(new SubscriptionStore().getAll()).toEqual([]);
+  });
+});
+
+describe('SubscriptionStore.load', () => {
+  it('is a no-op when no data file is configured', async () => {
+    const store = new SubscriptionStore();
+    await store.load();
+    expect(store.getAll()).toEqual([]);
+  });
+
+  it('starts empty when the data file does not exist', async () => {
+    const store = new SubscriptionStore(join(tempDir, 'missing.json'));
+    await store.load();
+    expect(store.getAll()).toEqual([]);
+  });
+
+  it('loads and parses persisted records', async () => {
+    await writeFile(
+      dataFile(),
+      JSON.stringify([
+        { did: 'DID:PLC:ONE', tokens: ['  token-a  ', 'token-b'] },
+        { did: 'did:plc:two', tokens: ['token-c'] },
+      ]),
+      'utf8',
+    );
+    const store = new SubscriptionStore(dataFile());
+    await store.load();
+    expect(store.getAll()).toEqual([
+      { did: 'did:plc:one', tokens: ['token-a', 'token-b'] },
+      { did: 'did:plc:two', tokens: ['token-c'] },
+    ]);
+  });
+
+  it('filters out non-string and empty tokens', async () => {
+    await writeFile(
+      dataFile(),
+      JSON.stringify([{ did: 'did:plc:one', tokens: ['token-a', '', 42, null, '  '] }]),
+      'utf8',
+    );
+    const store = new SubscriptionStore(dataFile());
+    await store.load();
+    expect(store.getAll()).toEqual([{ did: 'did:plc:one', tokens: ['token-a'] }]);
+  });
+
+  it('throws when persisted data is not an array', async () => {
+    await writeFile(dataFile(), JSON.stringify({ not: 'an array' }), 'utf8');
+    const store = new SubscriptionStore(dataFile());
+    await expect(store.load()).rejects.toThrow('Persisted subscription data must be an array.');
+  });
+
+  it('throws when an entry is not an object', async () => {
+    await writeFile(dataFile(), JSON.stringify(['not-an-object']), 'utf8');
+    const store = new SubscriptionStore(dataFile());
+    await expect(store.load()).rejects.toThrow('Persisted subscription entry at index 0 must be an object.');
+  });
+
+  it('throws when an entry is missing a valid did', async () => {
+    await writeFile(dataFile(), JSON.stringify([{ tokens: ['token-a'] }]), 'utf8');
+    const store = new SubscriptionStore(dataFile());
+    await expect(store.load()).rejects.toThrow('Persisted subscription entry at index 0 is missing a valid did.');
+  });
+
+  it('throws when an entry has no valid tokens', async () => {
+    await writeFile(dataFile(), JSON.stringify([{ did: 'did:plc:one', tokens: [] }]), 'utf8');
+    const store = new SubscriptionStore(dataFile());
+    await expect(store.load()).rejects.toThrow(
+      'Persisted subscription entry at index 0 must include at least one Expo push token.',
+    );
+  });
+
+  it('throws when tokens field is missing entirely', async () => {
+    await writeFile(dataFile(), JSON.stringify([{ did: 'did:plc:one' }]), 'utf8');
+    const store = new SubscriptionStore(dataFile());
+    await expect(store.load()).rejects.toThrow(
+      'Persisted subscription entry at index 0 must include at least one Expo push token.',
+    );
+  });
+
+  it('wraps JSON parse errors', async () => {
+    await writeFile(dataFile(), 'not valid json', 'utf8');
+    const store = new SubscriptionStore(dataFile());
+    await expect(store.load()).rejects.toThrow(/Failed to load subscription data:/);
+  });
+
+  it('round-trips data written by register through load', async () => {
+    const writer = new SubscriptionStore(dataFile());
+    await writer.register({ ...basePayload, expoPushToken: 'token-1' });
+    await writer.register({ ...basePayload, expoPushToken: 'token-2' });
+
+    const reader = new SubscriptionStore(dataFile());
+    await reader.load();
+    expect(reader.getAll()).toEqual([{ did: 'did:plc:abc', tokens: ['token-1', 'token-2'] }]);
+  });
+});

--- a/apps/notifier-registry/tsconfig.build.json
+++ b/apps/notifier-registry/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}


### PR DESCRIPTION
## What

`firehose-notifier`, `notifier-registry`, and `activity-service` had **no test infrastructure and 0% coverage**. This stands up jest for each and covers their logic.

## Infra (per service)
- `jest.config.cjs` — ts-jest ESM preset, `node` environment, `.js`→source mapper, v8 coverage (mirrors the API packages)
- `tsconfig.build.json` — keeps `*.test.ts` out of the build output; `build` now points at it
- `test` + `test:coverage` scripts (so they join `turbo run test` / `test:coverage`)

## Coverage — 177 new tests
| Service | Tests | Logic-module coverage |
|---|---|---|
| firehose-notifier | 67 | ~100% (config, subscription-utils/store, dids, notifier, firehose, logger) |
| notifier-registry | 78 | ~100% (config, subscription-store, server + bearer auth, logger) |
| activity-service | 32 | `app.ts` 98.6% (Hono routes, auth/cookies, PDS normalization, pagination, bucketing) |

All external I/O is mocked — `fetch`, `expo-server-sdk`, `@skyware/jetstream`, `bluesky-api`, and `node:fs` (via isolated temp dirs) — so no real network, sockets, or writes.

## Notes
- Bootstrap entry points (`index.ts`) are intentionally left uncovered — they call `serve()` / start the firehose with side effects on import.
- A couple of remaining uncovered branches are genuinely unreachable defensive guards (noted in code review of each).
- Verified the full gate passes: `turbo run lint` (14/14), `typecheck` (15/15), `test` (22/22 tasks), and builds emit no test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lucid-softworks/codesmith/akari/pr/407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782668333&installation_id=136510994&pr_number=407&repository=lucid-softworks%2Fakari&return_to=https%3A%2F%2Fgithub.com%2Flucid-softworks%2Fakari%2Fpull%2F407&signature=b2b05ba9807c8f4f45c01830f73d65a6fb89eb2bb26cc7b7e73bacbfa3529cb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->