### PR TITLE
test: cover akari app hooks and pure utils

### DIFF
--- a/apps/akari/__tests__/hooks/mutations/useBlockActorList.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useBlockActorList.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useBlockActorList } from '@/hooks/mutations/useBlockActorList';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockBlockActorList = jest.fn();
+const mockUnblockActorList = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    blockActorList: mockBlockActorList,
+    unblockActorList: mockUnblockActorList,
+  })),
+}));
+
+describe('useBlockActorList mutation hook', () => {
+  let invalidateSpy: jest.SpyInstance;
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockBlockActorList.mockResolvedValue({ uri: 'at://listblock' });
+    mockUnblockActorList.mockResolvedValue({});
+  });
+
+  it('blocks a moderation list and invalidates feeds', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlockActorList(), { wrapper });
+
+    result.current.mutate({ action: 'block', list: 'at://list' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockBlockActorList).toHaveBeenCalledWith('token', 'did:current', 'at://list');
+    expect(mockUnblockActorList).not.toHaveBeenCalled();
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['moderationLists'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['timeline'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['feed'] });
+  });
+
+  it('unblocks a moderation list by listblock uri', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlockActorList(), { wrapper });
+
+    result.current.mutate({ action: 'unblock', listblockUri: 'at://listblock' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockUnblockActorList).toHaveBeenCalledWith('token', 'at://listblock');
+    expect(mockBlockActorList).not.toHaveBeenCalled();
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlockActorList(), { wrapper });
+
+    result.current.mutate({ action: 'block', list: 'at://list' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockBlockActorList).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlockActorList(), { wrapper });
+
+    result.current.mutate({ action: 'block', list: 'at://list' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockBlockActorList).not.toHaveBeenCalled();
+  });
+
+  it('errors when did missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlockActorList(), { wrapper });
+
+    result.current.mutate({ action: 'block', list: 'at://list' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockBlockActorList).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useBookmarkPost.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useBookmarkPost.test.tsx
@@ -1,0 +1,230 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useBookmarkPost } from '@/hooks/mutations/useBookmarkPost';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useToast } from '@/contexts/ToastContext';
+import type { BlueskyFeedResponse, BlueskyPostView } from '@/bluesky-api';
+
+const mockCreateBookmark = jest.fn();
+const mockDeleteBookmark = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+// @/contexts/ToastContext and @/hooks/useTranslation are globally mocked in
+// jest.setup.js, so we read showToast off the shared mock rather than
+// re-mocking (a local mock would clobber the setup's beforeEach wiring).
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createBookmark: mockCreateBookmark,
+    deleteBookmark: mockDeleteBookmark,
+  })),
+}));
+
+const mockShowToast = () => (useToast() as unknown as { showToast: jest.Mock }).showToast;
+
+const postUri = 'at://post';
+
+const makePost = (bookmarked?: boolean): BlueskyPostView =>
+  ({
+    uri: postUri,
+    cid: 'cid',
+    author: {},
+    record: {},
+    indexedAt: '',
+    labels: [],
+    viewer: bookmarked === undefined ? {} : { bookmarked },
+  }) as unknown as BlueskyPostView;
+
+describe('useBookmarkPost mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockCreateBookmark.mockResolvedValue({});
+    mockDeleteBookmark.mockResolvedValue({});
+  });
+
+  it('bookmarks a post and optimistically updates caches', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const feedResponse = { feed: [{ post: makePost() }] } as unknown as BlueskyFeedResponse;
+    queryClient.setQueryData(['timeline'], feedResponse);
+    queryClient.setQueryData(['feed'], { pages: [feedResponse] });
+    queryClient.setQueryData(['authorFeed'], { pages: [feedResponse] });
+    queryClient.setQueryData(['post', postUri], makePost());
+    queryClient.setQueryData(['postThread', postUri], { thread: { post: makePost() } });
+
+    const { result } = renderHook(() => useBookmarkPost(), { wrapper });
+    result.current.mutate({ postUri, postCid: 'cid', action: 'bookmark' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockCreateBookmark).toHaveBeenCalledWith('token', postUri, 'cid');
+    const timeline = queryClient.getQueryData<BlueskyFeedResponse>(['timeline']);
+    expect(timeline?.feed[0].post.viewer?.bookmarked).toBe(true);
+    expect(queryClient.getQueryData<BlueskyPostView>(['post', postUri])?.viewer?.bookmarked).toBe(true);
+    expect(
+      queryClient.getQueryData<{ thread: { post: BlueskyPostView } }>(['postThread', postUri])
+        ?.thread.post.viewer?.bookmarked,
+    ).toBe(true);
+  });
+
+  it('patches inline reply.parent / reply.root and nested thread replies', async () => {
+    const { queryClient, wrapper } = createWrapper();
+
+    // Feed item where the bookmarked post is the inline parent + root of a reply.
+    const otherPost = { ...makePost(), uri: 'at://other', viewer: {} } as unknown as BlueskyPostView;
+    const timelineResponse = {
+      feed: [
+        {
+          post: otherPost,
+          reply: { parent: makePost(), root: makePost() },
+        },
+      ],
+    } as unknown as BlueskyFeedResponse;
+    queryClient.setQueryData(['timeline'], timelineResponse);
+    queryClient.setQueryData(['feed'], { pages: [timelineResponse] });
+
+    // Thread where the target lives as a nested reply rather than the root post.
+    queryClient.setQueryData(['postThread', 'at://root'], {
+      thread: {
+        post: { ...makePost(), uri: 'at://root', viewer: {} },
+        replies: [{ post: makePost(), replies: [{ post: makePost() }] }],
+      },
+    });
+
+    const { result } = renderHook(() => useBookmarkPost(), { wrapper });
+    result.current.mutate({ postUri, postCid: 'cid', action: 'bookmark' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const timeline = queryClient.getQueryData<BlueskyFeedResponse>(['timeline']);
+    expect(timeline?.feed[0].reply?.parent?.viewer?.bookmarked).toBe(true);
+    expect(timeline?.feed[0].reply?.root?.viewer?.bookmarked).toBe(true);
+
+    const thread = queryClient.getQueryData<any>(['postThread', 'at://root']);
+    expect(thread.thread.replies[0].post.viewer.bookmarked).toBe(true);
+    expect(thread.thread.replies[0].replies[0].post.viewer.bookmarked).toBe(true);
+  });
+
+  it('unbookmarks a post', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const feedResponse = { feed: [{ post: makePost(true) }] } as unknown as BlueskyFeedResponse;
+    queryClient.setQueryData(['timeline'], feedResponse);
+
+    const { result } = renderHook(() => useBookmarkPost(), { wrapper });
+    result.current.mutate({ postUri, postCid: 'cid', action: 'unbookmark' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockDeleteBookmark).toHaveBeenCalledWith('token', postUri);
+    const timeline = queryClient.getQueryData<BlueskyFeedResponse>(['timeline']);
+    expect(timeline?.feed[0].post.viewer?.bookmarked).toBe(false);
+  });
+
+  it('rolls back caches and toasts on error', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const feedResponse = { feed: [{ post: makePost() }] } as unknown as BlueskyFeedResponse;
+    queryClient.setQueryData(['timeline'], feedResponse);
+    queryClient.setQueryData(['post', postUri], makePost());
+    mockCreateBookmark.mockRejectedValueOnce(new Error('fail'));
+
+    const { result } = renderHook(() => useBookmarkPost(), { wrapper });
+    result.current.mutate({ postUri, postCid: 'cid', action: 'bookmark' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(queryClient.getQueryData<BlueskyPostView>(['post', postUri])?.viewer).toEqual({});
+    expect(mockShowToast()).toHaveBeenCalledWith({
+      type: 'error',
+      message: 'post.bookmarkFailed',
+    });
+  });
+
+  it('toasts the unbookmark failure message on error', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(['timeline'], {
+      feed: [{ post: makePost(true) }],
+    } as unknown as BlueskyFeedResponse);
+    mockDeleteBookmark.mockRejectedValueOnce(new Error('fail'));
+
+    const { result } = renderHook(() => useBookmarkPost(), { wrapper });
+    result.current.mutate({ postUri, postCid: 'cid', action: 'unbookmark' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mockShowToast()).toHaveBeenCalledWith({
+      type: 'error',
+      message: 'post.unbookmarkFailed',
+    });
+  });
+
+  it('invalidates bookmarks on success', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useBookmarkPost(), { wrapper });
+    result.current.mutate({ postUri, postCid: 'cid', action: 'bookmark' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['bookmarks'] });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBookmarkPost(), { wrapper });
+
+    result.current.mutate({ postUri, postCid: 'cid', action: 'bookmark' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateBookmark).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBookmarkPost(), { wrapper });
+
+    result.current.mutate({ postUri, postCid: 'cid', action: 'bookmark' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateBookmark).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useClearLiveStatus.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useClearLiveStatus.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useClearLiveStatus } from '@/hooks/mutations/useClearLiveStatus';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockClearActorStatus = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    clearActorStatus: mockClearActorStatus,
+  })),
+}));
+
+describe('useClearLiveStatus mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockClearActorStatus.mockResolvedValue(undefined);
+  });
+
+  it('clears the live status and invalidates profile caches', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useClearLiveStatus(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockClearActorStatus).toHaveBeenCalledWith('token', 'did');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['profile'] });
+  });
+
+  it('throws when the token is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useClearLiveStatus(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockClearActorStatus).not.toHaveBeenCalled();
+  });
+
+  it('throws when the DID is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { result } = renderHook(() => useClearLiveStatus(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockClearActorStatus).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PDS URL is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { result } = renderHook(() => useClearLiveStatus(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockClearActorStatus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useCreateAccount.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useCreateAccount.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useCreateAccount } from '@/hooks/mutations/useCreateAccount';
+
+const mockSetAuth = { mutateAsync: jest.fn() };
+const mockCreateAccount = jest.fn();
+const mockGetProfile = jest.fn();
+
+jest.mock('@/hooks/mutations/useSetAuthentication', () => ({
+  useSetAuthentication: jest.fn(() => mockSetAuth),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createAccount: mockCreateAccount,
+    getProfile: mockGetProfile,
+  })),
+}));
+
+describe('useCreateAccount mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateAccount.mockResolvedValue({
+      accessJwt: 'token',
+      refreshJwt: 'refresh',
+      did: 'did',
+      handle: 'handle',
+    });
+    mockGetProfile.mockResolvedValue({
+      did: 'did',
+      handle: 'handle',
+      displayName: 'Display Name',
+      avatar: 'https://avatar.test/img.png',
+      indexedAt: '2024-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('creates an account and stores auth data with profile metadata', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useCreateAccount(), { wrapper });
+
+    result.current.mutate({
+      email: 'a@b.com',
+      handle: 'handle',
+      password: 'pass',
+      inviteCode: 'code',
+      pdsUrl: 'https://pds',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockCreateAccount).toHaveBeenCalledWith({
+      email: 'a@b.com',
+      handle: 'handle',
+      password: 'pass',
+      inviteCode: 'code',
+    });
+    expect(mockGetProfile).toHaveBeenCalledWith('token', 'did');
+    expect(mockSetAuth.mutateAsync).toHaveBeenCalledWith({
+      token: 'token',
+      refreshToken: 'refresh',
+      did: 'did',
+      handle: 'handle',
+      pdsUrl: 'https://pds',
+      displayName: 'Display Name',
+      avatar: 'https://avatar.test/img.png',
+    });
+    expect(invalidateSpy).toHaveBeenCalled();
+  });
+
+  it('falls back to handle/null avatar when profile fetch fails', async () => {
+    const { wrapper } = createWrapper();
+    mockGetProfile.mockRejectedValueOnce(new Error('no profile'));
+    const { result } = renderHook(() => useCreateAccount(), { wrapper });
+
+    result.current.mutate({
+      email: 'a@b.com',
+      handle: 'handle',
+      password: 'pass',
+      pdsUrl: 'https://pds',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockSetAuth.mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ displayName: 'handle', avatar: null }),
+    );
+  });
+
+  it('surfaces an error when account creation fails', async () => {
+    const { wrapper } = createWrapper();
+    mockCreateAccount.mockRejectedValueOnce(new Error('taken'));
+    const { result } = renderHook(() => useCreateAccount(), { wrapper });
+
+    result.current.mutate({
+      email: 'a@b.com',
+      handle: 'handle',
+      password: 'pass',
+      pdsUrl: 'https://pds',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetAuth.mutateAsync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useCreateAppPassword.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useCreateAppPassword.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useCreateAppPassword } from '@/hooks/mutations/useCreateAppPassword';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockCreateAppPassword = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createAppPassword: mockCreateAppPassword,
+  })),
+}));
+
+describe('useCreateAppPassword mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockCreateAppPassword.mockResolvedValue({ name: 'cli', password: 'abcd-1234' });
+  });
+
+  it('creates a privileged app password and invalidates the list', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useCreateAppPassword(), { wrapper });
+
+    result.current.mutate({ name: 'cli', privileged: true });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreateAppPassword).toHaveBeenCalledWith('token', 'cli', true);
+    expect(result.current.data).toEqual({ name: 'cli', password: 'abcd-1234' });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['appPasswords'] });
+  });
+
+  it('defaults privileged to false when omitted', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateAppPassword(), { wrapper });
+
+    result.current.mutate({ name: 'cli' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreateAppPassword).toHaveBeenCalledWith('token', 'cli', false);
+  });
+
+  it('throws when the token is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useCreateAppPassword(), { wrapper });
+
+    result.current.mutate({ name: 'cli' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateAppPassword).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PDS URL is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { result } = renderHook(() => useCreateAppPassword(), { wrapper });
+
+    result.current.mutate({ name: 'cli' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateAppPassword).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useCreateList.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useCreateList.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useCreateList } from '@/hooks/mutations/useCreateList';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockCreateList = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createList: mockCreateList,
+  })),
+}));
+
+describe('useCreateList mutation hook', () => {
+  let invalidateSpy: jest.SpyInstance;
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockCreateList.mockResolvedValue({ uri: 'at://list' });
+  });
+
+  it('creates a curate list by default and invalidates lists', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateList(), { wrapper });
+
+    result.current.mutate({ name: 'My List', description: 'desc' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreateList).toHaveBeenCalledWith('token', 'did:current', {
+      name: 'My List',
+      description: 'desc',
+      purpose: 'app.bsky.graph.defs#curatelist',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['lists', 'https://pds', 'did:current', undefined],
+    });
+  });
+
+  it('honours an explicit purpose (modlist)', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateList(), { wrapper });
+
+    result.current.mutate({ name: 'Block List', purpose: 'app.bsky.graph.defs#modlist' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreateList).toHaveBeenCalledWith('token', 'did:current', {
+      name: 'Block List',
+      description: undefined,
+      purpose: 'app.bsky.graph.defs#modlist',
+    });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateList(), { wrapper });
+
+    result.current.mutate({ name: 'My List' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateList).not.toHaveBeenCalled();
+  });
+
+  it('errors when did missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateList(), { wrapper });
+
+    result.current.mutate({ name: 'My List' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateList).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateList(), { wrapper });
+
+    result.current.mutate({ name: 'My List' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateList).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useCreatePoll.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useCreatePoll.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useCreatePoll } from '@/hooks/mutations/useCreatePoll';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { pollEmbedUrlFromRecord } from '@/utils/tokimekiPoll';
+
+const mockCreatePoll = jest.fn();
+const mockCreatePost = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/utils/tokimekiPoll', () => ({
+  pollEmbedUrlFromRecord: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createPoll: mockCreatePoll,
+    createPost: mockCreatePost,
+  })),
+}));
+
+const input = {
+  question: 'Best color?',
+  options: ['Red', 'Blue'],
+  endsAt: '2026-06-01T00:00:00.000Z',
+  langs: ['en'],
+};
+
+describe('useCreatePoll mutation hook', () => {
+  let invalidateSpy: jest.SpyInstance;
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockCreatePoll.mockResolvedValue({ uri: 'at://poll' });
+    mockCreatePost.mockResolvedValue({ uri: 'at://post' });
+    (pollEmbedUrlFromRecord as jest.Mock).mockReturnValue('https://tokimeki/poll');
+  });
+
+  it('creates the poll record then a post embedding it', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreatePoll(), { wrapper });
+
+    result.current.mutate(input);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockCreatePoll).toHaveBeenCalledWith('token', 'did:current', {
+      options: ['Red', 'Blue'],
+      endsAt: '2026-06-01T00:00:00.000Z',
+    });
+    expect(pollEmbedUrlFromRecord).toHaveBeenCalledWith('at://poll', 2);
+    expect(mockCreatePost).toHaveBeenCalledWith('token', 'did:current', {
+      text: 'Best color?',
+      langs: ['en'],
+      externalEmbed: {
+        uri: 'https://tokimeki/poll',
+        title: 'Best color?',
+        description: 'Red / Blue',
+      },
+    });
+    expect(result.current.data).toEqual({
+      poll: { uri: 'at://poll' },
+      post: { uri: 'at://post' },
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['timeline'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['feed'] });
+  });
+
+  it('falls back to the poll uri when no embed url is derivable', async () => {
+    (pollEmbedUrlFromRecord as jest.Mock).mockReturnValue(null);
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreatePoll(), { wrapper });
+
+    result.current.mutate({ ...input, question: '' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockCreatePost).toHaveBeenCalledWith('token', 'did:current', {
+      text: '',
+      langs: ['en'],
+      externalEmbed: {
+        uri: 'at://poll',
+        title: 'Red / Blue',
+        description: 'Red / Blue',
+      },
+    });
+  });
+
+  it('errors when not signed in', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreatePoll(), { wrapper });
+
+    result.current.mutate(input);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreatePoll).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useCreateReview.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useCreateReview.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useCreateReview } from '@/hooks/mutations/useCreateReview';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import type { CreateReviewInput } from '@/bluesky-api';
+
+const mockCreateReview = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createReview: mockCreateReview,
+  })),
+}));
+
+describe('useCreateReview mutation hook', () => {
+  let invalidateSpy: jest.SpyInstance;
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  const review = { value: 4, item: 'at://item' } as unknown as CreateReviewInput;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockCreateReview.mockResolvedValue({ uri: 'at://review' });
+  });
+
+  it('creates a review and invalidates author posts + timeline', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateReview(), { wrapper });
+
+    result.current.mutate(review);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreateReview).toHaveBeenCalledWith('token', 'did:current', review);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['authorPosts'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['timeline'] });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateReview(), { wrapper });
+
+    result.current.mutate(review);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateReview).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateReview(), { wrapper });
+
+    result.current.mutate(review);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateReview).not.toHaveBeenCalled();
+  });
+
+  it('errors when did missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateReview(), { wrapper });
+
+    result.current.mutate(review);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateReview).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useDeactivateAccount.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useDeactivateAccount.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useDeactivateAccount } from '@/hooks/mutations/useDeactivateAccount';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockDeactivateAccount = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    deactivateAccount: mockDeactivateAccount,
+  })),
+}));
+
+describe('useDeactivateAccount mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockDeactivateAccount.mockResolvedValue(undefined);
+  });
+
+  it('deactivates the account with a scheduled delete date', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useDeactivateAccount(), { wrapper });
+
+    result.current.mutate('2030-01-01T00:00:00.000Z');
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockDeactivateAccount).toHaveBeenCalledWith('token', '2030-01-01T00:00:00.000Z');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['auth'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['session'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['profile', 'did'] });
+  });
+
+  it('deactivates without a delete date (reversible)', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeactivateAccount(), { wrapper });
+
+    result.current.mutate(undefined);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockDeactivateAccount).toHaveBeenCalledWith('token', undefined);
+  });
+
+  it('throws when the token is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useDeactivateAccount(), { wrapper });
+
+    result.current.mutate(undefined);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockDeactivateAccount).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PDS URL is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { result } = renderHook(() => useDeactivateAccount(), { wrapper });
+
+    result.current.mutate(undefined);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockDeactivateAccount).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useDeleteAccount.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useDeleteAccount.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useDeleteAccount, useRequestAccountDelete } from '@/hooks/mutations/useDeleteAccount';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockDeleteAccount = jest.fn();
+const mockRequestAccountDelete = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    deleteAccount: mockDeleteAccount,
+    requestAccountDelete: mockRequestAccountDelete,
+  })),
+}));
+
+describe('useDeleteAccount mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockDeleteAccount.mockResolvedValue(undefined);
+    mockRequestAccountDelete.mockResolvedValue(undefined);
+  });
+
+  describe('useRequestAccountDelete', () => {
+    it('emails a confirmation token and invalidates pds preferences', async () => {
+      const { queryClient, wrapper } = createWrapper();
+      const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+      const { result } = renderHook(() => useRequestAccountDelete(), { wrapper });
+
+      result.current.mutate();
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+      expect(mockRequestAccountDelete).toHaveBeenCalledWith('token');
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['preferences', 'https://pds', undefined],
+      });
+    });
+
+    it('throws when the token is missing', async () => {
+      const { wrapper } = createWrapper();
+      (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+      const { result } = renderHook(() => useRequestAccountDelete(), { wrapper });
+
+      result.current.mutate();
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+      expect(mockRequestAccountDelete).not.toHaveBeenCalled();
+    });
+
+    it('throws when the PDS URL is missing', async () => {
+      const { wrapper } = createWrapper();
+      (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+      const { result } = renderHook(() => useRequestAccountDelete(), { wrapper });
+
+      result.current.mutate();
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+      expect(mockRequestAccountDelete).not.toHaveBeenCalled();
+    });
+  });
+
+  it('deletes the account and invalidates every query', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useDeleteAccount(), { wrapper });
+
+    result.current.mutate({ password: 'pw', token: 'email-token' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockDeleteAccount).toHaveBeenCalledWith('did', 'pw', 'email-token');
+    expect(invalidateSpy).toHaveBeenCalledWith();
+  });
+
+  it('throws when the DID is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { result } = renderHook(() => useDeleteAccount(), { wrapper });
+
+    result.current.mutate({ password: 'pw', token: 'email-token' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockDeleteAccount).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PDS URL is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { result } = renderHook(() => useDeleteAccount(), { wrapper });
+
+    result.current.mutate({ password: 'pw', token: 'email-token' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockDeleteAccount).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useEmitOzoneEvent.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useEmitOzoneEvent.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useEmitOzoneEvent } from '@/hooks/mutations/useEmitOzoneEvent';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+
+const mockEmitEvent = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyOzone', () => ({ ozoneForAccount: jest.fn() }));
+
+describe('useEmitOzoneEvent hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper, invalidateSpy };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({ emitEvent: mockEmitEvent });
+  });
+
+  it('emits an event defaulting createdBy to the current DID and invalidates ozone', async () => {
+    mockEmitEvent.mockResolvedValue({ id: 1 });
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useEmitOzoneEvent(), { wrapper });
+
+    const input = {
+      event: { $type: 'tools.ozone.moderation.defs#modEventComment', comment: 'hi' },
+      subject: { $type: 'com.atproto.admin.defs#repoRef', did: 'did:s' },
+    };
+    result.current.mutate(input as never);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockEmitEvent).toHaveBeenCalledWith('token', 'did:ozone', {
+      ...input,
+      createdBy: 'did:current',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['ozone'] });
+  });
+
+  it('honours an explicit createdBy', async () => {
+    mockEmitEvent.mockResolvedValue({ id: 2 });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useEmitOzoneEvent(), { wrapper });
+
+    const input = {
+      event: { $type: 'x' },
+      subject: { did: 'did:s' },
+      createdBy: 'did:explicit',
+    } as never;
+    result.current.mutate(input);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockEmitEvent).toHaveBeenCalledWith(
+      'token',
+      'did:ozone',
+      expect.objectContaining({ createdBy: 'did:explicit' }),
+    );
+  });
+
+  it('throws when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useEmitOzoneEvent(), { wrapper });
+
+    result.current.mutate({ event: { $type: 'x' }, subject: {} } as never);
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockEmitEvent).not.toHaveBeenCalled();
+  });
+
+  it('throws when no current DID and no explicit createdBy', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useEmitOzoneEvent(), { wrapper });
+
+    result.current.mutate({ event: { $type: 'x' }, subject: {} } as never);
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockEmitEvent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useGroupConvo.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useGroupConvo.test.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  useAddConvoMembers,
+  useRemoveConvoMembers,
+  useUpdateConvoName,
+  useMuteConvo,
+  useLeaveConvo,
+} from '@/hooks/mutations/useGroupConvo';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockAddConvoMembers = jest.fn();
+const mockRemoveConvoMembers = jest.fn();
+const mockUpdateConvoName = jest.fn();
+const mockMuteConvo = jest.fn();
+const mockUnmuteConvo = jest.fn();
+const mockLeaveConvo = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    addConvoMembers: mockAddConvoMembers,
+    removeConvoMembers: mockRemoveConvoMembers,
+    updateConvoName: mockUpdateConvoName,
+    muteConvo: mockMuteConvo,
+    unmuteConvo: mockUnmuteConvo,
+    leaveConvo: mockLeaveConvo,
+  })),
+}));
+
+describe('useGroupConvo mutation hooks', () => {
+  let invalidateSpy: jest.SpyInstance;
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockAddConvoMembers.mockResolvedValue({});
+    mockRemoveConvoMembers.mockResolvedValue({});
+    mockUpdateConvoName.mockResolvedValue({});
+    mockMuteConvo.mockResolvedValue({});
+    mockUnmuteConvo.mockResolvedValue({});
+    mockLeaveConvo.mockResolvedValue({});
+  });
+
+  it('adds convo members and invalidates conversation + message caches', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAddConvoMembers(), { wrapper });
+
+    result.current.mutate({ convoId: 'c1', dids: ['did:a', 'did:b'] });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockAddConvoMembers).toHaveBeenCalledWith('token', 'c1', ['did:a', 'did:b']);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['conversations'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['messages'] });
+  });
+
+  it('add convo members errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAddConvoMembers(), { wrapper });
+
+    result.current.mutate({ convoId: 'c1', dids: ['did:a'] });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockAddConvoMembers).not.toHaveBeenCalled();
+  });
+
+  it('add convo members errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAddConvoMembers(), { wrapper });
+
+    result.current.mutate({ convoId: 'c1', dids: ['did:a'] });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockAddConvoMembers).not.toHaveBeenCalled();
+  });
+
+  it('removes convo members', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRemoveConvoMembers(), { wrapper });
+
+    result.current.mutate({ convoId: 'c1', dids: ['did:a'] });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockRemoveConvoMembers).toHaveBeenCalledWith('token', 'c1', ['did:a']);
+  });
+
+  it('updates convo name', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateConvoName(), { wrapper });
+
+    result.current.mutate({ convoId: 'c1', name: 'New Name' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockUpdateConvoName).toHaveBeenCalledWith('token', 'c1', 'New Name');
+  });
+
+  it('mutes a conversation', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMuteConvo(), { wrapper });
+
+    result.current.mutate({ convoId: 'c1', action: 'mute' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockMuteConvo).toHaveBeenCalledWith('token', 'c1');
+    expect(mockUnmuteConvo).not.toHaveBeenCalled();
+  });
+
+  it('unmutes a conversation', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMuteConvo(), { wrapper });
+
+    result.current.mutate({ convoId: 'c1', action: 'unmute' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockUnmuteConvo).toHaveBeenCalledWith('token', 'c1');
+    expect(mockMuteConvo).not.toHaveBeenCalled();
+  });
+
+  it('leaves a conversation', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useLeaveConvo(), { wrapper });
+
+    result.current.mutate({ convoId: 'c1' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockLeaveConvo).toHaveBeenCalledWith('token', 'c1');
+  });
+
+  it('every hook errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const remove = renderHook(() => useRemoveConvoMembers(), { wrapper });
+    remove.result.current.mutate({ convoId: 'c1', dids: ['did:a'] });
+    const rename = renderHook(() => useUpdateConvoName(), { wrapper });
+    rename.result.current.mutate({ convoId: 'c1', name: 'x' });
+    const mute = renderHook(() => useMuteConvo(), { wrapper });
+    mute.result.current.mutate({ convoId: 'c1', action: 'mute' });
+    const leave = renderHook(() => useLeaveConvo(), { wrapper });
+    leave.result.current.mutate({ convoId: 'c1' });
+
+    await waitFor(() => {
+      expect(remove.result.current.isError).toBe(true);
+      expect(rename.result.current.isError).toBe(true);
+      expect(mute.result.current.isError).toBe(true);
+      expect(leave.result.current.isError).toBe(true);
+    });
+    expect(mockRemoveConvoMembers).not.toHaveBeenCalled();
+    expect(mockUpdateConvoName).not.toHaveBeenCalled();
+    expect(mockMuteConvo).not.toHaveBeenCalled();
+    expect(mockLeaveConvo).not.toHaveBeenCalled();
+  });
+
+  it('every hook errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+
+    const remove = renderHook(() => useRemoveConvoMembers(), { wrapper });
+    remove.result.current.mutate({ convoId: 'c1', dids: ['did:a'] });
+    const rename = renderHook(() => useUpdateConvoName(), { wrapper });
+    rename.result.current.mutate({ convoId: 'c1', name: 'x' });
+    const mute = renderHook(() => useMuteConvo(), { wrapper });
+    mute.result.current.mutate({ convoId: 'c1', action: 'unmute' });
+    const leave = renderHook(() => useLeaveConvo(), { wrapper });
+    leave.result.current.mutate({ convoId: 'c1' });
+
+    await waitFor(() => {
+      expect(remove.result.current.isError).toBe(true);
+      expect(rename.result.current.isError).toBe(true);
+      expect(mute.result.current.isError).toBe(true);
+      expect(leave.result.current.isError).toBe(true);
+    });
+    expect(mockUnmuteConvo).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useListMembership.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useListMembership.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useListMembership } from '@/hooks/mutations/useListMembership';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockAddToList = jest.fn();
+const mockRemoveFromList = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    addToList: mockAddToList,
+    removeFromList: mockRemoveFromList,
+  })),
+}));
+
+describe('useListMembership mutation hook', () => {
+  let invalidateSpy: jest.SpyInstance;
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockAddToList.mockResolvedValue({ uri: 'at://listitem' });
+    mockRemoveFromList.mockResolvedValue({});
+  });
+
+  it('adds a subject to a list and invalidates snapshots', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useListMembership(), { wrapper });
+
+    result.current.mutate({ action: 'add', listUri: 'at://list', subjectDid: 'did:subject' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockAddToList).toHaveBeenCalledWith('token', 'did:current', 'at://list', 'did:subject');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['listSnapshot', 'https://pds', 'at://list'],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['list', 'https://pds', 'at://list'],
+    });
+  });
+
+  it('removes a subject from a list by listitem uri', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useListMembership(), { wrapper });
+
+    result.current.mutate({
+      action: 'remove',
+      listItemUri: 'at://listitem',
+      listUri: 'at://list',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockRemoveFromList).toHaveBeenCalledWith('token', 'at://listitem');
+    expect(mockAddToList).not.toHaveBeenCalled();
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useListMembership(), { wrapper });
+
+    result.current.mutate({ action: 'add', listUri: 'at://list', subjectDid: 'did:subject' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockAddToList).not.toHaveBeenCalled();
+  });
+
+  it('errors when did missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useListMembership(), { wrapper });
+
+    result.current.mutate({ action: 'add', listUri: 'at://list', subjectDid: 'did:subject' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockAddToList).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useListMembership(), { wrapper });
+
+    result.current.mutate({ action: 'add', listUri: 'at://list', subjectDid: 'did:subject' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockAddToList).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useMessageReaction.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useMessageReaction.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useMessageReaction } from '@/hooks/mutations/useMessageReaction';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockAddReaction = jest.fn();
+const mockRemoveReaction = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    addReaction: mockAddReaction,
+    removeReaction: mockRemoveReaction,
+  })),
+}));
+
+const convoId = 'c1';
+const messagesKey = ['messages', convoId, 50, 'did:current'];
+
+const buildPage = (reactions: { value: string; sender: { did: string }; createdAt: string }[]) => ({
+  pages: [
+    {
+      messages: [{ id: 'm1', reactions }],
+      cursor: undefined,
+    },
+  ],
+  pageParams: [undefined],
+});
+
+describe('useMessageReaction mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockAddReaction.mockResolvedValue({});
+    mockRemoveReaction.mockResolvedValue({});
+  });
+
+  it('adds a reaction and optimistically patches the cache', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(messagesKey, buildPage([]));
+
+    const { result } = renderHook(() => useMessageReaction(), { wrapper });
+    result.current.mutate({ convoId, messageId: 'm1', value: '👍', action: 'add' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockAddReaction).toHaveBeenCalledWith('token', convoId, 'm1', '👍');
+    const data = queryClient.getQueryData<any>(messagesKey);
+    expect(data.pages[0].messages[0].reactions).toHaveLength(1);
+    expect(data.pages[0].messages[0].reactions[0]).toMatchObject({
+      value: '👍',
+      sender: { did: 'did:current' },
+    });
+  });
+
+  it('does not double-add an existing reaction', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(
+      messagesKey,
+      buildPage([{ value: '👍', sender: { did: 'did:current' }, createdAt: 'now' }]),
+    );
+
+    const { result } = renderHook(() => useMessageReaction(), { wrapper });
+    result.current.mutate({ convoId, messageId: 'm1', value: '👍', action: 'add' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const data = queryClient.getQueryData<any>(messagesKey);
+    expect(data.pages[0].messages[0].reactions).toHaveLength(1);
+  });
+
+  it('removes a reaction and optimistically patches the cache', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(
+      messagesKey,
+      buildPage([{ value: '👍', sender: { did: 'did:current' }, createdAt: 'now' }]),
+    );
+
+    const { result } = renderHook(() => useMessageReaction(), { wrapper });
+    result.current.mutate({ convoId, messageId: 'm1', value: '👍', action: 'remove' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockRemoveReaction).toHaveBeenCalledWith('token', convoId, 'm1', '👍');
+    const data = queryClient.getQueryData<any>(messagesKey);
+    expect(data.pages[0].messages[0].reactions).toHaveLength(0);
+  });
+
+  it('invalidates the message cache on error', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(messagesKey, buildPage([]));
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    mockAddReaction.mockRejectedValueOnce(new Error('fail'));
+
+    const { result } = renderHook(() => useMessageReaction(), { wrapper });
+    result.current.mutate({ convoId, messageId: 'm1', value: '👍', action: 'add' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(invalidateSpy).toHaveBeenCalled();
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMessageReaction(), { wrapper });
+
+    result.current.mutate({ convoId, messageId: 'm1', value: '👍', action: 'add' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockAddReaction).not.toHaveBeenCalled();
+  });
+
+  it('skips optimistic patch when there is no current did', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMessageReaction(), { wrapper });
+
+    // No did means mutationFn passes the pdsUrl guard but onMutate returns early;
+    // addReaction still fires since token + pdsUrl are present.
+    result.current.mutate({ convoId, messageId: 'm1', value: '👍', action: 'add' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockAddReaction).toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useMuteActorList.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useMuteActorList.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useMuteActorList } from '@/hooks/mutations/useMuteActorList';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockMuteActorList = jest.fn();
+const mockUnmuteActorList = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    muteActorList: mockMuteActorList,
+    unmuteActorList: mockUnmuteActorList,
+  })),
+}));
+
+describe('useMuteActorList mutation hook', () => {
+  let invalidateSpy: jest.SpyInstance;
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockMuteActorList.mockResolvedValue({});
+    mockUnmuteActorList.mockResolvedValue({});
+  });
+
+  it('mutes a moderation list and invalidates feeds', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMuteActorList(), { wrapper });
+
+    result.current.mutate({ list: 'at://list', action: 'mute' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockMuteActorList).toHaveBeenCalledWith('token', 'at://list');
+    expect(mockUnmuteActorList).not.toHaveBeenCalled();
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['moderationLists'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['timeline'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['feed'] });
+  });
+
+  it('unmutes a moderation list', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMuteActorList(), { wrapper });
+
+    result.current.mutate({ list: 'at://list', action: 'unmute' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockUnmuteActorList).toHaveBeenCalledWith('token', 'at://list');
+    expect(mockMuteActorList).not.toHaveBeenCalled();
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMuteActorList(), { wrapper });
+
+    result.current.mutate({ list: 'at://list', action: 'mute' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockMuteActorList).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMuteActorList(), { wrapper });
+
+    result.current.mutate({ list: 'at://list', action: 'mute' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockMuteActorList).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useOzoneTemplateMutations.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useOzoneTemplateMutations.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  useCreateOzoneTemplate,
+  useUpdateOzoneTemplate,
+  useDeleteOzoneTemplate,
+} from '@/hooks/mutations/useOzoneTemplateMutations';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+
+const mockCreateCommTemplate = jest.fn();
+const mockUpdateCommTemplate = jest.fn();
+const mockDeleteCommTemplate = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyOzone', () => ({ ozoneForAccount: jest.fn() }));
+
+describe('useOzoneTemplateMutations hooks', () => {
+  const templatesKey = ['ozone', 'templates', 'did:ozone'];
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper, invalidateSpy };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({
+      createCommTemplate: mockCreateCommTemplate,
+      updateCommTemplate: mockUpdateCommTemplate,
+      deleteCommTemplate: mockDeleteCommTemplate,
+    });
+  });
+
+  it('useCreateOzoneTemplate creates with createdBy and invalidates', async () => {
+    mockCreateCommTemplate.mockResolvedValue({ id: 't1' });
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useCreateOzoneTemplate(), { wrapper });
+
+    result.current.mutate({ name: 'Hi', contentMarkdown: 'body', lang: 'en' });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockCreateCommTemplate).toHaveBeenCalledWith('token', 'did:ozone', {
+      name: 'Hi',
+      contentMarkdown: 'body',
+      lang: 'en',
+      createdBy: 'did:current',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: templatesKey });
+  });
+
+  it('useCreateOzoneTemplate throws when session missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateOzoneTemplate(), { wrapper });
+    result.current.mutate({ name: 'Hi', contentMarkdown: 'body' });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('useUpdateOzoneTemplate updates with updatedBy and invalidates', async () => {
+    mockUpdateCommTemplate.mockResolvedValue({ id: 't1' });
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useUpdateOzoneTemplate(), { wrapper });
+
+    result.current.mutate({ id: 't1', name: 'New', disabled: true });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockUpdateCommTemplate).toHaveBeenCalledWith('token', 'did:ozone', {
+      id: 't1',
+      name: 'New',
+      disabled: true,
+      updatedBy: 'did:current',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: templatesKey });
+  });
+
+  it('useUpdateOzoneTemplate throws when PDS missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: undefined } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateOzoneTemplate(), { wrapper });
+    result.current.mutate({ id: 't1' });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('useDeleteOzoneTemplate deletes, returns id, and invalidates', async () => {
+    mockDeleteCommTemplate.mockResolvedValue(undefined);
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useDeleteOzoneTemplate(), { wrapper });
+
+    result.current.mutate('t1');
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockDeleteCommTemplate).toHaveBeenCalledWith('token', 'did:ozone', 't1');
+    expect(result.current.data).toBe('t1');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: templatesKey });
+  });
+
+  it('useDeleteOzoneTemplate throws when session missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeleteOzoneTemplate(), { wrapper });
+    result.current.mutate('t1');
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useRateCommunityNote.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useRateCommunityNote.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useRateCommunityNote } from '@/hooks/mutations/useRateCommunityNote';
+
+describe('useRateCommunityNote stub hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('rates a community note and resolves ok', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRateCommunityNote(), { wrapper });
+
+    const input = {
+      noteId: 'note-1',
+      helpfulness: 'helpful' as const,
+      reasons: ['clear', 'sourced'],
+      comment: 'good note',
+    };
+    result.current.mutate(input);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual({ ok: true });
+    expect(logSpy).toHaveBeenCalledWith('[stub useRateCommunityNote]', input);
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useRegisterPushSubscription.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useRegisterPushSubscription.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useRegisterPushSubscription } from '@/hooks/mutations/useRegisterPushSubscription';
+
+describe('useRegisterPushSubscription mutation hook', () => {
+  const ORIGINAL_ENV = process.env.EXPO_PUBLIC_PUSH_REGISTRY_URL;
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.EXPO_PUBLIC_PUSH_REGISTRY_URL = 'https://registry.test/';
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: jest.fn().mockResolvedValue(''),
+    }) as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    process.env.EXPO_PUBLIC_PUSH_REGISTRY_URL = ORIGINAL_ENV;
+  });
+
+  it('posts the subscription payload to the trimmed registry url', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useRegisterPushSubscription(), { wrapper });
+
+    result.current.mutate({
+      did: 'did:plc:abc',
+      expoPushToken: 'expo-token',
+      platform: 'ios',
+      devicePushToken: 'device-token',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith('https://registry.test/subscriptions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        did: 'did:plc:abc',
+        expoPushToken: 'expo-token',
+        devicePushToken: 'device-token',
+        platform: 'ios',
+      }),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['notifications', 'preferences', 'did:plc:abc', undefined],
+    });
+  });
+
+  it('throws when the registry url is not configured', async () => {
+    delete process.env.EXPO_PUBLIC_PUSH_REGISTRY_URL;
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRegisterPushSubscription(), { wrapper });
+
+    result.current.mutate({ did: 'did', expoPushToken: 'expo-token', platform: 'ios' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('throws when the registry responds with a non-ok status', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+      text: jest.fn().mockResolvedValue('boom'),
+    }) as unknown as typeof fetch;
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRegisterPushSubscription(), { wrapper });
+
+    result.current.mutate({ did: 'did', expoPushToken: 'expo-token', platform: 'android' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(result.current.error?.message).toContain('500');
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useReport.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useReport.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useReport } from '@/hooks/mutations/useReport';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockCreateReport = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createReport: mockCreateReport,
+  })),
+}));
+
+describe('useReport mutation hook', () => {
+  let invalidateSpy: jest.SpyInstance;
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockCreateReport.mockResolvedValue({});
+  });
+
+  it('reports an account and invalidates the profile', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useReport(), { wrapper });
+
+    result.current.mutate({
+      subject: { type: 'account', did: 'did:bad' },
+      reasonType: 'reasonSpam',
+      reason: 'spammy',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreateReport).toHaveBeenCalledWith(
+      'token',
+      { did: 'did:bad' },
+      'reasonSpam',
+      'spammy',
+      undefined,
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['profile', 'did:bad'] });
+  });
+
+  it('reports a post and invalidates post + thread caches', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useReport(), { wrapper });
+
+    result.current.mutate({
+      subject: { type: 'post', uri: 'at://post', cid: 'cid' },
+      reasonType: 'reasonViolation',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreateReport).toHaveBeenCalledWith(
+      'token',
+      { uri: 'at://post', cid: 'cid' },
+      'reasonViolation',
+      undefined,
+      undefined,
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['post'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['postThread'] });
+  });
+
+  it('forwards a labeler did for an appeal', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useReport(), { wrapper });
+
+    result.current.mutate({
+      subject: { type: 'account', did: 'did:bad' },
+      reasonType: 'reasonAppeal',
+      labelerDid: 'did:labeler',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreateReport).toHaveBeenCalledWith(
+      'token',
+      { did: 'did:bad' },
+      'reasonAppeal',
+      undefined,
+      'did:labeler',
+    );
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useReport(), { wrapper });
+
+    result.current.mutate({
+      subject: { type: 'account', did: 'did:bad' },
+      reasonType: 'reasonSpam',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateReport).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useReport(), { wrapper });
+
+    result.current.mutate({
+      subject: { type: 'account', did: 'did:bad' },
+      reasonType: 'reasonSpam',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateReport).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useRequestEmailUpdate.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useRequestEmailUpdate.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useRequestEmailUpdate } from '@/hooks/mutations/useRequestEmailUpdate';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockRequestEmailUpdate = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    requestEmailUpdate: mockRequestEmailUpdate,
+  })),
+}));
+
+describe('useRequestEmailUpdate mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockRequestEmailUpdate.mockResolvedValue({ tokenRequired: true });
+  });
+
+  it('requests an email update and invalidates preferences for the pds', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useRequestEmailUpdate(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockRequestEmailUpdate).toHaveBeenCalledWith('token');
+    expect(result.current.data).toEqual({ tokenRequired: true });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['preferences', 'https://pds', undefined],
+    });
+  });
+
+  it('throws when the token is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useRequestEmailUpdate(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockRequestEmailUpdate).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PDS URL is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { result } = renderHook(() => useRequestEmailUpdate(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockRequestEmailUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useRevokeAppPassword.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useRevokeAppPassword.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useRevokeAppPassword } from '@/hooks/mutations/useRevokeAppPassword';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockRevokeAppPassword = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    revokeAppPassword: mockRevokeAppPassword,
+  })),
+}));
+
+describe('useRevokeAppPassword mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockRevokeAppPassword.mockResolvedValue(undefined);
+  });
+
+  it('revokes the app password by name and returns the name', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useRevokeAppPassword(), { wrapper });
+
+    result.current.mutate('cli');
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockRevokeAppPassword).toHaveBeenCalledWith('token', 'cli');
+    expect(result.current.data).toBe('cli');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['appPasswords'] });
+  });
+
+  it('throws when the token is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useRevokeAppPassword(), { wrapper });
+
+    result.current.mutate('cli');
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockRevokeAppPassword).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PDS URL is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { result } = renderHook(() => useRevokeAppPassword(), { wrapper });
+
+    result.current.mutate('cli');
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockRevokeAppPassword).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useSetLiveStatus.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useSetLiveStatus.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useSetLiveStatus } from '@/hooks/mutations/useSetLiveStatus';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockSetActorStatus = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    setActorStatus: mockSetActorStatus,
+  })),
+}));
+
+describe('useSetLiveStatus mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockSetActorStatus.mockResolvedValue(undefined);
+  });
+
+  it('publishes a live status with the friendly service name as the card title', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useSetLiveStatus(), { wrapper });
+
+    result.current.mutate({ url: 'https://twitch.tv/someone', durationMinutes: 60 });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockSetActorStatus).toHaveBeenCalledWith('token', 'did', {
+      durationMinutes: 60,
+      createdAt: undefined,
+      external: {
+        uri: 'https://twitch.tv/someone',
+        title: 'Twitch',
+        description: 'https://twitch.tv/someone',
+      },
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['profile'] });
+  });
+
+  it('preserves createdAt when editing an existing status', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSetLiveStatus(), { wrapper });
+
+    result.current.mutate({
+      url: 'https://youtube.com/watch?v=x',
+      durationMinutes: 30,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockSetActorStatus).toHaveBeenCalledWith('token', 'did', {
+      durationMinutes: 30,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      external: {
+        uri: 'https://youtube.com/watch?v=x',
+        title: 'YouTube',
+        description: 'https://youtube.com/watch?v=x',
+      },
+    });
+  });
+
+  it('falls back to the raw url as title for an unparseable url', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSetLiveStatus(), { wrapper });
+
+    result.current.mutate({ url: 'not a url', durationMinutes: 15 });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockSetActorStatus).toHaveBeenCalledWith(
+      'token',
+      'did',
+      expect.objectContaining({
+        external: { uri: 'not a url', title: 'not a url', description: 'not a url' },
+      }),
+    );
+  });
+
+  it('throws when the token is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useSetLiveStatus(), { wrapper });
+
+    result.current.mutate({ url: 'https://twitch.tv/someone', durationMinutes: 60 });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetActorStatus).not.toHaveBeenCalled();
+  });
+
+  it('throws when the DID is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { result } = renderHook(() => useSetLiveStatus(), { wrapper });
+
+    result.current.mutate({ url: 'https://twitch.tv/someone', durationMinutes: 60 });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetActorStatus).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PDS URL is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { result } = renderHook(() => useSetLiveStatus(), { wrapper });
+
+    result.current.mutate({ url: 'https://twitch.tv/someone', durationMinutes: 60 });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetActorStatus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useStartConvo.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useStartConvo.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useStartConvo } from '@/hooks/mutations/useStartConvo';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetConvoForMembers = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getConvoForMembers: mockGetConvoForMembers,
+  })),
+}));
+
+describe('useStartConvo mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper, invalidateSpy };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockGetConvoForMembers.mockResolvedValue({ convo: { id: 'convo-1' } });
+  });
+
+  it('resolves a conversation and returns the convo view', async () => {
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useStartConvo(), { wrapper });
+
+    result.current.mutate({ memberDids: ['did:peer'] });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetConvoForMembers).toHaveBeenCalledWith('token', ['did:peer']);
+    expect(result.current.data).toEqual({ id: 'convo-1' });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['conversations'] });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useStartConvo(), { wrapper });
+
+    result.current.mutate({ memberDids: ['did:peer'] });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetConvoForMembers).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useStartConvo(), { wrapper });
+
+    result.current.mutate({ memberDids: ['did:peer'] });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetConvoForMembers).not.toHaveBeenCalled();
+  });
+
+  it('errors when no member dids provided', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useStartConvo(), { wrapper });
+
+    result.current.mutate({ memberDids: [] });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetConvoForMembers).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useSubmitCommunityNote.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useSubmitCommunityNote.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  useSubmitCommunityNote,
+  useRequestCommunityNote,
+} from '@/hooks/mutations/useSubmitCommunityNote';
+
+describe('useSubmitCommunityNote stub hooks', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('submits a community note and resolves ok', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSubmitCommunityNote(), { wrapper });
+
+    const input = {
+      postUri: 'at://post',
+      body: 'context',
+      sources: ['https://src'],
+      classification: 'misleading' as const,
+    };
+    result.current.mutate(input);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual({ ok: true });
+    expect(logSpy).toHaveBeenCalledWith('[stub useSubmitCommunityNote]', input);
+  });
+
+  it('requests a community note and resolves ok', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRequestCommunityNote(), { wrapper });
+
+    const input = {
+      postUri: 'at://post',
+      reason: 'misinformation' as const,
+      comment: 'please review',
+    };
+    result.current.mutate(input);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual({ ok: true });
+    expect(logSpy).toHaveBeenCalledWith('[stub useRequestCommunityNote]', input);
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateAccountAppView.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateAccountAppView.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateAccountAppView } from '@/hooks/mutations/useUpdateAccountAppView';
+import { storage } from '@/utils/secureStorage';
+
+jest.mock('@/utils/secureStorage', () => ({
+  storage: {
+    setItem: jest.fn(),
+    getItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+describe('useUpdateAccountAppView mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('persists the override to the accounts list and current account', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const setQueryDataSpy = jest.spyOn(queryClient, 'setQueryData');
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const accounts = [
+      { did: 'a1', handle: 'h1' },
+      { did: 'a2', handle: 'h2' },
+    ];
+    const current = { did: 'a1', handle: 'h1' };
+    (storage.getItem as jest.Mock).mockImplementation((key: string) => {
+      if (key === 'accounts') return accounts;
+      if (key === 'currentAccount') return current;
+      return null;
+    });
+
+    const override = { did: 'did:appview' } as any;
+    const { result } = renderHook(() => useUpdateAccountAppView(), { wrapper });
+
+    result.current.mutate({ did: 'a1', override });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const expectedAccounts = [
+      { did: 'a1', handle: 'h1', appView: override },
+      { did: 'a2', handle: 'h2' },
+    ];
+    expect(storage.setItem).toHaveBeenCalledWith('accounts', expectedAccounts);
+    expect(setQueryDataSpy).toHaveBeenCalledWith(['accounts'], expectedAccounts);
+    expect(storage.setItem).toHaveBeenCalledWith('currentAccount', {
+      did: 'a1',
+      handle: 'h1',
+      appView: override,
+    });
+    expect(setQueryDataSpy).toHaveBeenCalledWith(['currentAccount'], {
+      did: 'a1',
+      handle: 'h1',
+      appView: override,
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith();
+  });
+
+  it('does not touch the current account when a different DID is updated', async () => {
+    const { wrapper } = createWrapper();
+    const accounts = [{ did: 'a1', handle: 'h1' }];
+    const current = { did: 'a2', handle: 'h2' };
+    (storage.getItem as jest.Mock).mockImplementation((key: string) => {
+      if (key === 'accounts') return accounts;
+      if (key === 'currentAccount') return current;
+      return null;
+    });
+
+    const { result } = renderHook(() => useUpdateAccountAppView(), { wrapper });
+
+    result.current.mutate({ did: 'a1', override: undefined });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(storage.setItem).toHaveBeenCalledWith('accounts', [
+      { did: 'a1', handle: 'h1', appView: undefined },
+    ]);
+    expect(storage.setItem).not.toHaveBeenCalledWith('currentAccount', expect.anything());
+  });
+
+  it('handles an empty stored accounts list', async () => {
+    const { wrapper } = createWrapper();
+    (storage.getItem as jest.Mock).mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useUpdateAccountAppView(), { wrapper });
+
+    result.current.mutate({ did: 'a1', override: undefined });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(storage.setItem).toHaveBeenCalledWith('accounts', []);
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateAccountAutomated.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateAccountAutomated.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateAccountAutomated } from '@/hooks/mutations/useUpdateAccountAutomated';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockSetAccountAutomated = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    setAccountAutomated: mockSetAccountAutomated,
+  })),
+}));
+
+describe('useUpdateAccountAutomated mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockSetAccountAutomated.mockResolvedValue(undefined);
+  });
+
+  it('sets the automated self-label and invalidates the profile', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateAccountAutomated(), { wrapper });
+
+    result.current.mutate(true);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockSetAccountAutomated).toHaveBeenCalledWith('token', 'did', true);
+    expect(result.current.data).toBe(true);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['profile'] });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateAccountAutomated(), { wrapper });
+
+    result.current.mutate(true);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetAccountAutomated).not.toHaveBeenCalled();
+  });
+
+  it('errors when DID missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateAccountAutomated(), { wrapper });
+
+    result.current.mutate(true);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetAccountAutomated).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateAccountAutomated(), { wrapper });
+
+    result.current.mutate(true);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetAccountAutomated).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateAdultContentPref.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateAdultContentPref.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateAdultContentPref } from '@/hooks/mutations/useUpdateAdultContentPref';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#adultContentPref';
+
+describe('useUpdateAdultContentPref mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('toggles the adult-content slot and puts the merged list back', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const other = { $type: 'app.bsky.actor.defs#interestsPref', tags: ['art'] };
+    mockGetPreferences.mockResolvedValueOnce({
+      preferences: [other, { $type: PREF_TYPE, enabled: false }],
+    });
+    const { result } = renderHook(() => useUpdateAdultContentPref(), { wrapper });
+
+    result.current.mutate(true);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [other, { $type: PREF_TYPE, enabled: true }]);
+    expect(result.current.data).toBe(true);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('inserts the pref when none exists', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateAdultContentPref(), { wrapper });
+
+    result.current.mutate(false);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [{ $type: PREF_TYPE, enabled: false }]);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateAdultContentPref(), { wrapper });
+
+    result.current.mutate(true);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateAdultContentPref(), { wrapper });
+
+    result.current.mutate(true);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateAiPreferences.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateAiPreferences.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  buildAiPreferencesRecord,
+  useUpdateAiPreferences,
+} from '@/hooks/mutations/useUpdateAiPreferences';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockPutAiPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    putAiPreferences: mockPutAiPreferences,
+  })),
+}));
+
+const queryKey = ['aiPreferences', 'did', 'https://pds'];
+
+describe('useUpdateAiPreferences mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockPutAiPreferences.mockResolvedValue(undefined);
+  });
+
+  it('writes the record and stores it in the cache on success', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const record = buildAiPreferencesRecord({ training: true }, null);
+    const { result } = renderHook(() => useUpdateAiPreferences(), { wrapper });
+
+    result.current.mutate(record);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutAiPreferences).toHaveBeenCalledWith('token', 'did', record);
+    expect(queryClient.getQueryData(queryKey)).toEqual(record);
+    expect(result.current.data).toEqual(record);
+  });
+
+  it('rolls back to the previous cache value on error', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const previous = buildAiPreferencesRecord({ embedding: true }, null);
+    queryClient.setQueryData(queryKey, previous);
+    mockPutAiPreferences.mockRejectedValueOnce(new Error('fail'));
+    const next = buildAiPreferencesRecord({ embedding: false }, null);
+    const { result } = renderHook(() => useUpdateAiPreferences(), { wrapper });
+
+    result.current.mutate(next);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(queryClient.getQueryData(queryKey)).toEqual(previous);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateAiPreferences(), { wrapper });
+
+    result.current.mutate(buildAiPreferencesRecord({}, null));
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockPutAiPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateAiPreferences(), { wrapper });
+
+    result.current.mutate(buildAiPreferencesRecord({}, null));
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockPutAiPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when DID missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateAiPreferences(), { wrapper });
+
+    result.current.mutate(buildAiPreferencesRecord({}, null));
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockPutAiPreferences).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildAiPreferencesRecord helper', () => {
+  it('defaults every category to opt-out when no current record', () => {
+    const record = buildAiPreferencesRecord({}, null);
+    expect(record.$type).toBe('community.lexicon.preference.ai');
+    expect(record.preferences.embedding.allow).toBe(false);
+    expect(record.preferences.inference.allow).toBe(false);
+    expect(record.preferences.syntheticContent.allow).toBe(false);
+    expect(record.preferences.training.allow).toBe(false);
+    expect(record.scope).toEqual({ $type: 'community.lexicon.preference.ai#globalScope' });
+  });
+
+  it('layers changes on top of the existing record', () => {
+    const current = buildAiPreferencesRecord({ training: true, embedding: true }, null);
+    const record = buildAiPreferencesRecord({ embedding: false }, current);
+    expect(record.preferences.training.allow).toBe(true);
+    expect(record.preferences.embedding.allow).toBe(false);
+  });
+
+  it('skips change keys whose value is undefined', () => {
+    const current = buildAiPreferencesRecord({ training: true }, null);
+    const record = buildAiPreferencesRecord({ training: undefined }, current);
+    // undefined change is a no-op; the existing flag survives.
+    expect(record.preferences.training.allow).toBe(true);
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateContentLanguages.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateContentLanguages.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateContentLanguages } from '@/hooks/mutations/useUpdateContentLanguages';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#contentLanguagesPref';
+
+describe('useUpdateContentLanguages mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('swaps the content-languages slot and puts the merged list back', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const other = { $type: 'app.bsky.actor.defs#adultContentPref', enabled: true };
+    mockGetPreferences.mockResolvedValueOnce({
+      preferences: [other, { $type: PREF_TYPE, languages: ['en'] }],
+    });
+    const { result } = renderHook(() => useUpdateContentLanguages(), { wrapper });
+
+    result.current.mutate((current) => [...current, 'fr']);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      other,
+      { $type: PREF_TYPE, languages: ['en', 'fr'] },
+    ]);
+    expect(result.current.data).toEqual(['en', 'fr']);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('defaults to an empty list when no existing pref', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateContentLanguages(), { wrapper });
+
+    result.current.mutate(() => ['de']);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [{ $type: PREF_TYPE, languages: ['de'] }]);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateContentLanguages(), { wrapper });
+
+    result.current.mutate(() => ['en']);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateContentLanguages(), { wrapper });
+
+    result.current.mutate(() => ['en']);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('surfaces putPreferences errors', async () => {
+    const { wrapper } = createWrapper();
+    mockPutPreferences.mockRejectedValueOnce(new Error('boom'));
+    const { result } = renderHook(() => useUpdateContentLanguages(), { wrapper });
+
+    result.current.mutate(() => ['en']);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateEmail.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateEmail.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateEmail } from '@/hooks/mutations/useUpdateEmail';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockUpdateEmail = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    updateEmail: mockUpdateEmail,
+  })),
+}));
+
+describe('useUpdateEmail mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockUpdateEmail.mockResolvedValue(undefined);
+  });
+
+  it('updates the email with a confirmation token and invalidates session', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateEmail(), { wrapper });
+
+    result.current.mutate({ email: 'new@b.com', token: 'email-token' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockUpdateEmail).toHaveBeenCalledWith('token', 'new@b.com', 'email-token');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['session'] });
+  });
+
+  it('updates the email without a token', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateEmail(), { wrapper });
+
+    result.current.mutate({ email: 'new@b.com' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockUpdateEmail).toHaveBeenCalledWith('token', 'new@b.com', undefined);
+  });
+
+  it('throws when the token is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useUpdateEmail(), { wrapper });
+
+    result.current.mutate({ email: 'new@b.com' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockUpdateEmail).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PDS URL is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { result } = renderHook(() => useUpdateEmail(), { wrapper });
+
+    result.current.mutate({ email: 'new@b.com' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockUpdateEmail).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateFeedViewPref.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateFeedViewPref.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateFeedViewPref } from '@/hooks/mutations/useUpdateFeedViewPref';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#feedViewPref';
+
+describe('useUpdateFeedViewPref mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('merges the patch onto the existing entry for the feed', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const otherFeed = { $type: PREF_TYPE, feed: 'at://feed/x', hideReplies: true };
+    const existing = { $type: PREF_TYPE, feed: 'home', hideReplies: true, hideReposts: false };
+    mockGetPreferences.mockResolvedValueOnce({ preferences: [otherFeed, existing] });
+    const { result } = renderHook(() => useUpdateFeedViewPref(), { wrapper });
+
+    result.current.mutate({ feed: 'home', patch: { hideReposts: true } });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    // other-feed entry preserved; the home entry merged.
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      otherFeed,
+      { $type: PREF_TYPE, feed: 'home', hideReplies: true, hideReposts: true },
+    ]);
+    expect(result.current.data).toEqual({
+      $type: PREF_TYPE,
+      feed: 'home',
+      hideReplies: true,
+      hideReposts: true,
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('inserts a new entry when the feed has none', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateFeedViewPref(), { wrapper });
+
+    result.current.mutate({ feed: 'home', patch: { hideReplies: true } });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      { $type: PREF_TYPE, feed: 'home', hideReplies: true },
+    ]);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateFeedViewPref(), { wrapper });
+
+    result.current.mutate({ feed: 'home', patch: {} });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateFeedViewPref(), { wrapper });
+
+    result.current.mutate({ feed: 'home', patch: {} });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateHandle.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateHandle.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateHandle } from '@/hooks/mutations/useUpdateHandle';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockUpdateHandle = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    updateHandle: mockUpdateHandle,
+  })),
+}));
+
+describe('useUpdateHandle mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockUpdateHandle.mockResolvedValue(undefined);
+  });
+
+  it('updates the handle, returns it, and invalidates identity caches', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateHandle(), { wrapper });
+
+    result.current.mutate('newhandle.bsky.social');
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockUpdateHandle).toHaveBeenCalledWith('token', 'newhandle.bsky.social');
+    expect(result.current.data).toBe('newhandle.bsky.social');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['session'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['profile'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['currentAccount'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['accounts'] });
+  });
+
+  it('surfaces the error when the PDS rejects the handle', async () => {
+    const { wrapper } = createWrapper();
+    mockUpdateHandle.mockRejectedValueOnce(new Error('handle unavailable'));
+    const { result } = renderHook(() => useUpdateHandle(), { wrapper });
+
+    result.current.mutate('taken.bsky.social');
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(result.current.error?.message).toBe('handle unavailable');
+  });
+
+  it('throws when the token is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useUpdateHandle(), { wrapper });
+
+    result.current.mutate('newhandle.bsky.social');
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockUpdateHandle).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PDS URL is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { result } = renderHook(() => useUpdateHandle(), { wrapper });
+
+    result.current.mutate('newhandle.bsky.social');
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockUpdateHandle).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateInterests.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateInterests.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateInterests } from '@/hooks/mutations/useUpdateInterests';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#interestsPref';
+
+describe('useUpdateInterests mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('swaps the interests slot and puts the merged list back', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const other = { $type: 'app.bsky.actor.defs#adultContentPref', enabled: false };
+    mockGetPreferences.mockResolvedValueOnce({
+      preferences: [other, { $type: PREF_TYPE, tags: ['art'] }],
+    });
+    const { result } = renderHook(() => useUpdateInterests(), { wrapper });
+
+    result.current.mutate((current) => [...current, 'music']);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      other,
+      { $type: PREF_TYPE, tags: ['art', 'music'] },
+    ]);
+    expect(result.current.data).toEqual(['art', 'music']);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('defaults to an empty list when no existing pref', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateInterests(), { wrapper });
+
+    result.current.mutate(() => ['tech']);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [{ $type: PREF_TYPE, tags: ['tech'] }]);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateInterests(), { wrapper });
+
+    result.current.mutate(() => ['x']);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateInterests(), { wrapper });
+
+    result.current.mutate(() => ['x']);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateLabelersPref.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateLabelersPref.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateLabelersPref } from '@/hooks/mutations/useUpdateLabelersPref';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#labelersPref';
+
+describe('useUpdateLabelersPref mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('swaps the labelers slot and puts the merged list back', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const other = { $type: 'app.bsky.actor.defs#adultContentPref', enabled: false };
+    mockGetPreferences.mockResolvedValueOnce({
+      preferences: [other, { $type: PREF_TYPE, labelers: [{ did: 'did:a' }] }],
+    });
+    const { result } = renderHook(() => useUpdateLabelersPref(), { wrapper });
+
+    result.current.mutate((current) => [...current, { did: 'did:b' }]);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      other,
+      { $type: PREF_TYPE, labelers: [{ did: 'did:a' }, { did: 'did:b' }] },
+    ]);
+    expect(result.current.data).toEqual([{ did: 'did:a' }, { did: 'did:b' }]);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('defaults to an empty list when no existing pref', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateLabelersPref(), { wrapper });
+
+    result.current.mutate(() => [{ did: 'did:c' }]);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      { $type: PREF_TYPE, labelers: [{ did: 'did:c' }] },
+    ]);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateLabelersPref(), { wrapper });
+
+    result.current.mutate(() => []);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateLabelersPref(), { wrapper });
+
+    result.current.mutate(() => []);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateLoggedOutVisibility.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateLoggedOutVisibility.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateLoggedOutVisibility } from '@/hooks/mutations/useUpdateLoggedOutVisibility';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockSetLoggedOutVisibilityDiscouraged = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    setLoggedOutVisibilityDiscouraged: mockSetLoggedOutVisibilityDiscouraged,
+  })),
+}));
+
+describe('useUpdateLoggedOutVisibility mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockSetLoggedOutVisibilityDiscouraged.mockResolvedValue(undefined);
+  });
+
+  it('sets the no-unauthenticated label and invalidates the profile', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateLoggedOutVisibility(), { wrapper });
+
+    result.current.mutate(true);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockSetLoggedOutVisibilityDiscouraged).toHaveBeenCalledWith('token', 'did', true);
+    expect(result.current.data).toBe(true);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['profile'] });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateLoggedOutVisibility(), { wrapper });
+
+    result.current.mutate(false);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetLoggedOutVisibilityDiscouraged).not.toHaveBeenCalled();
+  });
+
+  it('errors when DID missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateLoggedOutVisibility(), { wrapper });
+
+    result.current.mutate(false);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetLoggedOutVisibilityDiscouraged).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateLoggedOutVisibility(), { wrapper });
+
+    result.current.mutate(false);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetLoggedOutVisibilityDiscouraged).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateMutedWords.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateMutedWords.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateMutedWords } from '@/hooks/mutations/useUpdateMutedWords';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#mutedWordsPref';
+
+describe('useUpdateMutedWords mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('swaps the muted-words slot and puts the merged list back', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const other = { $type: 'app.bsky.actor.defs#adultContentPref', enabled: false };
+    const existingWord = { value: 'spoiler', targets: ['content'] };
+    mockGetPreferences.mockResolvedValueOnce({
+      preferences: [other, { $type: PREF_TYPE, items: [existingWord] }],
+    });
+    const newWord = { value: 'politics', targets: ['content'] };
+    const { result } = renderHook(() => useUpdateMutedWords(), { wrapper });
+
+    result.current.mutate((current) => [...current, newWord] as any);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      other,
+      { $type: PREF_TYPE, items: [existingWord, newWord] },
+    ]);
+    expect(result.current.data).toEqual([existingWord, newWord]);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('defaults to an empty list when no existing pref', async () => {
+    const { wrapper } = createWrapper();
+    const word = { value: 'x', targets: ['content'] };
+    const { result } = renderHook(() => useUpdateMutedWords(), { wrapper });
+
+    result.current.mutate(() => [word] as any);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [{ $type: PREF_TYPE, items: [word] }]);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateMutedWords(), { wrapper });
+
+    result.current.mutate(() => []);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateMutedWords(), { wrapper });
+
+    result.current.mutate(() => []);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateNotificationPreferences.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateNotificationPreferences.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateNotificationPreferences } from '@/hooks/mutations/useUpdateNotificationPreferences';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockPutNotificationPreferencesV2 = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    putNotificationPreferencesV2: mockPutNotificationPreferencesV2,
+  })),
+}));
+
+describe('useUpdateNotificationPreferences mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockPutNotificationPreferencesV2.mockResolvedValue({});
+  });
+
+  it('patches notification preferences and invalidates the per-did prefs key', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const patch = { like: { list: true, push: false } } as any;
+    const { result } = renderHook(() => useUpdateNotificationPreferences(), { wrapper });
+
+    result.current.mutate(patch);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutNotificationPreferencesV2).toHaveBeenCalledWith('token', patch);
+    expect(result.current.data).toEqual(patch);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['notifications', 'preferences', 'did', undefined],
+    });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateNotificationPreferences(), { wrapper });
+
+    result.current.mutate({});
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockPutNotificationPreferencesV2).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateNotificationPreferences(), { wrapper });
+
+    result.current.mutate({});
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockPutNotificationPreferencesV2).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdatePersonalDetails.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdatePersonalDetails.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdatePersonalDetails } from '@/hooks/mutations/useUpdatePersonalDetails';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#personalDetailsPref';
+
+describe('useUpdatePersonalDetails mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('writes the birthDate and puts the merged list back', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const other = { $type: 'app.bsky.actor.defs#adultContentPref', enabled: false };
+    mockGetPreferences.mockResolvedValueOnce({
+      preferences: [other, { $type: PREF_TYPE, birthDate: '1990-01-01' }],
+    });
+    const { result } = renderHook(() => useUpdatePersonalDetails(), { wrapper });
+
+    result.current.mutate({ birthDate: '2000-12-31' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      other,
+      { $type: PREF_TYPE, birthDate: '2000-12-31' },
+    ]);
+    expect(result.current.data).toBe('2000-12-31');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('omits birthDate when not provided', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdatePersonalDetails(), { wrapper });
+
+    result.current.mutate({});
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [{ $type: PREF_TYPE }]);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdatePersonalDetails(), { wrapper });
+
+    result.current.mutate({ birthDate: '2000-01-01' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdatePersonalDetails(), { wrapper });
+
+    result.current.mutate({ birthDate: '2000-01-01' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdatePostInteractionSettings.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdatePostInteractionSettings.test.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdatePostInteractionSettings } from '@/hooks/mutations/useUpdatePostInteractionSettings';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#postInteractionSettingsPref';
+
+describe('useUpdatePostInteractionSettings mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('encodes anyone-mode with no rules and allowed quotes', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const input = {
+      mode: 'anyone' as const,
+      followers: false,
+      following: false,
+      mentioned: false,
+      allowQuotes: true,
+      allowedLists: [],
+    };
+    const { result } = renderHook(() => useUpdatePostInteractionSettings(), { wrapper });
+
+    result.current.mutate(input);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    // no threadgate rules (undefined) and quotes allowed -> empty pref body.
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [{ $type: PREF_TYPE }]);
+    expect(result.current.data).toEqual(input);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('encodes nobody-mode as an empty allow-rules array', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdatePostInteractionSettings(), { wrapper });
+
+    result.current.mutate({
+      mode: 'nobody',
+      followers: true,
+      following: true,
+      mentioned: true,
+      allowQuotes: true,
+      allowedLists: ['at://list/1'],
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      { $type: PREF_TYPE, threadgateAllowRules: [] },
+    ]);
+  });
+
+  it('encodes follower/following/mention/list rules and disables quotes', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdatePostInteractionSettings(), { wrapper });
+
+    result.current.mutate({
+      mode: 'anyone',
+      followers: true,
+      following: true,
+      mentioned: true,
+      allowQuotes: false,
+      allowedLists: ['at://list/1', 'at://list/2'],
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      {
+        $type: PREF_TYPE,
+        threadgateAllowRules: [
+          { $type: 'app.bsky.feed.threadgate#followerRule' },
+          { $type: 'app.bsky.feed.threadgate#followingRule' },
+          { $type: 'app.bsky.feed.threadgate#mentionRule' },
+          { $type: 'app.bsky.feed.threadgate#listRule', list: 'at://list/1' },
+          { $type: 'app.bsky.feed.threadgate#listRule', list: 'at://list/2' },
+        ],
+        postgateEmbeddingRules: [{ $type: 'app.bsky.feed.postgate#disableRule' }],
+      },
+    ]);
+  });
+
+  it('replaces an existing pref slot, preserving others', async () => {
+    const { wrapper } = createWrapper();
+    const other = { $type: 'app.bsky.actor.defs#adultContentPref', enabled: false };
+    mockGetPreferences.mockResolvedValueOnce({
+      preferences: [other, { $type: PREF_TYPE, threadgateAllowRules: [] }],
+    });
+    const { result } = renderHook(() => useUpdatePostInteractionSettings(), { wrapper });
+
+    result.current.mutate({
+      mode: 'anyone',
+      followers: false,
+      following: false,
+      mentioned: false,
+      allowQuotes: true,
+      allowedLists: [],
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [other, { $type: PREF_TYPE }]);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdatePostInteractionSettings(), { wrapper });
+
+    result.current.mutate({
+      mode: 'anyone',
+      followers: false,
+      following: false,
+      mentioned: false,
+      allowQuotes: true,
+      allowedLists: [],
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdatePostInteractionSettings(), { wrapper });
+
+    result.current.mutate({
+      mode: 'anyone',
+      followers: false,
+      following: false,
+      mentioned: false,
+      allowQuotes: true,
+      allowedLists: [],
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateSavedFeeds.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateSavedFeeds.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateSavedFeeds } from '@/hooks/mutations/useUpdateSavedFeeds';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#savedFeedsPrefV2';
+
+describe('useUpdateSavedFeeds mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('rewrites the saved-feeds slot and puts the merged list back', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const other = { $type: 'app.bsky.actor.defs#adultContentPref', enabled: false };
+    const existingItem = { id: '1', type: 'feed', value: 'at://feed/1', pinned: true };
+    mockGetPreferences.mockResolvedValueOnce({
+      preferences: [other, { $type: PREF_TYPE, items: [existingItem] }],
+    });
+    const newItem = { id: '2', type: 'feed', value: 'at://feed/2', pinned: false };
+    const { result } = renderHook(() => useUpdateSavedFeeds(), { wrapper });
+
+    result.current.mutate((current) => [...current, newItem] as any);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      other,
+      { $type: PREF_TYPE, items: [existingItem, newItem] },
+    ]);
+    expect(result.current.data).toEqual([existingItem, newItem]);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('defaults to an empty list when no existing pref', async () => {
+    const { wrapper } = createWrapper();
+    const item = { id: '1', type: 'feed', value: 'at://feed/1', pinned: true };
+    const { result } = renderHook(() => useUpdateSavedFeeds(), { wrapper });
+
+    result.current.mutate(() => [item] as any);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [{ $type: PREF_TYPE, items: [item] }]);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateSavedFeeds(), { wrapper });
+
+    result.current.mutate(() => []);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateSavedFeeds(), { wrapper });
+
+    result.current.mutate(() => []);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateThreadPreferences.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateThreadPreferences.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateThreadPreferences } from '@/hooks/mutations/useUpdateThreadPreferences';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#threadViewPref';
+
+describe('useUpdateThreadPreferences mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('writes thread view prefs and puts the merged list back', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const other = { $type: 'app.bsky.actor.defs#adultContentPref', enabled: false };
+    mockGetPreferences.mockResolvedValueOnce({
+      preferences: [other, { $type: PREF_TYPE, sort: 'oldest', prioritizeFollowedUsers: false }],
+    });
+    const input = { sort: 'hotness' as const, prioritizeFollowedUsers: true };
+    const { result } = renderHook(() => useUpdateThreadPreferences(), { wrapper });
+
+    result.current.mutate(input);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      other,
+      { $type: PREF_TYPE, sort: 'hotness', prioritizeFollowedUsers: true },
+    ]);
+    expect(result.current.data).toEqual(input);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateThreadPreferences(), { wrapper });
+
+    result.current.mutate({ sort: 'hotness', prioritizeFollowedUsers: false });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateThreadPreferences(), { wrapper });
+
+    result.current.mutate({ sort: 'hotness', prioritizeFollowedUsers: false });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useVotePoll.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useVotePoll.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useVotePoll } from '@/hooks/mutations/useVotePoll';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { recordLocalVote, clearLocalVote, type PollVotes } from '@/hooks/queries/usePoll';
+
+const mockCreatePollVote = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/usePoll', () => ({
+  recordLocalVote: jest.fn(),
+  clearLocalVote: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createPollVote: mockCreatePollVote,
+  })),
+}));
+
+const poll = { uri: 'at://poll', cid: 'cid' };
+
+describe('useVotePoll mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockCreatePollVote.mockResolvedValue({ uri: 'at://vote' });
+  });
+
+  it('casts a vote and records it locally', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useVotePoll(), { wrapper });
+
+    result.current.mutate({ poll, optionIndex: 1 });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreatePollVote).toHaveBeenCalledWith('token', 'did:current', {
+      poll,
+      optionIndex: 1,
+    });
+    expect(recordLocalVote).toHaveBeenCalledWith('at://poll', 'did:current', 1);
+  });
+
+  it('optimistically bumps the tally cache for a first-time vote', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const key = ['pollVotes', 'at://poll', 'did:current'];
+    queryClient.setQueryData<PollVotes>(key, {
+      counts: [2, 0],
+      total: 2,
+      sampled: 2,
+      myOptionIndex: null,
+    });
+
+    const { result } = renderHook(() => useVotePoll(), { wrapper });
+    result.current.mutate({ poll, optionIndex: 1 });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const updated = queryClient.getQueryData<PollVotes>(key);
+    expect(updated).toEqual({
+      counts: [2, 1],
+      total: 3,
+      sampled: 3,
+      myOptionIndex: 1,
+    });
+  });
+
+  it('does not re-bump when the viewer already voted', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const key = ['pollVotes', 'at://poll', 'did:current'];
+    queryClient.setQueryData<PollVotes>(key, {
+      counts: [1, 1],
+      total: 2,
+      sampled: 2,
+      myOptionIndex: 0,
+    });
+
+    const { result } = renderHook(() => useVotePoll(), { wrapper });
+    result.current.mutate({ poll, optionIndex: 1 });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(queryClient.getQueryData<PollVotes>(key)).toEqual({
+      counts: [1, 1],
+      total: 2,
+      sampled: 2,
+      myOptionIndex: 0,
+    });
+  });
+
+  it('rolls back the optimistic vote on error', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const key = ['pollVotes', 'at://poll', 'did:current'];
+    const previous: PollVotes = { counts: [2, 0], total: 2, sampled: 2, myOptionIndex: null };
+    queryClient.setQueryData<PollVotes>(key, previous);
+    mockCreatePollVote.mockRejectedValueOnce(new Error('fail'));
+
+    const { result } = renderHook(() => useVotePoll(), { wrapper });
+    result.current.mutate({ poll, optionIndex: 1 });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(clearLocalVote).toHaveBeenCalledWith('at://poll', 'did:current');
+    expect(queryClient.getQueryData<PollVotes>(key)).toEqual(previous);
+  });
+
+  it('errors when not signed in', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useVotePoll(), { wrapper });
+
+    result.current.mutate({ poll, optionIndex: 0 });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreatePollVote).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useAiPreferences.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useAiPreferences.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useAiPreferences } from '@/hooks/queries/useAiPreferences';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetAiPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getAiPreferences: mockGetAiPreferences,
+  })),
+}));
+
+describe('useAiPreferences query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+  });
+
+  it('fetches the AI preferences record', async () => {
+    const record = { value: { allowAi: true } };
+    mockGetAiPreferences.mockResolvedValueOnce(record);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAiPreferences(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetAiPreferences).toHaveBeenCalledWith('token', 'did:me');
+    expect(result.current.data).toEqual(record);
+  });
+
+  it('returns null for accounts without a record', async () => {
+    mockGetAiPreferences.mockResolvedValueOnce(null);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAiPreferences(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toBeNull();
+  });
+
+  it('is disabled when token is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAiPreferences(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetAiPreferences).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when did is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAiPreferences(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetAiPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useAppPasswords.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useAppPasswords.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useAppPasswords } from '@/hooks/queries/useAppPasswords';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockListAppPasswords = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    listAppPasswords: mockListAppPasswords,
+  })),
+}));
+
+describe('useAppPasswords query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+  });
+
+  it('lists app passwords and unwraps the passwords array', async () => {
+    const passwords = [{ name: 'phone', createdAt: '2024-01-01T00:00:00Z' }];
+    mockListAppPasswords.mockResolvedValueOnce({ passwords });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAppPasswords(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockListAppPasswords).toHaveBeenCalledWith('token');
+    expect(result.current.data).toEqual(passwords);
+  });
+
+  it('is disabled when token is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAppPasswords(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockListAppPasswords).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when pdsUrl is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:me' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAppPasswords(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockListAppPasswords).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useAuthorRecipes.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useAuthorRecipes.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useAuthorRecipes } from '@/hooks/queries/useAuthorRecipes';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { usePdsUrl } from '@/hooks/queries/usePdsUrl';
+
+const mockGetActorRecipes = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/usePdsUrl', () => ({
+  usePdsUrl: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getActorRecipes: mockGetActorRecipes,
+  })),
+}));
+
+describe('useAuthorRecipes query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (usePdsUrl as jest.Mock).mockReturnValue({ data: 'https://pds', isLoading: false });
+  });
+
+  it('fetches recipes and flattens pages across fetchNextPage', async () => {
+    mockGetActorRecipes
+      .mockResolvedValueOnce({ records: [{ uri: 'r1' }], cursor: 'next' })
+      .mockResolvedValueOnce({ records: [{ uri: 'r2' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRecipes('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorRecipes).toHaveBeenCalledWith('token', 'alice', 5, undefined);
+    expect(result.current.data).toEqual([{ uri: 'r1' }]);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ uri: 'r1' }, { uri: 'r2' }]);
+    });
+    expect(mockGetActorRecipes).toHaveBeenLastCalledWith('token', 'alice', 5, 'next');
+  });
+
+  it('defaults the limit to 50', async () => {
+    mockGetActorRecipes.mockResolvedValueOnce({ records: [], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRecipes('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorRecipes).toHaveBeenCalledWith('token', 'alice', 50, undefined);
+  });
+
+  it('is disabled when there is no token', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRecipes('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorRecipes).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when there is no identifier', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRecipes(undefined, 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorRecipes).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when the PDS URL is still loading', async () => {
+    (usePdsUrl as jest.Mock).mockReturnValue({ data: 'https://pds', isLoading: true });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRecipes('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorRecipes).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useAuthorRepos.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useAuthorRepos.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useAuthorRepos } from '@/hooks/queries/useAuthorRepos';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetActorRepos = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getActorRepos: mockGetActorRepos,
+  })),
+}));
+
+describe('useAuthorRepos query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+  });
+
+  it('fetches repos and flattens pages across fetchNextPage', async () => {
+    mockGetActorRepos
+      .mockResolvedValueOnce({ records: [{ uri: 'repo1' }], cursor: 'next' })
+      .mockResolvedValueOnce({ records: [{ uri: 'repo2' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRepos('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorRepos).toHaveBeenCalledWith('token', 'alice', 5, undefined);
+    expect(result.current.data).toEqual([{ uri: 'repo1' }]);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ uri: 'repo1' }, { uri: 'repo2' }]);
+    });
+    expect(mockGetActorRepos).toHaveBeenLastCalledWith('token', 'alice', 5, 'next');
+  });
+
+  it('defaults the limit to 50', async () => {
+    mockGetActorRepos.mockResolvedValueOnce({ records: [], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRepos('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorRepos).toHaveBeenCalledWith('token', 'alice', 50, undefined);
+  });
+
+  it('throws when the PDS URL is missing at fetch time', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: {} });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRepos('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect((result.current.error as Error).message).toBe('No PDS URL available');
+    expect(mockGetActorRepos).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when there is no token', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRepos('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorRepos).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when there is no identifier', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRepos(undefined, 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorRepos).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useAuthorReposts.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useAuthorReposts.test.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useAuthorReposts } from '@/hooks/queries/useAuthorReposts';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useAppViewEnabled } from '@/hooks/useAppViewEnabled';
+import { useAcceptLabelerDids } from '@/hooks/queries/useAcceptLabelerDids';
+
+const mockGetAuthorFeed = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewEnabled', () => ({
+  useAppViewEnabled: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useAcceptLabelerDids', () => ({
+  useAcceptLabelerDids: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getAuthorFeed: mockGetAuthorFeed,
+  })),
+}));
+
+const repostReason = { $type: 'app.bsky.feed.defs#reasonRepost' };
+
+describe('useAuthorReposts query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+    (useAcceptLabelerDids as jest.Mock).mockReturnValue(['did:labeler']);
+  });
+
+  it('keeps only reposts, dedupes by uri, and flattens pages', async () => {
+    mockGetAuthorFeed
+      .mockResolvedValueOnce({
+        feed: [
+          { post: { uri: 'a' }, reason: repostReason },
+          { post: { uri: 'b' } }, // not a repost, dropped
+          { post: { uri: 'a' }, reason: repostReason }, // duplicate, deduped
+        ],
+        cursor: 'next',
+      })
+      .mockResolvedValueOnce({
+        feed: [{ post: { uri: 'c' }, reason: repostReason }],
+        cursor: undefined,
+      });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorReposts('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetAuthorFeed).toHaveBeenCalledWith(
+      'token',
+      'alice',
+      5,
+      undefined,
+      undefined,
+      ['did:labeler'],
+    );
+    expect(result.current.data).toEqual([{ uri: 'a' }]);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ uri: 'a' }, { uri: 'c' }]);
+    });
+    expect(mockGetAuthorFeed).toHaveBeenLastCalledWith(
+      'token',
+      'alice',
+      5,
+      'next',
+      undefined,
+      ['did:labeler'],
+    );
+  });
+
+  it('uses the guest path with an empty token when no token is present', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    mockGetAuthorFeed.mockResolvedValueOnce({
+      feed: [{ post: { uri: 'a' }, reason: repostReason }],
+      cursor: undefined,
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorReposts('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetAuthorFeed).toHaveBeenCalledWith(
+      '',
+      'alice',
+      5,
+      undefined,
+      undefined,
+      ['did:labeler'],
+    );
+    expect(result.current.data).toEqual([{ uri: 'a' }]);
+  });
+
+  it('uses the guest path when the account has no PDS URL', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: {} });
+    mockGetAuthorFeed.mockResolvedValueOnce({
+      feed: [{ post: { uri: 'a' }, reason: repostReason }],
+      cursor: undefined,
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorReposts('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetAuthorFeed).toHaveBeenCalledWith(
+      '',
+      'alice',
+      5,
+      undefined,
+      undefined,
+      ['did:labeler'],
+    );
+  });
+
+  it('throws when no identifier is provided', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorReposts(undefined, 5), { wrapper });
+
+    const fetchResult = await result.current.fetchNextPage();
+    expect((fetchResult.error as Error).message).toBe('No identifier provided');
+    expect(mockGetAuthorFeed).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useBlocks.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useBlocks.test.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useBlocks } from '@/hooks/queries/useBlocks';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useAppViewEnabled } from '@/hooks/useAppViewEnabled';
+import { getAuthor, pdsListRecords } from '@/hooks/queries/microcosm';
+
+const mockGetBlocks = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewEnabled', () => ({
+  useAppViewEnabled: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+}));
+
+jest.mock('@/hooks/queries/microcosm', () => ({
+  getAuthor: jest.fn(),
+  pdsListRecords: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getBlocks: mockGetBlocks,
+  })),
+}));
+
+describe('useBlocks query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+    (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+  });
+
+  it('fetches blocks through the AppView when enabled', async () => {
+    const response = { blocks: [{ did: 'did:blocked' }], cursor: undefined };
+    mockGetBlocks.mockResolvedValueOnce(response);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBlocks(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetBlocks).toHaveBeenCalledWith('token', 50, undefined);
+    expect(result.current.data?.pages[0]).toEqual(response);
+  });
+
+  it('hydrates blocks from the PDS when the AppView is disabled (microcosm path)', async () => {
+    (useAppViewEnabled as jest.Mock).mockReturnValue(false);
+    (pdsListRecords as jest.Mock).mockResolvedValueOnce({
+      records: [
+        {
+          uri: 'at://did:me/app.bsky.graph.block/1',
+          value: { subject: 'did:blocked', createdAt: '2024-01-01T00:00:00Z' },
+        },
+      ],
+      cursor: 'next',
+    });
+    (getAuthor as jest.Mock).mockResolvedValueOnce({
+      did: 'did:blocked',
+      handle: 'blocked.test',
+      displayName: 'Blocked',
+      avatar: 'a.jpg',
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBlocks(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(pdsListRecords).toHaveBeenCalledWith({
+      pdsUrl: 'https://pds',
+      repo: 'did:me',
+      collection: 'app.bsky.graph.block',
+      limit: 50,
+      cursor: undefined,
+    });
+    expect(mockGetBlocks).not.toHaveBeenCalled();
+    expect(result.current.data?.pages[0]).toEqual({
+      blocks: [
+        {
+          did: 'did:blocked',
+          handle: 'blocked.test',
+          displayName: 'Blocked',
+          avatar: 'a.jpg',
+          indexedAt: '2024-01-01T00:00:00Z',
+          viewer: { blocking: 'at://did:me/app.bsky.graph.block/1' },
+          labels: [],
+        },
+      ],
+      cursor: 'next',
+    });
+  });
+
+  it('is disabled when token is missing and AppView enabled', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBlocks(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetBlocks).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when did is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBlocks(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useBookmarks.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useBookmarks.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useBookmarks } from '@/hooks/queries/useBookmarks';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useAcceptLabelerDids } from '@/hooks/queries/useAcceptLabelerDids';
+import { useAppViewEnabled } from '@/hooks/useAppViewEnabled';
+import { readAppViewEnabled } from '@/hooks/useAppViewSettings';
+
+const mockGetBookmarks = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useAcceptLabelerDids', () => ({
+  useAcceptLabelerDids: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewEnabled', () => ({
+  useAppViewEnabled: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewEnabled: jest.fn(),
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getBookmarks: mockGetBookmarks,
+  })),
+}));
+
+describe('useBookmarks query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+    (useAcceptLabelerDids as jest.Mock).mockReturnValue(['did:labeler']);
+    (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+    (readAppViewEnabled as jest.Mock).mockReturnValue(true);
+  });
+
+  it('fetches bookmarks and paginates by cursor', async () => {
+    mockGetBookmarks
+      .mockResolvedValueOnce({ bookmarks: [{ uri: 'a' }], cursor: 'next' })
+      .mockResolvedValueOnce({ bookmarks: [{ uri: 'b' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBookmarks(10), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetBookmarks).toHaveBeenCalledWith('token', 10, undefined, ['did:labeler']);
+    expect(result.current.data?.pages[0]).toEqual({ bookmarks: [{ uri: 'a' }], cursor: 'next' });
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.pages).toHaveLength(2);
+    });
+    expect(mockGetBookmarks).toHaveBeenLastCalledWith('token', 10, 'next', ['did:labeler']);
+  });
+
+  it('uses the default limit of 50 when omitted', async () => {
+    mockGetBookmarks.mockResolvedValueOnce({ bookmarks: [], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBookmarks(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetBookmarks).toHaveBeenCalledWith('token', 50, undefined, ['did:labeler']);
+  });
+
+  it('throws AppViewRequiredError when the AppView is disabled', async () => {
+    (readAppViewEnabled as jest.Mock).mockReturnValue(false);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBookmarks(10), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect((result.current.error as Error).message).toContain('bookmarks');
+    expect(mockGetBookmarks).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when token is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBookmarks(10), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetBookmarks).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when did is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBookmarks(10), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetBookmarks).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useContentLanguages.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useContentLanguages.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { useContentLanguages } from '@/hooks/queries/useContentLanguages';
+import { usePreferences } from '@/hooks/queries/usePreferences';
+
+jest.mock('@/hooks/queries/usePreferences', () => ({
+  usePreferences: jest.fn(),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#contentLanguagesPref';
+
+describe('useContentLanguages query hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an empty list when there is no data', () => {
+    (usePreferences as jest.Mock).mockReturnValue({ data: undefined, isLoading: true });
+
+    const { result } = renderHook(() => useContentLanguages());
+
+    expect(result.current.data).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns an empty list when the pref is absent', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: 'other' }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useContentLanguages());
+
+    expect(result.current.data).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('returns the languages from the pref', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: PREF_TYPE, languages: ['en', 'ja'] }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useContentLanguages());
+
+    expect(result.current.data).toEqual(['en', 'ja']);
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useConvo.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useConvo.test.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useConvo } from '@/hooks/queries/useConvo';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useAppViewEnabled } from '@/hooks/useAppViewEnabled';
+import { readAppViewEnabled } from '@/hooks/useAppViewSettings';
+
+const mockGetConvo = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewEnabled', () => ({
+  useAppViewEnabled: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewEnabled: jest.fn(),
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getConvo: mockGetConvo,
+  })),
+}));
+
+describe('useConvo query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+    (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+    (readAppViewEnabled as jest.Mock).mockReturnValue(true);
+  });
+
+  it('fetches and transforms a one-on-one conversation', async () => {
+    mockGetConvo.mockResolvedValueOnce({
+      convo: {
+        id: 'convo-1',
+        members: [
+          { did: 'did:me', handle: 'me' },
+          { did: 'did:other', handle: 'alice', displayName: 'Alice', avatar: 'a.jpg', verification: 'v' },
+        ],
+        lastMessage: { text: 'hi', sentAt: '2023-01-01T00:00:00Z' },
+        unreadCount: 2,
+        status: 'accepted',
+        muted: false,
+      },
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useConvo('convo-1'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetConvo).toHaveBeenCalledWith('token', 'convo-1');
+    expect(result.current.data).toEqual({
+      id: 'convo-1',
+      convoId: 'convo-1',
+      handle: 'alice',
+      displayName: 'Alice',
+      avatar: 'a.jpg',
+      verification: 'v',
+      members: [
+        { did: 'did:other', handle: 'alice', displayName: 'Alice', avatar: 'a.jpg', verification: 'v' },
+      ],
+      isGroup: false,
+      lastMessage: 'hi',
+      timestamp: new Date('2023-01-01T00:00:00Z').toLocaleDateString(),
+      unreadCount: 2,
+      status: 'accepted',
+      muted: false,
+    });
+  });
+
+  it('flags group conversations and falls back to handle/no-message defaults', async () => {
+    mockGetConvo.mockResolvedValueOnce({
+      convo: {
+        id: 'convo-2',
+        members: [
+          { did: 'did:me', handle: 'me' },
+          { did: 'did:a', handle: 'alice' },
+          { did: 'did:b', handle: 'bob' },
+        ],
+        unreadCount: 0,
+        status: 'request',
+        muted: true,
+      },
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useConvo('convo-2'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data?.isGroup).toBe(true);
+    expect(result.current.data?.displayName).toBe('alice');
+    expect(result.current.data?.lastMessage).toBe('No messages yet');
+    expect(result.current.data?.timestamp).toBe('No messages');
+  });
+
+  it('errors when no other member is found', async () => {
+    mockGetConvo.mockResolvedValue({
+      convo: {
+        id: 'convo-3',
+        members: [{ did: 'did:me', handle: 'me' }],
+        unreadCount: 0,
+        status: 'accepted',
+        muted: false,
+      },
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useConvo('convo-3'), { wrapper });
+
+    await waitFor(
+      () => {
+        expect(result.current.isError).toBe(true);
+      },
+      { timeout: 5000 },
+    );
+    expect((result.current.error as Error).message).toBe('No other member found in conversation');
+  });
+
+  it('throws AppViewRequiredError when the AppView is disabled', async () => {
+    (readAppViewEnabled as jest.Mock).mockReturnValue(false);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useConvo('convo-1'), { wrapper });
+
+    await waitFor(
+      () => {
+        expect(result.current.isError).toBe(true);
+      },
+      { timeout: 5000 },
+    );
+    expect((result.current.error as Error).message).toContain('conversations');
+    expect(mockGetConvo).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when convoId is missing', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useConvo(undefined), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetConvo).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when token is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useConvo('convo-1'), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetConvo).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useGrainGalleries.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useGrainGalleries.test.tsx
@@ -1,0 +1,244 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import {
+  useGrainGalleries,
+  useGrainGalleryItems,
+  useGrainPhotos,
+  useGrainPhotoExif,
+  indexGrainPhotosByUri,
+  indexGrainExifByPhotoUri,
+  groupGalleryItems,
+} from '@/hooks/queries/useGrainGalleries';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { usePdsUrl } from '@/hooks/queries/usePdsUrl';
+
+const mockGetActorGalleries = jest.fn();
+const mockGetActorGrainGalleryItems = jest.fn();
+const mockGetActorGrainPhotos = jest.fn();
+const mockGetActorGrainPhotoExif = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/usePdsUrl', () => ({
+  usePdsUrl: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getActorGalleries: mockGetActorGalleries,
+    getActorGrainGalleryItems: mockGetActorGrainGalleryItems,
+    getActorGrainPhotos: mockGetActorGrainPhotos,
+    getActorGrainPhotoExif: mockGetActorGrainPhotoExif,
+  })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+  (usePdsUrl as jest.Mock).mockReturnValue({ data: 'https://pds', isLoading: false });
+});
+
+describe('useGrainGalleries query hook', () => {
+
+  it('fetches galleries and flattens pages across fetchNextPage', async () => {
+    mockGetActorGalleries
+      .mockResolvedValueOnce({ records: [{ uri: 'a' }], cursor: 'next' })
+      .mockResolvedValueOnce({ records: [{ uri: 'b' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainGalleries('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorGalleries).toHaveBeenCalledWith('token', 'alice', 5, undefined);
+    expect(result.current.data).toEqual([{ uri: 'a' }]);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ uri: 'a' }, { uri: 'b' }]);
+    });
+    expect(mockGetActorGalleries).toHaveBeenLastCalledWith('token', 'alice', 5, 'next');
+  });
+
+  it('uses the default limit of 30 when none is provided', async () => {
+    mockGetActorGalleries.mockResolvedValueOnce({ records: [], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainGalleries('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorGalleries).toHaveBeenCalledWith('token', 'alice', 30, undefined);
+  });
+
+  it('is disabled when there is no token', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainGalleries('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorGalleries).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when there is no identifier', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainGalleries(undefined, 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorGalleries).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when the PDS URL is missing', async () => {
+    (usePdsUrl as jest.Mock).mockReturnValue({ data: undefined, isLoading: false });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainGalleries('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorGalleries).not.toHaveBeenCalled();
+  });
+
+  it('is disabled while the PDS URL is still loading', async () => {
+    (usePdsUrl as jest.Mock).mockReturnValue({ data: 'https://pds', isLoading: true });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainGalleries('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorGalleries).not.toHaveBeenCalled();
+  });
+});
+
+describe('useGrainGalleryItems query hook', () => {
+  it('paginates and accumulates items until the cursor runs out', async () => {
+    mockGetActorGrainGalleryItems
+      .mockResolvedValueOnce({ records: [{ uri: 'i1' }], cursor: 'c1' })
+      .mockResolvedValueOnce({ records: [{ uri: 'i2' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainGalleryItems('alice', 50), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorGrainGalleryItems).toHaveBeenNthCalledWith(1, 'token', 'alice', 50, undefined);
+    expect(mockGetActorGrainGalleryItems).toHaveBeenNthCalledWith(2, 'token', 'alice', 50, 'c1');
+    expect(result.current.data).toEqual([{ uri: 'i1' }, { uri: 'i2' }]);
+  });
+
+  it('is disabled without a token', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainGalleryItems('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorGrainGalleryItems).not.toHaveBeenCalled();
+  });
+});
+
+describe('useGrainPhotos query hook', () => {
+  it('paginates and accumulates photos until the cursor runs out', async () => {
+    mockGetActorGrainPhotos
+      .mockResolvedValueOnce({ records: [{ uri: 'p1' }], cursor: 'c1' })
+      .mockResolvedValueOnce({ records: [{ uri: 'p2' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainPhotos('alice', 50), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual([{ uri: 'p1' }, { uri: 'p2' }]);
+  });
+
+  it('is disabled when the identifier is missing', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainPhotos(undefined), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorGrainPhotos).not.toHaveBeenCalled();
+  });
+});
+
+describe('useGrainPhotoExif query hook', () => {
+  it('fetches a single page of exif records', async () => {
+    mockGetActorGrainPhotoExif.mockResolvedValueOnce({ records: [{ uri: 'x1' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainPhotoExif('alice', 50), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorGrainPhotoExif).toHaveBeenCalledWith('token', 'alice', 50, undefined);
+    expect(result.current.data).toEqual([{ uri: 'x1' }]);
+  });
+});
+
+describe('grain helper functions', () => {
+  it('indexGrainPhotosByUri maps photos by uri and tolerates undefined', () => {
+    expect(indexGrainPhotosByUri(undefined).size).toBe(0);
+    const map = indexGrainPhotosByUri([
+      { uri: 'a' },
+      { uri: 'b' },
+    ] as never);
+    expect(map.get('a')).toEqual({ uri: 'a' });
+    expect(map.size).toBe(2);
+  });
+
+  it('indexGrainExifByPhotoUri keys by the described photo uri, skipping records without one', () => {
+    expect(indexGrainExifByPhotoUri(undefined).size).toBe(0);
+    const map = indexGrainExifByPhotoUri([
+      { uri: 'exif1', value: { photo: 'photoA' } },
+      { uri: 'exif2', value: {} },
+    ] as never);
+    expect(map.get('photoA')).toEqual({ uri: 'exif1', value: { photo: 'photoA' } });
+    expect(map.size).toBe(1);
+  });
+
+  it('groupGalleryItems buckets by gallery uri and sorts each bucket by position', () => {
+    expect(groupGalleryItems(undefined).size).toBe(0);
+    const map = groupGalleryItems([
+      { uri: 'i1', value: { gallery: 'g1', position: 2 } },
+      { uri: 'i2', value: { gallery: 'g1', position: 1 } },
+      { uri: 'i3', value: { gallery: 'g2' } },
+    ] as never);
+    expect(map.get('g1')?.map((item) => item.uri)).toEqual(['i2', 'i1']);
+    expect(map.get('g2')?.map((item) => item.uri)).toEqual(['i3']);
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useInterests.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useInterests.test.tsx
@@ -1,0 +1,47 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { useInterests } from '@/hooks/queries/useInterests';
+import { usePreferences } from '@/hooks/queries/usePreferences';
+
+jest.mock('@/hooks/queries/usePreferences', () => ({
+  usePreferences: jest.fn(),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#interestsPref';
+
+describe('useInterests query hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an empty list when there is no data', () => {
+    (usePreferences as jest.Mock).mockReturnValue({ data: undefined, isLoading: true });
+
+    const { result } = renderHook(() => useInterests());
+
+    expect(result.current.data).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns an empty list when the pref is absent', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: 'other' }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useInterests());
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('returns the tags from the pref', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: PREF_TYPE, tags: ['art', 'tech'] }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useInterests());
+
+    expect(result.current.data).toEqual(['art', 'tech']);
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useLists.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useLists.test.tsx
@@ -1,0 +1,289 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useLists, useListMembership } from '@/hooks/queries/useLists';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useAppViewEnabled } from '@/hooks/useAppViewEnabled';
+import {
+  getActorListsPage,
+  resolveIdentifierToDid,
+  resolvePdsUrl,
+} from '@/hooks/queries/microcosm';
+
+const mockGetLists = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewEnabled', () => ({
+  useAppViewEnabled: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+}));
+
+jest.mock('@/hooks/queries/microcosm', () => ({
+  getActorListsPage: jest.fn(),
+  resolveIdentifierToDid: jest.fn(),
+  resolvePdsUrl: jest.fn(),
+}));
+
+const mockGetList = jest.fn();
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getLists: mockGetLists,
+    getList: mockGetList,
+  })),
+}));
+
+describe('useLists query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+    (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+  });
+
+  it('fetches lists through the AppView for an explicit actor', async () => {
+    const response = { lists: [{ uri: 'at://list/1' }], cursor: undefined };
+    mockGetLists.mockResolvedValueOnce(response);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLists('did:actor'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetLists).toHaveBeenCalledWith('token', 'did:actor', 50, undefined);
+    expect(result.current.data?.pages[0]).toEqual(response);
+  });
+
+  it('defaults to the current user did when no actor is given', async () => {
+    mockGetLists.mockResolvedValueOnce({ lists: [], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLists(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetLists).toHaveBeenCalledWith('token', 'did:me', 50, undefined);
+  });
+
+  it('uses the known PDS for the current user on the microcosm path', async () => {
+    (useAppViewEnabled as jest.Mock).mockReturnValue(false);
+    (resolveIdentifierToDid as jest.Mock).mockResolvedValueOnce('did:me');
+    const response = { lists: [{ uri: 'at://list/1' }], cursor: undefined };
+    (getActorListsPage as jest.Mock).mockResolvedValueOnce(response);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLists('did:me'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(resolvePdsUrl).not.toHaveBeenCalled();
+    expect(getActorListsPage).toHaveBeenCalledWith({
+      did: 'did:me',
+      pdsUrl: 'https://pds',
+      limit: 50,
+      cursor: undefined,
+    });
+    expect(mockGetLists).not.toHaveBeenCalled();
+    expect(result.current.data?.pages[0]).toEqual(response);
+  });
+
+  it('resolves the PDS via DID document for other actors on the microcosm path', async () => {
+    (useAppViewEnabled as jest.Mock).mockReturnValue(false);
+    (resolveIdentifierToDid as jest.Mock).mockResolvedValueOnce('did:other');
+    (resolvePdsUrl as jest.Mock).mockResolvedValueOnce('https://other-pds');
+    (getActorListsPage as jest.Mock).mockResolvedValueOnce({ lists: [], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLists('did:other'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(resolvePdsUrl).toHaveBeenCalledWith('did:other');
+    expect(getActorListsPage).toHaveBeenCalledWith({
+      did: 'did:other',
+      pdsUrl: 'https://other-pds',
+      limit: 50,
+      cursor: undefined,
+    });
+  });
+
+  it('errors when the PDS cannot be resolved on the microcosm path', async () => {
+    (useAppViewEnabled as jest.Mock).mockReturnValue(false);
+    (resolveIdentifierToDid as jest.Mock).mockResolvedValueOnce('did:other');
+    (resolvePdsUrl as jest.Mock).mockResolvedValueOnce(undefined);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLists('did:other'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect((result.current.error as Error).message).toContain("Couldn't resolve PDS URL");
+  });
+
+  it('is disabled when there is no target', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLists(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetLists).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when token is missing and AppView enabled', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLists('did:actor'), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetLists).not.toHaveBeenCalled();
+  });
+});
+
+describe('useListMembership', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+    (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+  });
+
+  it('reports membership and the listitem uri when the subject is found', async () => {
+    mockGetList.mockResolvedValueOnce({
+      items: [
+        { uri: 'at://listitem/1', subject: { did: 'did:subject' } },
+        { uri: 'at://listitem/2', subject: { did: 'did:other' } },
+      ],
+      cursor: undefined,
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useListMembership('at://list/1', 'did:subject'),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isMember).toBe(true);
+    });
+    expect(mockGetList).toHaveBeenCalledWith('token', 'at://list/1', 50, undefined);
+    expect(result.current.listItemUri).toBe('at://listitem/1');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('walks pages until the subject is found', async () => {
+    mockGetList
+      .mockResolvedValueOnce({
+        items: [{ uri: 'at://listitem/1', subject: { did: 'did:other' } }],
+        cursor: 'next',
+      })
+      .mockResolvedValueOnce({
+        items: [{ uri: 'at://listitem/2', subject: { did: 'did:subject' } }],
+        cursor: undefined,
+      });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useListMembership('at://list/1', 'did:subject'),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isMember).toBe(true);
+    });
+    expect(result.current.listItemUri).toBe('at://listitem/2');
+    expect(mockGetList).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports no membership when the subject is absent and pages are exhausted', async () => {
+    mockGetList.mockResolvedValueOnce({
+      items: [{ uri: 'at://listitem/1', subject: { did: 'did:other' } }],
+      cursor: undefined,
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useListMembership('at://list/1', 'did:subject'),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.isMember).toBe(false);
+    expect(result.current.listItemUri).toBeUndefined();
+  });
+
+  it('is not a member when no subject is provided', async () => {
+    mockGetList.mockResolvedValueOnce({
+      items: [{ uri: 'at://listitem/1', subject: { did: 'did:other' } }],
+      cursor: undefined,
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useListMembership('at://list/1', undefined),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.isMember).toBe(false);
+    expect(result.current.listItemUri).toBeUndefined();
+  });
+
+  it('is disabled when no list uri is provided', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useListMembership(undefined, 'did:subject'),
+      { wrapper },
+    );
+
+    expect(result.current.isMember).toBe(false);
+    expect(mockGetList).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useNotificationPreferences.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useNotificationPreferences.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useNotificationPreferences } from '@/hooks/queries/useNotificationPreferences';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useAppViewEnabled } from '@/hooks/useAppViewEnabled';
+import { readAppViewEnabled } from '@/hooks/useAppViewSettings';
+
+const mockGetNotificationPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewEnabled', () => ({
+  useAppViewEnabled: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewEnabled: jest.fn(),
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getNotificationPreferences: mockGetNotificationPreferences,
+  })),
+}));
+
+describe('useNotificationPreferences query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+    (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+    (readAppViewEnabled as jest.Mock).mockReturnValue(true);
+  });
+
+  it('fetches notification preferences', async () => {
+    const prefs = { chat: { include: 'all' } };
+    mockGetNotificationPreferences.mockResolvedValueOnce(prefs);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useNotificationPreferences(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetNotificationPreferences).toHaveBeenCalledWith('token');
+    expect(result.current.data).toEqual(prefs);
+  });
+
+  it('throws AppViewRequiredError when the AppView is disabled', async () => {
+    (readAppViewEnabled as jest.Mock).mockReturnValue(false);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useNotificationPreferences(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect((result.current.error as Error).message).toContain('notifications');
+    expect(mockGetNotificationPreferences).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when token is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useNotificationPreferences(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetNotificationPreferences).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when pdsUrl is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:me' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useNotificationPreferences(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetNotificationPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useOzoneAdminQueries.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useOzoneAdminQueries.test.tsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  useSafelinkRules,
+  useAddSafelinkRule,
+  useRemoveSafelinkRule,
+  useOzoneSets,
+  useOzoneVerifications,
+  useFindRelatedAccounts,
+} from '@/hooks/queries/useOzoneAdminQueries';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+
+const mockQuerySafelinkRules = jest.fn();
+const mockAddSafelinkRule = jest.fn();
+const mockRemoveSafelinkRule = jest.fn();
+const mockListSets = jest.fn();
+const mockListVerifications = jest.fn();
+const mockFindRelatedAccounts = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/useOzoneSettings', () => ({
+  useOzoneDid: jest.fn(),
+}));
+
+jest.mock('@/utils/blueskyOzone', () => ({
+  ozoneForAccount: jest.fn(),
+}));
+
+describe('useOzoneAdminQueries', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper, invalidateSpy };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({
+      querySafelinkRules: mockQuerySafelinkRules,
+      addSafelinkRule: mockAddSafelinkRule,
+      removeSafelinkRule: mockRemoveSafelinkRule,
+      listSets: mockListSets,
+      listVerifications: mockListVerifications,
+      findRelatedAccounts: mockFindRelatedAccounts,
+    });
+  });
+
+  it('useSafelinkRules fetches rules', async () => {
+    mockQuerySafelinkRules.mockResolvedValue({ rules: [{ id: 'r1' }] });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSafelinkRules(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockQuerySafelinkRules).toHaveBeenCalledWith('token', 'did:ozone', { limit: 100 });
+    expect(result.current.data).toEqual([{ id: 'r1' }]);
+  });
+
+  it('useSafelinkRules is disabled without token', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSafelinkRules(), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockQuerySafelinkRules).not.toHaveBeenCalled();
+  });
+
+  it('useOzoneSets fetches sets', async () => {
+    mockListSets.mockResolvedValue({ sets: [{ name: 's1' }] });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneSets(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockListSets).toHaveBeenCalledWith('token', 'did:ozone', { limit: 100 });
+    expect(result.current.data).toEqual([{ name: 's1' }]);
+  });
+
+  it('useOzoneVerifications fetches verifications', async () => {
+    mockListVerifications.mockResolvedValue({ verifications: [{ id: 'v1' }] });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneVerifications(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockListVerifications).toHaveBeenCalledWith('token', 'did:ozone', { limit: 100 });
+    expect(result.current.data).toEqual([{ id: 'v1' }]);
+  });
+
+  it('useFindRelatedAccounts fetches related accounts', async () => {
+    mockFindRelatedAccounts.mockResolvedValue({ accounts: [{ did: 'did:x' }] });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFindRelatedAccounts('did:target'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockFindRelatedAccounts).toHaveBeenCalledWith('token', 'did:ozone', 'did:target');
+    expect(result.current.data).toEqual([{ did: 'did:x' }]);
+  });
+
+  it('useFindRelatedAccounts is disabled without a did', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFindRelatedAccounts(undefined), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockFindRelatedAccounts).not.toHaveBeenCalled();
+  });
+
+  it('useAddSafelinkRule calls the API with createdBy and invalidates', async () => {
+    mockAddSafelinkRule.mockResolvedValue({});
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useAddSafelinkRule(), { wrapper });
+
+    result.current.mutate({
+      url: 'https://bad',
+      pattern: 'domain',
+      action: 'block',
+      reason: 'spam',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockAddSafelinkRule).toHaveBeenCalledWith('token', 'did:ozone', {
+      url: 'https://bad',
+      pattern: 'domain',
+      action: 'block',
+      reason: 'spam',
+      createdBy: 'did:current',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['ozone', 'safelink', 'rules'] });
+  });
+
+  it('useAddSafelinkRule throws when session missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAddSafelinkRule(), { wrapper });
+
+    result.current.mutate({ url: 'u', pattern: 'url', action: 'warn', reason: 'r' });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('useRemoveSafelinkRule calls the API and invalidates', async () => {
+    mockRemoveSafelinkRule.mockResolvedValue({});
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useRemoveSafelinkRule(), { wrapper });
+
+    result.current.mutate({ url: 'https://bad', pattern: 'domain' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockRemoveSafelinkRule).toHaveBeenCalledWith('token', 'did:ozone', {
+      url: 'https://bad',
+      pattern: 'domain',
+      createdBy: 'did:current',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['ozone', 'safelink', 'rules'] });
+  });
+
+  it('useRemoveSafelinkRule throws when PDS missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: undefined } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRemoveSafelinkRule(), { wrapper });
+
+    result.current.mutate({ url: 'u', pattern: 'url' });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useOzoneCommTemplates.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useOzoneCommTemplates.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useOzoneCommTemplates } from '@/hooks/queries/useOzoneCommTemplates';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+
+const mockListCommTemplates = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyOzone', () => ({ ozoneForAccount: jest.fn() }));
+
+describe('useOzoneCommTemplates hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({
+      listCommTemplates: mockListCommTemplates,
+    });
+  });
+
+  it('lists communication templates', async () => {
+    mockListCommTemplates.mockResolvedValue({
+      communicationTemplates: [{ id: 't1', name: 'Welcome' }],
+    });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneCommTemplates(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockListCommTemplates).toHaveBeenCalledWith('token', 'did:ozone');
+    expect(result.current.data).toEqual([{ id: 't1', name: 'Welcome' }]);
+  });
+
+  it('is disabled when ozoneDid missing', () => {
+    (useOzoneDid as jest.Mock).mockReturnValue('');
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneCommTemplates(), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockListCommTemplates).not.toHaveBeenCalled();
+  });
+
+  it('is disabled without a token', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneCommTemplates(), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useOzoneEvents.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useOzoneEvents.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useOzoneEvents } from '@/hooks/queries/useOzoneEvents';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+import { apiForAccount } from '@/utils/blueskyApi';
+import { fetchAvatarsByDid, subjectDid } from '@/utils/ozoneAvatars';
+
+const mockQueryEvents = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyOzone', () => ({ ozoneForAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+jest.mock('@/utils/ozoneAvatars', () => ({
+  fetchAvatarsByDid: jest.fn(),
+  subjectDid: jest.fn(),
+}));
+
+describe('useOzoneEvents hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({ queryEvents: mockQueryEvents });
+    (apiForAccount as jest.Mock).mockReturnValue({});
+    (fetchAvatarsByDid as jest.Mock).mockResolvedValue(new Map());
+    (subjectDid as jest.Mock).mockReturnValue(undefined);
+  });
+
+  it('queries events with filters and enriches avatars', async () => {
+    mockQueryEvents.mockResolvedValue({
+      events: [{ createdBy: 'did:c', subject: { did: 'did:s' } }],
+      cursor: 'next',
+    });
+    (subjectDid as jest.Mock).mockReturnValue('did:s');
+    (fetchAvatarsByDid as jest.Mock).mockResolvedValue(
+      new Map([
+        ['did:c', 'cav'],
+        ['did:s', 'sav'],
+      ]),
+    );
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneEvents({ types: ['x'] } as never, 20), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockQueryEvents).toHaveBeenCalledWith('token', 'did:ozone', {
+      types: ['x'],
+      limit: 20,
+      cursor: undefined,
+    });
+    expect(result.current.data?.pages[0].events[0]).toMatchObject({
+      creatorAvatar: 'cav',
+      subjectAvatar: 'sav',
+    });
+    expect(result.current.hasNextPage).toBe(true);
+  });
+
+  it('paginates using the cursor', async () => {
+    mockQueryEvents
+      .mockResolvedValueOnce({ events: [{ createdBy: 'a', subject: {} }], cursor: 'c1' })
+      .mockResolvedValueOnce({ events: [{ createdBy: 'b', subject: {} }], cursor: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneEvents({}, 10), { wrapper });
+
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(result.current.data?.pages.length).toBe(2));
+    expect(mockQueryEvents).toHaveBeenLastCalledWith('token', 'did:ozone', {
+      limit: 10,
+      cursor: 'c1',
+    });
+  });
+
+  it('falls back to raw response when enrichment throws', async () => {
+    mockQueryEvents.mockResolvedValue({ events: [{ createdBy: 'a', subject: {} }], cursor: undefined });
+    (fetchAvatarsByDid as jest.Mock).mockRejectedValue(new Error('boom'));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneEvents(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.pages[0]).toEqual({
+      events: [{ createdBy: 'a', subject: {} }],
+      cursor: undefined,
+    });
+  });
+
+  it('is disabled when ozoneDid missing', () => {
+    (useOzoneDid as jest.Mock).mockReturnValue('');
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneEvents(), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockQueryEvents).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useOzoneLabelOptions.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useOzoneLabelOptions.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useOzoneLabelOptions } from '@/hooks/queries/useOzoneLabelOptions';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { apiForAccount } from '@/utils/blueskyApi';
+
+const mockGetLabelerServices = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+
+const FALLBACK_TAGS = ['auto-flagged', 'repeat-offender', 'reviewed', 'needs-translation'];
+
+describe('useOzoneLabelOptions hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (apiForAccount as jest.Mock).mockReturnValue({
+      getLabelerServices: mockGetLabelerServices,
+    });
+  });
+
+  it('returns labeler-provided label values plus fallback tags', async () => {
+    mockGetLabelerServices.mockResolvedValue({
+      views: [{ policies: { labelValues: ['spam', 'porn'] } }],
+    });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneLabelOptions(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetLabelerServices).toHaveBeenCalledWith('token', ['did:ozone'], true);
+    expect(result.current.data).toEqual({ labels: ['spam', 'porn'], tags: FALLBACK_TAGS });
+  });
+
+  it('falls back to default labels when the labeler returns none', async () => {
+    mockGetLabelerServices.mockResolvedValue({ views: [{ policies: { labelValues: [] } }] });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneLabelOptions(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.labels).toContain('spam');
+    expect(result.current.data?.labels.length).toBeGreaterThan(0);
+    expect(result.current.data?.tags).toEqual(FALLBACK_TAGS);
+  });
+
+  it('falls back to defaults when the API call throws', async () => {
+    mockGetLabelerServices.mockRejectedValue(new Error('network'));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneLabelOptions(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.labels).toContain('impersonation');
+    expect(result.current.data?.tags).toEqual(FALLBACK_TAGS);
+  });
+
+  it('is disabled when ozoneDid missing', () => {
+    (useOzoneDid as jest.Mock).mockReturnValue('');
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneLabelOptions(), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetLabelerServices).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useOzoneQueue.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useOzoneQueue.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useOzoneQueue } from '@/hooks/queries/useOzoneQueue';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+import { apiForAccount } from '@/utils/blueskyApi';
+import { fetchAvatarsByDid, subjectDid } from '@/utils/ozoneAvatars';
+
+const mockQueryStatuses = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyOzone', () => ({ ozoneForAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+jest.mock('@/utils/ozoneAvatars', () => ({
+  fetchAvatarsByDid: jest.fn(),
+  subjectDid: jest.fn(),
+}));
+
+describe('useOzoneQueue hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({ queryStatuses: mockQueryStatuses });
+    (apiForAccount as jest.Mock).mockReturnValue({});
+    (fetchAvatarsByDid as jest.Mock).mockResolvedValue(new Map());
+    (subjectDid as jest.Mock).mockReturnValue(undefined);
+  });
+
+  it('queries statuses with filters and splices avatars into accountStats', async () => {
+    mockQueryStatuses.mockResolvedValue({
+      subjectStatuses: [{ subject: { did: 'did:s' }, accountStats: { reportCount: 3 } }],
+      cursor: 'next',
+    });
+    (subjectDid as jest.Mock).mockReturnValue('did:s');
+    (fetchAvatarsByDid as jest.Mock).mockResolvedValue(new Map([['did:s', 'av']]));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneQueue({ reviewState: 'open' } as never, 50), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockQueryStatuses).toHaveBeenCalledWith('token', 'did:ozone', {
+      reviewState: 'open',
+      limit: 50,
+      cursor: undefined,
+    });
+    expect(result.current.data?.pages[0].subjectStatuses[0]).toEqual({
+      subject: { did: 'did:s' },
+      accountStats: { reportCount: 3, avatar: 'av' },
+    });
+    expect(result.current.hasNextPage).toBe(true);
+  });
+
+  it('leaves rows untouched when no avatar is found', async () => {
+    mockQueryStatuses.mockResolvedValue({
+      subjectStatuses: [{ subject: { did: 'did:s' } }],
+      cursor: undefined,
+    });
+    (subjectDid as jest.Mock).mockReturnValue('did:s');
+    (fetchAvatarsByDid as jest.Mock).mockResolvedValue(new Map());
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneQueue(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.pages[0].subjectStatuses[0]).toEqual({ subject: { did: 'did:s' } });
+  });
+
+  it('paginates using the cursor', async () => {
+    mockQueryStatuses
+      .mockResolvedValueOnce({ subjectStatuses: [{ subject: {} }], cursor: 'c1' })
+      .mockResolvedValueOnce({ subjectStatuses: [{ subject: {} }], cursor: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneQueue({}, 25), { wrapper });
+
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+    await waitFor(() => expect(result.current.data?.pages.length).toBe(2));
+    expect(mockQueryStatuses).toHaveBeenLastCalledWith('token', 'did:ozone', {
+      limit: 25,
+      cursor: 'c1',
+    });
+  });
+
+  it('falls back to raw response when enrichment throws', async () => {
+    mockQueryStatuses.mockResolvedValue({ subjectStatuses: [{ subject: {} }], cursor: undefined });
+    (fetchAvatarsByDid as jest.Mock).mockRejectedValue(new Error('boom'));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneQueue(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.pages[0]).toEqual({
+      subjectStatuses: [{ subject: {} }],
+      cursor: undefined,
+    });
+  });
+
+  it('is disabled when ozoneDid missing', () => {
+    (useOzoneDid as jest.Mock).mockReturnValue('');
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneQueue(), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockQueryStatuses).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useOzoneScheduledActions.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useOzoneScheduledActions.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  useOzoneScheduledActions,
+  useCancelOzoneScheduledActions,
+} from '@/hooks/queries/useOzoneScheduledActions';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+
+const mockListScheduledActions = jest.fn();
+const mockCancelScheduledActions = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyOzone', () => ({ ozoneForAccount: jest.fn() }));
+
+describe('useOzoneScheduledActions hooks', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper, invalidateSpy };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({
+      listScheduledActions: mockListScheduledActions,
+      cancelScheduledActions: mockCancelScheduledActions,
+    });
+  });
+
+  it('lists scheduled actions with the default pending status', async () => {
+    mockListScheduledActions.mockResolvedValue({ actions: [{ id: 'a1' }] });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneScheduledActions(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockListScheduledActions).toHaveBeenCalledWith('token', 'did:ozone', {
+      statuses: ['pending'],
+    });
+    expect(result.current.data).toEqual([{ id: 'a1' }]);
+  });
+
+  it('passes custom statuses through', async () => {
+    mockListScheduledActions.mockResolvedValue({ actions: [] });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useOzoneScheduledActions(['executed', 'failed']),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockListScheduledActions).toHaveBeenCalledWith('token', 'did:ozone', {
+      statuses: ['executed', 'failed'],
+    });
+  });
+
+  it('is disabled when ozoneDid missing', () => {
+    (useOzoneDid as jest.Mock).mockReturnValue('');
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneScheduledActions(), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockListScheduledActions).not.toHaveBeenCalled();
+  });
+
+  it('useCancelOzoneScheduledActions cancels and invalidates all ozone queries', async () => {
+    mockCancelScheduledActions.mockResolvedValue({});
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useCancelOzoneScheduledActions(), { wrapper });
+
+    result.current.mutate({ subjects: ['did:a', 'did:b'], comment: 'stop' });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockCancelScheduledActions).toHaveBeenCalledWith(
+      'token',
+      'did:ozone',
+      ['did:a', 'did:b'],
+      'stop',
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['ozone'] });
+  });
+
+  it('useCancelOzoneScheduledActions throws when session missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCancelOzoneScheduledActions(), { wrapper });
+
+    result.current.mutate({ subjects: ['did:a'] });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useOzoneSubject.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useOzoneSubject.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useOzoneSubjectStatus, useOzoneSubjectEvents } from '@/hooks/queries/useOzoneSubject';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+import { apiForAccount } from '@/utils/blueskyApi';
+import { fetchAvatarsByDid, subjectDid } from '@/utils/ozoneAvatars';
+
+const mockQueryStatuses = jest.fn();
+const mockQueryEvents = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyOzone', () => ({ ozoneForAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+jest.mock('@/utils/ozoneAvatars', () => ({
+  fetchAvatarsByDid: jest.fn(),
+  subjectDid: jest.fn(),
+}));
+
+describe('useOzoneSubject hooks', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({
+      queryStatuses: mockQueryStatuses,
+      queryEvents: mockQueryEvents,
+    });
+    (apiForAccount as jest.Mock).mockReturnValue({});
+    (fetchAvatarsByDid as jest.Mock).mockResolvedValue(new Map());
+    (subjectDid as jest.Mock).mockReturnValue(undefined);
+  });
+
+  it('useOzoneSubjectStatus returns the first status', async () => {
+    mockQueryStatuses.mockResolvedValue({ subjectStatuses: [{ id: 1 }, { id: 2 }] });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneSubjectStatus('did:subject'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockQueryStatuses).toHaveBeenCalledWith('token', 'did:ozone', {
+      subject: 'did:subject',
+      limit: 1,
+    });
+    expect(result.current.data).toEqual({ id: 1 });
+  });
+
+  it('useOzoneSubjectStatus is disabled without subject', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneSubjectStatus(undefined), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockQueryStatuses).not.toHaveBeenCalled();
+  });
+
+  it('useOzoneSubjectEvents queries events and enriches with avatars', async () => {
+    mockQueryEvents.mockResolvedValue({
+      events: [
+        { createdBy: 'did:creator', subject: { did: 'did:sub' } },
+      ],
+    });
+    (subjectDid as jest.Mock).mockReturnValue('did:sub');
+    (fetchAvatarsByDid as jest.Mock).mockResolvedValue(
+      new Map([
+        ['did:creator', 'creator-av'],
+        ['did:sub', 'sub-av'],
+      ]),
+    );
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneSubjectEvents('did:sub', 10), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockQueryEvents).toHaveBeenCalledWith('token', 'did:ozone', {
+      subject: 'did:sub',
+      limit: 10,
+      includeAllUserRecords: true,
+      sortDirection: 'desc',
+    });
+    expect(result.current.data?.[0]).toMatchObject({
+      creatorAvatar: 'creator-av',
+      subjectAvatar: 'sub-av',
+    });
+  });
+
+  it('useOzoneSubjectEvents uses includeAllUserRecords=false for non-did subjects', async () => {
+    mockQueryEvents.mockResolvedValue({ events: [] });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useOzoneSubjectEvents('at://did:plc:x/app.bsky.feed.post/abc'),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockQueryEvents).toHaveBeenCalledWith(
+      'token',
+      'did:ozone',
+      expect.objectContaining({ includeAllUserRecords: false, limit: 50 }),
+    );
+  });
+
+  it('useOzoneSubjectEvents falls back to raw events when enrichment throws', async () => {
+    mockQueryEvents.mockResolvedValue({ events: [{ createdBy: 'did:c', subject: {} }] });
+    (fetchAvatarsByDid as jest.Mock).mockRejectedValue(new Error('boom'));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneSubjectEvents('did:sub'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ createdBy: 'did:c', subject: {} }]);
+  });
+
+  it('useOzoneSubjectEvents is disabled without subject', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneSubjectEvents(undefined), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockQueryEvents).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useOzoneTeam.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useOzoneTeam.test.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  useOzoneTeam,
+  useAddOzoneTeamMember,
+  useUpdateOzoneTeamMember,
+  useDeleteOzoneTeamMember,
+} from '@/hooks/queries/useOzoneTeam';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+import { apiForAccount } from '@/utils/blueskyApi';
+import { fetchProfilesByDid } from '@/utils/ozoneAvatars';
+
+const mockListTeamMembers = jest.fn();
+const mockAddTeamMember = jest.fn();
+const mockUpdateTeamMember = jest.fn();
+const mockDeleteTeamMember = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyOzone', () => ({ ozoneForAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+jest.mock('@/utils/ozoneAvatars', () => ({ fetchProfilesByDid: jest.fn() }));
+
+describe('useOzoneTeam hooks', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper, invalidateSpy };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({
+      listTeamMembers: mockListTeamMembers,
+      addTeamMember: mockAddTeamMember,
+      updateTeamMember: mockUpdateTeamMember,
+      deleteTeamMember: mockDeleteTeamMember,
+    });
+    (apiForAccount as jest.Mock).mockReturnValue({});
+    (fetchProfilesByDid as jest.Mock).mockResolvedValue(new Map());
+  });
+
+  it('lists team members and merges fetched profiles', async () => {
+    mockListTeamMembers.mockResolvedValue({
+      members: [
+        { did: 'did:a', profile: { handle: 'old' } },
+        { did: 'did:b', profile: {} },
+      ],
+    });
+    (fetchProfilesByDid as jest.Mock).mockResolvedValue(
+      new Map([['did:a', { handle: 'new', avatar: 'av' }]]),
+    );
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneTeam(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockListTeamMembers).toHaveBeenCalledWith('token', 'did:ozone', { limit: 100 });
+    expect(fetchProfilesByDid).toHaveBeenCalledWith(expect.anything(), 'token', ['did:a', 'did:b']);
+    expect(result.current.data).toEqual([
+      { did: 'did:a', profile: { handle: 'new', avatar: 'av' } },
+      { did: 'did:b', profile: {} },
+    ]);
+  });
+
+  it('falls back to raw members when profile enrichment throws', async () => {
+    mockListTeamMembers.mockResolvedValue({ members: [{ did: 'did:a' }] });
+    (fetchProfilesByDid as jest.Mock).mockRejectedValue(new Error('boom'));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneTeam(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ did: 'did:a' }]);
+  });
+
+  it('is disabled when ozoneDid missing', () => {
+    (useOzoneDid as jest.Mock).mockReturnValue('');
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneTeam(), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('useAddOzoneTeamMember calls API and invalidates', async () => {
+    mockAddTeamMember.mockResolvedValue({});
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useAddOzoneTeamMember(), { wrapper });
+
+    result.current.mutate({ did: 'did:new', role: 'moderator' });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockAddTeamMember).toHaveBeenCalledWith('token', 'did:ozone', {
+      did: 'did:new',
+      role: 'moderator',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['ozone', 'teamMembers', 'did:ozone'],
+    });
+  });
+
+  it('useAddOzoneTeamMember throws when session missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAddOzoneTeamMember(), { wrapper });
+    result.current.mutate({ did: 'did:new', role: 'moderator' });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('useUpdateOzoneTeamMember calls API and invalidates', async () => {
+    mockUpdateTeamMember.mockResolvedValue({});
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useUpdateOzoneTeamMember(), { wrapper });
+
+    result.current.mutate({ did: 'did:x', role: 'admin', disabled: true });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockUpdateTeamMember).toHaveBeenCalledWith('token', 'did:ozone', {
+      did: 'did:x',
+      role: 'admin',
+      disabled: true,
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['ozone', 'teamMembers', 'did:ozone'],
+    });
+  });
+
+  it('useUpdateOzoneTeamMember throws when PDS missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: undefined } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateOzoneTeamMember(), { wrapper });
+    result.current.mutate({ did: 'did:x' });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('useDeleteOzoneTeamMember calls API, returns did, and invalidates', async () => {
+    mockDeleteTeamMember.mockResolvedValue(undefined);
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useDeleteOzoneTeamMember(), { wrapper });
+
+    result.current.mutate('did:gone');
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockDeleteTeamMember).toHaveBeenCalledWith('token', 'did:ozone', 'did:gone');
+    expect(result.current.data).toBe('did:gone');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['ozone', 'teamMembers', 'did:ozone'],
+    });
+  });
+
+  it('useDeleteOzoneTeamMember throws when session missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeleteOzoneTeamMember(), { wrapper });
+    result.current.mutate('did:gone');
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/usePersonalDetails.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/usePersonalDetails.test.tsx
@@ -1,0 +1,47 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { usePersonalDetails } from '@/hooks/queries/usePersonalDetails';
+import { usePreferences } from '@/hooks/queries/usePreferences';
+
+jest.mock('@/hooks/queries/usePreferences', () => ({
+  usePreferences: jest.fn(),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#personalDetailsPref';
+
+describe('usePersonalDetails query hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns undefined birthDate when there is no data', () => {
+    (usePreferences as jest.Mock).mockReturnValue({ data: undefined, isLoading: true });
+
+    const { result } = renderHook(() => usePersonalDetails());
+
+    expect(result.current.birthDate).toBeUndefined();
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns undefined when the pref is absent', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: 'other' }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => usePersonalDetails());
+
+    expect(result.current.birthDate).toBeUndefined();
+  });
+
+  it('returns the birthDate from the pref', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: PREF_TYPE, birthDate: '1990-01-01' }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => usePersonalDetails());
+
+    expect(result.current.birthDate).toBe('1990-01-01');
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/usePostInteractionSettings.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/usePostInteractionSettings.test.tsx
@@ -1,0 +1,88 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { usePostInteractionSettings } from '@/hooks/queries/usePostInteractionSettings';
+import { usePreferences } from '@/hooks/queries/usePreferences';
+
+jest.mock('@/hooks/queries/usePreferences', () => ({
+  usePreferences: jest.fn(),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#postInteractionSettingsPref';
+
+describe('usePostInteractionSettings query hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns defaults when there is no preferences data', () => {
+    (usePreferences as jest.Mock).mockReturnValue({ data: undefined, isLoading: true });
+
+    const { result } = renderHook(() => usePostInteractionSettings());
+
+    expect(result.current.data).toEqual({
+      mode: 'anyone',
+      followers: false,
+      following: false,
+      mentioned: false,
+      allowQuotes: true,
+      allowedLists: [],
+    });
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns defaults when the pref is absent', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: 'other' }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => usePostInteractionSettings());
+
+    expect(result.current.data.mode).toBe('anyone');
+    expect(result.current.data.allowQuotes).toBe(true);
+  });
+
+  it('decodes an empty allow-rules array as "nobody"', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: PREF_TYPE, threadgateAllowRules: [] }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => usePostInteractionSettings());
+
+    expect(result.current.data.mode).toBe('nobody');
+  });
+
+  it('decodes follower/following/mention/list rules and disabled quotes', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: {
+        preferences: [
+          {
+            $type: PREF_TYPE,
+            threadgateAllowRules: [
+              { $type: 'app.bsky.feed.threadgate#followerRule' },
+              { $type: 'app.bsky.feed.threadgate#followingRule' },
+              { $type: 'app.bsky.feed.threadgate#mentionRule' },
+              { $type: 'app.bsky.feed.threadgate#listRule', list: 'at://list/1' },
+              null,
+              { foo: 'no-type' },
+            ],
+            postgateEmbeddingRules: [{ $type: 'app.bsky.feed.postgate#disableRule' }],
+          },
+        ],
+      },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => usePostInteractionSettings());
+
+    expect(result.current.data).toEqual({
+      mode: 'anyone',
+      followers: true,
+      following: true,
+      mentioned: true,
+      allowQuotes: false,
+      allowedLists: ['at://list/1'],
+    });
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useProfileRecord.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useProfileRecord.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  useProfileRecord,
+  isLoggedOutVisibilityDiscouraged,
+  isAccountAutomated,
+} from '@/hooks/queries/useProfileRecord';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetProfileRecord = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getProfileRecord: mockGetProfileRecord,
+  })),
+}));
+
+describe('useProfileRecord query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+  });
+
+  it('fetches the profile record for the current user', async () => {
+    const record = { uri: 'at://record', value: { labels: undefined } };
+    mockGetProfileRecord.mockResolvedValueOnce(record);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useProfileRecord(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetProfileRecord).toHaveBeenCalledWith('token', 'did:me');
+    expect(result.current.data).toEqual(record);
+  });
+
+  it('is disabled when token is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useProfileRecord(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetProfileRecord).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when pdsUrl is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:me' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useProfileRecord(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetProfileRecord).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when did is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useProfileRecord(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetProfileRecord).not.toHaveBeenCalled();
+  });
+});
+
+describe('isLoggedOutVisibilityDiscouraged', () => {
+  it('returns true when the !no-unauthenticated self-label is present', () => {
+    const record = {
+      value: { labels: { values: [{ val: '!no-unauthenticated' }] } },
+    };
+    expect(isLoggedOutVisibilityDiscouraged(record)).toBe(true);
+  });
+
+  it('returns false when the label is absent', () => {
+    expect(isLoggedOutVisibilityDiscouraged({ value: { labels: { values: [{ val: 'other' }] } } })).toBe(false);
+  });
+
+  it('returns false for null, missing labels, or missing values', () => {
+    expect(isLoggedOutVisibilityDiscouraged(null)).toBe(false);
+    expect(isLoggedOutVisibilityDiscouraged(undefined)).toBe(false);
+    expect(isLoggedOutVisibilityDiscouraged({ value: {} })).toBe(false);
+    expect(isLoggedOutVisibilityDiscouraged({ value: { labels: {} } })).toBe(false);
+  });
+});
+
+describe('isAccountAutomated', () => {
+  it('returns true when the automated self-label is present', () => {
+    const record = { value: { labels: { values: [{ val: 'automated' }] } } };
+    expect(isAccountAutomated(record)).toBe(true);
+  });
+
+  it('returns false when the label is absent', () => {
+    expect(isAccountAutomated({ value: { labels: { values: [{ val: 'other' }] } } })).toBe(false);
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useRpgInventory.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useRpgInventory.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useRpgInventory } from '@/hooks/queries/useRpgInventory';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { usePdsUrl } from '@/hooks/queries/usePdsUrl';
+
+const mockGetActorRpgInventory = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/usePdsUrl', () => ({
+  usePdsUrl: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getActorRpgInventory: mockGetActorRpgInventory,
+  })),
+}));
+
+describe('useRpgInventory query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (usePdsUrl as jest.Mock).mockReturnValue({ data: 'https://pds', isLoading: false });
+  });
+
+  it('fetches inventory items and flattens pages across fetchNextPage', async () => {
+    mockGetActorRpgInventory
+      .mockResolvedValueOnce({ records: [{ uri: 'i1' }], cursor: 'next' })
+      .mockResolvedValueOnce({ records: [{ uri: 'i2' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useRpgInventory('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorRpgInventory).toHaveBeenCalledWith('token', 'alice', 5, undefined);
+    expect(result.current.data).toEqual([{ uri: 'i1' }]);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ uri: 'i1' }, { uri: 'i2' }]);
+    });
+    expect(mockGetActorRpgInventory).toHaveBeenLastCalledWith('token', 'alice', 5, 'next');
+  });
+
+  it('defaults the limit to 50', async () => {
+    mockGetActorRpgInventory.mockResolvedValueOnce({ records: [], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useRpgInventory('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorRpgInventory).toHaveBeenCalledWith('token', 'alice', 50, undefined);
+  });
+
+  it('is disabled when there is no token', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useRpgInventory('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorRpgInventory).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when there is no identifier', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useRpgInventory(undefined, 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorRpgInventory).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when the PDS URL is missing', async () => {
+    (usePdsUrl as jest.Mock).mockReturnValue({ data: undefined, isLoading: false });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useRpgInventory('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorRpgInventory).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useSifaProfile.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useSifaProfile.test.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import {
+  useSifaSelf,
+  useSifaPositions,
+  useSifaEducation,
+  sortSifaPositions,
+  sortSifaEducation,
+} from '@/hooks/queries/useSifaProfile';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { usePdsUrl } from '@/hooks/queries/usePdsUrl';
+
+const mockGetSifaProfileSelf = jest.fn();
+const mockGetActorSifaPositions = jest.fn();
+const mockGetActorSifaEducation = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/usePdsUrl', () => ({
+  usePdsUrl: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getSifaProfileSelf: mockGetSifaProfileSelf,
+    getActorSifaPositions: mockGetActorSifaPositions,
+    getActorSifaEducation: mockGetActorSifaEducation,
+  })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+  (usePdsUrl as jest.Mock).mockReturnValue({ data: 'https://pds', isLoading: false });
+});
+
+describe('useSifaSelf query hook', () => {
+  it('reads the sifa self record', async () => {
+    mockGetSifaProfileSelf.mockResolvedValueOnce({ uri: 'self' });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSifaSelf('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetSifaProfileSelf).toHaveBeenCalledWith('token', 'alice');
+    expect(result.current.data).toEqual({ uri: 'self' });
+  });
+
+  it('returns null when the actor has no record', async () => {
+    mockGetSifaProfileSelf.mockResolvedValueOnce(null);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSifaSelf('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toBeNull();
+  });
+
+  it('is disabled when there is no token', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSifaSelf('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetSifaProfileSelf).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when the PDS URL is missing', async () => {
+    (usePdsUrl as jest.Mock).mockReturnValue({ data: undefined, isLoading: false });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSifaSelf('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetSifaProfileSelf).not.toHaveBeenCalled();
+  });
+});
+
+describe('useSifaPositions query hook', () => {
+  it('fetches positions and flattens pages across fetchNextPage', async () => {
+    mockGetActorSifaPositions
+      .mockResolvedValueOnce({ records: [{ uri: 'p1' }], cursor: 'next' })
+      .mockResolvedValueOnce({ records: [{ uri: 'p2' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSifaPositions('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorSifaPositions).toHaveBeenCalledWith('token', 'alice', 5, undefined);
+    expect(result.current.data).toEqual([{ uri: 'p1' }]);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ uri: 'p1' }, { uri: 'p2' }]);
+    });
+    expect(mockGetActorSifaPositions).toHaveBeenLastCalledWith('token', 'alice', 5, 'next');
+  });
+
+  it('defaults the limit to 50', async () => {
+    mockGetActorSifaPositions.mockResolvedValueOnce({ records: [], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSifaPositions('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorSifaPositions).toHaveBeenCalledWith('token', 'alice', 50, undefined);
+  });
+
+  it('is disabled when there is no identifier', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSifaPositions(undefined, 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorSifaPositions).not.toHaveBeenCalled();
+  });
+});
+
+describe('useSifaEducation query hook', () => {
+  it('fetches education and flattens pages across fetchNextPage', async () => {
+    mockGetActorSifaEducation
+      .mockResolvedValueOnce({ records: [{ uri: 'e1' }], cursor: 'next' })
+      .mockResolvedValueOnce({ records: [{ uri: 'e2' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSifaEducation('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorSifaEducation).toHaveBeenCalledWith('token', 'alice', 5, undefined);
+    expect(result.current.data).toEqual([{ uri: 'e1' }]);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ uri: 'e1' }, { uri: 'e2' }]);
+    });
+    expect(mockGetActorSifaEducation).toHaveBeenLastCalledWith('token', 'alice', 5, 'next');
+  });
+
+  it('is disabled when the PDS URL is still loading', async () => {
+    (usePdsUrl as jest.Mock).mockReturnValue({ data: 'https://pds', isLoading: true });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSifaEducation('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorSifaEducation).not.toHaveBeenCalled();
+  });
+});
+
+describe('sortSifaPositions helper', () => {
+  it('returns an empty array for undefined input', () => {
+    expect(sortSifaPositions(undefined)).toEqual([]);
+  });
+
+  it('floats primary positions to the top, then sorts by startedAt descending', () => {
+    const sorted = sortSifaPositions([
+      { uri: 'a', value: { startedAt: '2020-01-01' } },
+      { uri: 'b', value: { startedAt: '2022-01-01' } },
+      { uri: 'c', value: { isPrimary: true, startedAt: '2018-01-01' } },
+    ] as never);
+    expect(sorted.map((p) => p.uri)).toEqual(['c', 'b', 'a']);
+  });
+});
+
+describe('sortSifaEducation helper', () => {
+  it('returns an empty array for undefined input', () => {
+    expect(sortSifaEducation(undefined)).toEqual([]);
+  });
+
+  it('sorts by endedAt (falling back to startedAt) descending', () => {
+    const sorted = sortSifaEducation([
+      { uri: 'a', value: { endedAt: '2015-01-01' } },
+      { uri: 'b', value: { startedAt: '2021-01-01' } }, // still enrolled, uses startedAt
+      { uri: 'c', value: { endedAt: '2018-01-01' } },
+    ] as never);
+    expect(sorted.map((e) => e.uri)).toEqual(['b', 'c', 'a']);
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useThreadPreferences.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useThreadPreferences.test.tsx
@@ -1,0 +1,60 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { useThreadPreferences } from '@/hooks/queries/useThreadPreferences';
+import { usePreferences } from '@/hooks/queries/usePreferences';
+
+jest.mock('@/hooks/queries/usePreferences', () => ({
+  usePreferences: jest.fn(),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#threadViewPref';
+
+describe('useThreadPreferences query hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns defaults when there is no data', () => {
+    (usePreferences as jest.Mock).mockReturnValue({ data: undefined, isLoading: true });
+
+    const { result } = renderHook(() => useThreadPreferences());
+
+    expect(result.current.data).toEqual({ sort: 'hotness', prioritizeFollowedUsers: false });
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns defaults when the pref is absent', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: 'other' }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useThreadPreferences());
+
+    expect(result.current.data).toEqual({ sort: 'hotness', prioritizeFollowedUsers: false });
+  });
+
+  it('decodes the pref values', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: {
+        preferences: [{ $type: PREF_TYPE, sort: 'newest', prioritizeFollowedUsers: true }],
+      },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useThreadPreferences());
+
+    expect(result.current.data).toEqual({ sort: 'newest', prioritizeFollowedUsers: true });
+  });
+
+  it('falls back to defaults for individual missing fields', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: PREF_TYPE }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useThreadPreferences());
+
+    expect(result.current.data).toEqual({ sort: 'hotness', prioritizeFollowedUsers: false });
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useTrendingTopics.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useTrendingTopics.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useTrendingTopics } from '@/hooks/queries/useTrendingTopics';
+import { useAppViewEnabled } from '@/hooks/useAppViewEnabled';
+import { readAppViewEnabled, useAppViewSettings } from '@/hooks/useAppViewSettings';
+
+const mockGetTrendingTopics = jest.fn();
+
+jest.mock('@/hooks/useAppViewEnabled', () => ({
+  useAppViewEnabled: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewEnabled: jest.fn(),
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+  useAppViewSettings: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getTrendingTopics: mockGetTrendingTopics,
+  })),
+}));
+
+describe('useTrendingTopics query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+    (readAppViewEnabled as jest.Mock).mockReturnValue(true);
+    (useAppViewSettings as jest.Mock).mockReturnValue({
+      config: { preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true },
+    });
+  });
+
+  it('fetches trending topics and unwraps the topics array', async () => {
+    const topics = [{ topic: 'news', link: '/search?q=news' }];
+    mockGetTrendingTopics.mockResolvedValueOnce({ topics });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useTrendingTopics(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetTrendingTopics).toHaveBeenCalledWith(12);
+    expect(result.current.data).toEqual(topics);
+  });
+
+  it('passes a custom limit to the API', async () => {
+    mockGetTrendingTopics.mockResolvedValueOnce({ topics: [] });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useTrendingTopics(5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetTrendingTopics).toHaveBeenCalledWith(5);
+  });
+
+  it('throws AppViewRequiredError when the AppView is disabled', async () => {
+    (readAppViewEnabled as jest.Mock).mockReturnValue(false);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useTrendingTopics(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect((result.current.error as Error).message).toContain('trendingTopics');
+    expect(mockGetTrendingTopics).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when the enabled flag is false', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useTrendingTopics(12, false), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetTrendingTopics).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/useCreateAccount.test.tsx
+++ b/apps/akari/__tests__/hooks/useCreateAccount.test.tsx
@@ -1,0 +1,297 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useAddAccount } from '@/hooks/mutations/useAddAccount';
+import { useCreateAccount as useCreateAccountMutation } from '@/hooks/mutations/useCreateAccount';
+import { useSwitchAccount } from '@/hooks/mutations/useSwitchAccount';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useConfirm } from '@/hooks/useConfirm';
+import { useCreateAccount, type CreateAccountInput } from '@/hooks/useCreateAccount';
+
+jest.mock('@/hooks/mutations/useAddAccount', () => ({ useAddAccount: jest.fn() }));
+jest.mock('@/hooks/mutations/useCreateAccount', () => ({ useCreateAccount: jest.fn() }));
+jest.mock('@/hooks/mutations/useSwitchAccount', () => ({ useSwitchAccount: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useConfirm', () => ({ useConfirm: jest.fn() }));
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockConfirm = jest.fn();
+const mockCreateMutateAsync = jest.fn();
+const mockAddMutateAsync = jest.fn();
+const mockSwitchMutateAsync = jest.fn();
+
+const validBskyInput: CreateAccountInput = {
+  provider: 'bsky',
+  email: 'alice@example.com',
+  password: 'supersecret',
+  handle: 'alice',
+  handleSuffix: '.bsky.social',
+};
+
+const session = {
+  did: 'did:plc:alice',
+  handle: 'alice.bsky.social',
+  accessJwt: 'access',
+  refreshJwt: 'refresh',
+  profile: { displayName: 'Alice', avatar: 'https://avatar' },
+};
+
+function setup() {
+  return renderHook(() => useCreateAccount());
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useConfirm as jest.Mock).mockReturnValue(mockConfirm);
+  (useCurrentAccount as jest.Mock).mockReturnValue({ data: undefined });
+  (useCreateAccountMutation as jest.Mock).mockReturnValue({
+    mutateAsync: mockCreateMutateAsync,
+    isPending: false,
+  });
+  (useAddAccount as jest.Mock).mockReturnValue({ mutateAsync: mockAddMutateAsync });
+  (useSwitchAccount as jest.Mock).mockReturnValue({ mutateAsync: mockSwitchMutateAsync });
+
+  mockCreateMutateAsync.mockResolvedValue(session);
+  mockAddMutateAsync.mockResolvedValue({ did: 'did:plc:alice' });
+  mockSwitchMutateAsync.mockResolvedValue(undefined);
+});
+
+describe('useCreateAccount', () => {
+  it('exposes the loading flag from the create mutation', () => {
+    (useCreateAccountMutation as jest.Mock).mockReturnValue({
+      mutateAsync: mockCreateMutateAsync,
+      isPending: true,
+    });
+    const { result } = setup();
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('reports whether there is already a current account', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'x' } });
+    const { result } = setup();
+    expect(result.current.hasCurrentAccount).toBe(true);
+  });
+
+  it('runs the full create -> add -> switch flow and redirects home', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount(validBskyInput);
+    });
+
+    expect(mockCreateMutateAsync).toHaveBeenCalledWith({
+      email: 'alice@example.com',
+      handle: 'alice.bsky.social',
+      password: 'supersecret',
+      inviteCode: undefined,
+      pdsUrl: 'https://bsky.social',
+    });
+    expect(mockAddMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        did: 'did:plc:alice',
+        handle: 'alice.bsky.social',
+        displayName: 'Alice',
+        avatar: 'https://avatar',
+        jwtToken: 'access',
+        refreshToken: 'refresh',
+        pdsUrl: 'https://bsky.social',
+      }),
+    );
+    expect(mockSwitchMutateAsync).toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(result.current.redirectAfterAuth).toBe('/');
+    });
+  });
+
+  it('redirects to settings when adding a second account', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'existing' } });
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount(validBskyInput);
+    });
+
+    await waitFor(() => {
+      expect(result.current.redirectAfterAuth).toBe('/(tabs)/settings');
+    });
+  });
+
+  it('passes a trimmed invite code through to the mutation', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount({ ...validBskyInput, inviteCode: '  abc-123  ' });
+    });
+
+    expect(mockCreateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ inviteCode: 'abc-123' }),
+    );
+  });
+
+  it('falls back to the handle for displayName when the profile is missing', async () => {
+    mockCreateMutateAsync.mockResolvedValueOnce({ ...session, profile: undefined });
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount(validBskyInput);
+    });
+
+    expect(mockAddMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ displayName: 'alice.bsky.social', avatar: undefined }),
+    );
+  });
+
+  it('validates required fields before hitting the network', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount({ ...validBskyInput, email: '   ' });
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'auth.fillAllFields' }),
+    );
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed email', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount({ ...validBskyInput, email: 'not-an-email' });
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'auth.signupInvalidEmail' }),
+    );
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('rejects a too-short password', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount({ ...validBskyInput, password: 'short' });
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'auth.signupPasswordTooShort' }),
+    );
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('rejects a too-short handle for a preset provider', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount({ ...validBskyInput, handle: 'ab' });
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'auth.signupHandleTooShort' }),
+    );
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid handle local part for a preset provider', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount({ ...validBskyInput, handle: 'bad_handle!' });
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'auth.signupHandleInvalid' }),
+    );
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('creates an account on a custom PDS with a full handle', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount({
+        provider: 'custom',
+        email: 'alice@example.com',
+        password: 'supersecret',
+        handle: 'me.example.com',
+        pdsUrl: 'https://pds.example.com/',
+      });
+    });
+
+    expect(mockCreateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        handle: 'me.example.com',
+        // trailing slash trimmed
+        pdsUrl: 'https://pds.example.com',
+      }),
+    );
+  });
+
+  it('rejects an invalid custom PDS url', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount({
+        provider: 'custom',
+        email: 'alice@example.com',
+        password: 'supersecret',
+        handle: 'me.example.com',
+        pdsUrl: 'ftp://not-https',
+      });
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'auth.signupCustomInvalidPdsUrl' }),
+    );
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid custom full handle', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount({
+        provider: 'custom',
+        email: 'alice@example.com',
+        password: 'supersecret',
+        handle: 'nodot',
+        pdsUrl: 'https://pds.example.com',
+      });
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'auth.signupCustomInvalidHandle' }),
+    );
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the error message when account creation throws', async () => {
+    mockCreateMutateAsync.mockRejectedValueOnce(new Error('PDS rejected handle'));
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount(validBskyInput);
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'PDS rejected handle' }),
+    );
+    expect(result.current.redirectAfterAuth).toBeNull();
+  });
+
+  it('falls back to a generic message for non-Error throws', async () => {
+    mockCreateMutateAsync.mockRejectedValueOnce('weird');
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount(validBskyInput);
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'auth.signupFailedGeneric' }),
+    );
+  });
+});

--- a/apps/akari/__tests__/hooks/useExternalMediaSettings.test.tsx
+++ b/apps/akari/__tests__/hooks/useExternalMediaSettings.test.tsx
@@ -1,0 +1,49 @@
+import { renderHook, act } from '@testing-library/react-native';
+
+import { useExternalMediaSettings } from '@/hooks/useExternalMediaSettings';
+
+describe('useExternalMediaSettings', () => {
+  it('defaults both providers to enabled', () => {
+    const { result } = renderHook(() => useExternalMediaSettings());
+    expect(result.current.youtubeEnabled).toBe(true);
+    expect(result.current.gifEnabled).toBe(true);
+  });
+
+  it('toggles the youtube provider', () => {
+    const { result } = renderHook(() => useExternalMediaSettings());
+
+    act(() => {
+      result.current.setYoutubeEnabled(false);
+    });
+    expect(result.current.youtubeEnabled).toBe(false);
+    // gif is untouched
+    expect(result.current.gifEnabled).toBe(true);
+
+    act(() => {
+      result.current.setYoutubeEnabled(true);
+    });
+    expect(result.current.youtubeEnabled).toBe(true);
+  });
+
+  it('toggles the gif provider independently', () => {
+    const { result } = renderHook(() => useExternalMediaSettings());
+
+    act(() => {
+      result.current.setGifEnabled(false);
+    });
+    expect(result.current.gifEnabled).toBe(false);
+    expect(result.current.youtubeEnabled).toBe(true);
+  });
+
+  it('propagates changes to other mounted consumers', () => {
+    const a = renderHook(() => useExternalMediaSettings());
+    const b = renderHook(() => useExternalMediaSettings());
+
+    act(() => {
+      a.result.current.setGifEnabled(false);
+    });
+
+    expect(a.result.current.gifEnabled).toBe(false);
+    expect(b.result.current.gifEnabled).toBe(false);
+  });
+});

--- a/apps/akari/__tests__/hooks/useFavicon.test.tsx
+++ b/apps/akari/__tests__/hooks/useFavicon.test.tsx
@@ -1,0 +1,96 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useFavicon } from '@/hooks/useFavicon';
+import { fetchFavicon, getDomainFromUrl } from '@/utils/faviconUtils';
+
+jest.mock('@/utils/faviconUtils', () => ({
+  fetchFavicon: jest.fn(),
+  getDomainFromUrl: jest.fn(),
+}));
+
+describe('useFavicon', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getDomainFromUrl as jest.Mock).mockImplementation((url: string) => `domain(${url})`);
+  });
+
+  it('fetches and exposes the favicon url for a plain url', async () => {
+    (fetchFavicon as jest.Mock).mockResolvedValueOnce('https://favicon.test/icon.png');
+
+    const { result } = renderHook(() => useFavicon('https://example.com'));
+
+    // starts loading immediately
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.domain).toBe('domain(https://example.com)');
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.faviconUrl).toBe('https://favicon.test/icon.png');
+    expect(fetchFavicon).toHaveBeenCalledWith('https://example.com');
+  });
+
+  it('does not fetch when an emoji is provided', () => {
+    const { result } = renderHook(() => useFavicon('https://example.com', '🔥'));
+
+    expect(fetchFavicon).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.faviconUrl).toBeNull();
+  });
+
+  it('treats a whitespace-only emoji as absent and still fetches', async () => {
+    (fetchFavicon as jest.Mock).mockResolvedValueOnce('https://favicon.test/icon.png');
+
+    const { result } = renderHook(() => useFavicon('https://example.com', '   '));
+
+    await waitFor(() => {
+      expect(result.current.faviconUrl).toBe('https://favicon.test/icon.png');
+    });
+    expect(fetchFavicon).toHaveBeenCalled();
+  });
+
+  it('does not fetch when the url is empty', () => {
+    const { result } = renderHook(() => useFavicon(''));
+
+    expect(fetchFavicon).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.faviconUrl).toBeNull();
+  });
+
+  it('clears the favicon when the fetch rejects', async () => {
+    (fetchFavicon as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+
+    const { result } = renderHook(() => useFavicon('https://example.com'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.faviconUrl).toBeNull();
+  });
+
+  it('ignores a resolved fetch after the url changes (cancellation)', async () => {
+    let resolveFirst: (value: string | null) => void = () => {};
+    (fetchFavicon as jest.Mock)
+      .mockImplementationOnce(
+        () =>
+          new Promise<string | null>((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce('https://favicon.test/second.png');
+
+    const { result, rerender } = renderHook(({ url }: { url: string }) => useFavicon(url), {
+      initialProps: { url: 'https://first.com' },
+    });
+
+    // swap url before the first promise resolves
+    rerender({ url: 'https://second.com' });
+
+    // resolve the now-cancelled first fetch
+    resolveFirst('https://favicon.test/first.png');
+
+    await waitFor(() => {
+      expect(result.current.faviconUrl).toBe('https://favicon.test/second.png');
+    });
+  });
+});

--- a/apps/akari/__tests__/hooks/useFollowingCleanupController.test.tsx
+++ b/apps/akari/__tests__/hooks/useFollowingCleanupController.test.tsx
@@ -1,0 +1,248 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import { useFollowingCleanupController } from '@/hooks/useFollowingCleanupController';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useFollowUser } from '@/hooks/mutations/useFollowUser';
+import { useToast } from '@/contexts/ToastContext';
+import { apiForAccount } from '@/utils/blueskyApi';
+import {
+  getFollowingCleanupController,
+  initialFollowingCleanupState,
+} from '@/utils/followingCleanupController';
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/mutations/useFollowUser', () => ({ useFollowUser: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+jest.mock('@/utils/followingCleanupController', () => ({
+  getFollowingCleanupController: jest.fn(),
+  followingCleanupQueryKey: (did: string | undefined) => ['followingCleanup', did],
+  initialFollowingCleanupState: jest.fn(() => ({
+    entries: {},
+    totalDiscovered: 0,
+    totalScanned: 0,
+    paginationDone: false,
+    runState: 'idle',
+  })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+};
+
+type Ctrl = {
+  getState: jest.Mock;
+  start: jest.Mock;
+  pause: jest.Mock;
+  clear: jest.Mock;
+  removeProfile: jest.Mock;
+  restoreEntry: jest.Mock;
+};
+
+function makeController(): Ctrl {
+  return {
+    getState: jest.fn(() => initialFollowingCleanupState()),
+    start: jest.fn(() => Promise.resolve()),
+    pause: jest.fn(),
+    clear: jest.fn(),
+    removeProfile: jest.fn(),
+    restoreEntry: jest.fn(),
+  };
+}
+
+describe('useFollowingCleanupController', () => {
+  const mutate = jest.fn();
+  let controller: Ctrl;
+  let showToast: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    controller = makeController();
+    (getFollowingCleanupController as jest.Mock).mockReturnValue(controller);
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did:plc:me', pdsUrl: 'https://pds' },
+    });
+    (useFollowUser as jest.Mock).mockReturnValue({ mutate, isPending: false });
+    (apiForAccount as jest.Mock).mockReturnValue({ id: 'api' });
+    showToast = jest.fn();
+    (useToast as jest.Mock).mockReturnValue({ showToast, hideToast: jest.fn() });
+  });
+
+  it('exposes account context, initial state and pending flag', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    expect(result.current.accountDid).toBe('did:plc:me');
+    expect(result.current.token).toBe('token');
+    expect(result.current.state.runState).toBe('idle');
+    expect(result.current.unfollowPending).toBe(false);
+  });
+
+  it('start() invokes the controller with the api and token', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    act(() => {
+      result.current.start();
+    });
+
+    expect(apiForAccount).toHaveBeenCalledWith({ did: 'did:plc:me', pdsUrl: 'https://pds' });
+    expect(controller.start).toHaveBeenCalledWith({ api: { id: 'api' }, token: 'token' });
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it('start() shows an error toast and bails when credentials are missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    act(() => {
+      result.current.start();
+    });
+
+    expect(controller.start).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith({ type: 'error', message: 'common.somethingWentWrong' });
+  });
+
+  it('start() surfaces a toast and logs if the controller scan rejects', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    controller.start.mockReturnValue(Promise.reject(new Error('boom')));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    await act(async () => {
+      result.current.start();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith({ type: 'error', message: 'common.somethingWentWrong' });
+    });
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it('pause() and clear() delegate to the controller', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    act(() => {
+      result.current.pause();
+      result.current.clear();
+    });
+
+    expect(controller.pause).toHaveBeenCalledTimes(1);
+    expect(controller.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('pause() and clear() no-op when there is no account did', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    act(() => {
+      result.current.pause();
+      result.current.clear();
+    });
+
+    expect(controller.pause).not.toHaveBeenCalled();
+    expect(controller.clear).not.toHaveBeenCalled();
+  });
+
+  it('unfollow() optimistically removes the profile and fires the mutation', () => {
+    const profile = {
+      did: 'did:plc:target',
+      viewer: { following: 'at://follow/uri' },
+    } as never;
+    controller.getState.mockReturnValue({
+      ...initialFollowingCleanupState(),
+      entries: { 'did:plc:target': { profile, status: 'done', lastActivityAt: null, followedAt: null } },
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    act(() => {
+      result.current.unfollow(profile);
+    });
+
+    expect(controller.removeProfile).toHaveBeenCalledWith('did:plc:target');
+    expect(mutate).toHaveBeenCalledWith(
+      { did: 'did:plc:target', followUri: 'at://follow/uri', action: 'unfollow' },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
+  });
+
+  it('unfollow() restores the entry and toasts on mutation error', () => {
+    const previousEntry = {
+      profile: { did: 'did:plc:target' },
+      status: 'done',
+      lastActivityAt: null,
+      followedAt: null,
+    };
+    const profile = {
+      did: 'did:plc:target',
+      viewer: { following: 'at://follow/uri' },
+    } as never;
+    controller.getState.mockReturnValue({
+      ...initialFollowingCleanupState(),
+      entries: { 'did:plc:target': previousEntry },
+    });
+    mutate.mockImplementation((_vars, opts) => opts.onError());
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    act(() => {
+      result.current.unfollow(profile);
+    });
+
+    expect(controller.restoreEntry).toHaveBeenCalledWith(previousEntry);
+    expect(showToast).toHaveBeenCalledWith({
+      type: 'error',
+      message: 'settings.followingCleanup.unfollowFailed',
+    });
+  });
+
+  it('unfollow() shows an error and bails when there is no follow uri', () => {
+    const profile = { did: 'did:plc:target', viewer: {} } as never;
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    act(() => {
+      result.current.unfollow(profile);
+    });
+
+    expect(mutate).not.toHaveBeenCalled();
+    expect(controller.removeProfile).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith({
+      type: 'error',
+      message: 'settings.followingCleanup.unfollowFailed',
+    });
+  });
+
+  it('reconciles cached state with the live controller on mount', async () => {
+    const liveState = {
+      ...initialFollowingCleanupState(),
+      runState: 'paused' as const,
+      entries: { 'did:plc:x': { profile: { did: 'did:plc:x' }, status: 'done', lastActivityAt: null, followedAt: null } },
+    };
+    controller.getState.mockReturnValue(liveState);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.state.runState).toBe('paused');
+    });
+    expect(result.current.state.entries['did:plc:x']).toBeDefined();
+  });
+});

--- a/apps/akari/__tests__/hooks/useFollowingCleanupFilters.test.tsx
+++ b/apps/akari/__tests__/hooks/useFollowingCleanupFilters.test.tsx
@@ -1,0 +1,184 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { useFollowingCleanupFilters } from '@/hooks/useFollowingCleanupFilters';
+import type { FollowingCleanupEntry, FollowingCleanupState } from '@/utils/followingCleanupController';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = new Date('2026-05-29T00:00:00.000Z').getTime();
+
+function makeEntry(overrides: Partial<FollowingCleanupEntry> & { did: string }): FollowingCleanupEntry {
+  const { did, profile, ...rest } = overrides;
+  return {
+    status: 'done',
+    lastActivityAt: null,
+    followedAt: null,
+    ...rest,
+    profile: {
+      did,
+      handle: `${did}.test`,
+      ...profile,
+    } as FollowingCleanupEntry['profile'],
+  };
+}
+
+function makeState(entries: FollowingCleanupEntry[]): FollowingCleanupState {
+  const map: FollowingCleanupState['entries'] = {};
+  for (const e of entries) map[e.profile.did] = e;
+  return {
+    entries: map,
+    totalDiscovered: entries.length,
+    totalScanned: entries.length,
+    paginationDone: true,
+    runState: 'completed',
+  };
+}
+
+describe('useFollowingCleanupFilters', () => {
+  it('excludes entries that are not done', () => {
+    const state = makeState([
+      makeEntry({ did: 'pending', status: 'pending', lastActivityAt: null }),
+      makeEntry({ did: 'done', status: 'done', lastActivityAt: null }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(), 'never', 'lastActivity', NOW),
+    );
+    expect(result.current.filteredFollows.map((e) => e.profile.did)).toEqual(['done']);
+  });
+
+  it('excludes skipped dids from filteredFollows', () => {
+    const state = makeState([
+      makeEntry({ did: 'a', lastActivityAt: null }),
+      makeEntry({ did: 'b', lastActivityAt: null }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(['a']), 'never', 'lastActivity', NOW),
+    );
+    expect(result.current.filteredFollows.map((e) => e.profile.did)).toEqual(['b']);
+  });
+
+  it("threshold 'never' only keeps entries with null lastActivity", () => {
+    const state = makeState([
+      makeEntry({ did: 'silent', lastActivityAt: null }),
+      makeEntry({ did: 'active', lastActivityAt: new Date(NOW).toISOString() }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(), 'never', 'lastActivity', NOW),
+    );
+    expect(result.current.filteredFollows.map((e) => e.profile.did)).toEqual(['silent']);
+  });
+
+  it('numeric threshold keeps null-activity entries and entries older than the cutoff', () => {
+    const state = makeState([
+      makeEntry({ did: 'null', lastActivityAt: null }),
+      makeEntry({ did: 'old', lastActivityAt: new Date(NOW - 40 * DAY_MS).toISOString() }),
+      makeEntry({ did: 'recent', lastActivityAt: new Date(NOW - 10 * DAY_MS).toISOString() }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(), 30, 'lastActivity', NOW),
+    );
+    const dids = result.current.filteredFollows.map((e) => e.profile.did);
+    expect(dids).toContain('null');
+    expect(dids).toContain('old');
+    expect(dids).not.toContain('recent');
+  });
+
+  it('sorts by lastActivity ascending (oldest first, null treated as 0)', () => {
+    const state = makeState([
+      makeEntry({ did: 'newer', lastActivityAt: new Date(NOW - 40 * DAY_MS).toISOString() }),
+      makeEntry({ did: 'older', lastActivityAt: new Date(NOW - 100 * DAY_MS).toISOString() }),
+      makeEntry({ did: 'null', lastActivityAt: null }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(), 30, 'lastActivity', NOW),
+    );
+    expect(result.current.filteredFollows.map((e) => e.profile.did)).toEqual([
+      'null',
+      'older',
+      'newer',
+    ]);
+  });
+
+  it('sorts by followedAt with null sorting to the bottom', () => {
+    const state = makeState([
+      makeEntry({ did: 'recentFollow', lastActivityAt: null, followedAt: new Date(NOW - 5 * DAY_MS).toISOString() }),
+      makeEntry({ did: 'oldFollow', lastActivityAt: null, followedAt: new Date(NOW - 500 * DAY_MS).toISOString() }),
+      makeEntry({ did: 'noFollow', lastActivityAt: null, followedAt: null }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(), 'never', 'followedAt', NOW),
+    );
+    expect(result.current.filteredFollows.map((e) => e.profile.did)).toEqual([
+      'oldFollow',
+      'recentFollow',
+      'noFollow',
+    ]);
+  });
+
+  it('sorts by fewestPosts ascending (missing count treated as 0)', () => {
+    const state = makeState([
+      makeEntry({ did: 'many', lastActivityAt: null, profile: { postsCount: 100 } as never }),
+      makeEntry({ did: 'few', lastActivityAt: null, profile: { postsCount: 2 } as never }),
+      makeEntry({ did: 'none', lastActivityAt: null }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(), 'never', 'fewestPosts', NOW),
+    );
+    expect(result.current.filteredFollows.map((e) => e.profile.did)).toEqual([
+      'none',
+      'few',
+      'many',
+    ]);
+  });
+
+  it('sorts by mostFollowers descending (missing count treated as 0)', () => {
+    const state = makeState([
+      makeEntry({ did: 'small', lastActivityAt: null, profile: { followersCount: 5 } as never }),
+      makeEntry({ did: 'big', lastActivityAt: null, profile: { followersCount: 9000 } as never }),
+      makeEntry({ did: 'none', lastActivityAt: null }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(), 'never', 'mostFollowers', NOW),
+    );
+    expect(result.current.filteredFollows.map((e) => e.profile.did)).toEqual([
+      'big',
+      'small',
+      'none',
+    ]);
+  });
+
+  it('followedAt sort handles both present and missing followedAt on either side', () => {
+    const state = makeState([
+      makeEntry({ did: 'hasFollow', lastActivityAt: null, followedAt: new Date(NOW - 3 * DAY_MS).toISOString() }),
+      makeEntry({ did: 'noFollowA', lastActivityAt: null, followedAt: null }),
+      makeEntry({ did: 'noFollowB', lastActivityAt: null, followedAt: null }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(), 'never', 'followedAt', NOW),
+    );
+    expect(result.current.filteredFollows[0].profile.did).toBe('hasFollow');
+  });
+
+  it('lastActivity sort places null-activity entries first', () => {
+    const state = makeState([
+      makeEntry({ did: 'hasActivity', lastActivityAt: new Date(NOW - 200 * DAY_MS).toISOString() }),
+      makeEntry({ did: 'nullActivity', lastActivityAt: null }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(), 30, 'lastActivity', NOW),
+    );
+    expect(result.current.filteredFollows.map((e) => e.profile.did)).toEqual([
+      'nullActivity',
+      'hasActivity',
+    ]);
+  });
+
+  it('skippedEntries only includes skipped dids that have a scanned entry', () => {
+    const state = makeState([
+      makeEntry({ did: 'scanned', lastActivityAt: null }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(['scanned', 'unscanned']), 'never', 'lastActivity', NOW),
+    );
+    expect(result.current.skippedEntries.map((e) => e.profile.did)).toEqual(['scanned']);
+  });
+});

--- a/apps/akari/__tests__/hooks/useFollowingCleanupLabels.test.tsx
+++ b/apps/akari/__tests__/hooks/useFollowingCleanupLabels.test.tsx
@@ -1,0 +1,135 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { useFollowingCleanupLabels } from '@/hooks/useFollowingCleanupLabels';
+import type { FollowingCleanupEntry } from '@/utils/followingCleanupController';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = new Date('2026-05-29T00:00:00.000Z').getTime();
+
+function makeEntry(overrides: Omit<Partial<FollowingCleanupEntry>, 'profile'> & { profile?: Record<string, unknown> }): FollowingCleanupEntry {
+  const { profile, ...rest } = overrides;
+  return {
+    status: 'done',
+    lastActivityAt: null,
+    followedAt: null,
+    ...rest,
+    profile: {
+      did: 'did:plc:test',
+      handle: 'test.test',
+      ...profile,
+    } as FollowingCleanupEntry['profile'],
+  };
+}
+
+describe('useFollowingCleanupLabels', () => {
+  describe('getLastActivityLabel', () => {
+    it('returns activityUnknown when lastActivity is null and postsCount is undefined', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      const label = result.current.getLastActivityLabel(makeEntry({ lastActivityAt: null }));
+      expect(label).toBe('settings.followingCleanup.activityUnknown');
+    });
+
+    it('returns activityUnknown when null activity but postsCount > 0 (AppView gap)', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      const label = result.current.getLastActivityLabel(
+        makeEntry({ lastActivityAt: null, profile: { postsCount: 12 } }),
+      );
+      expect(label).toBe('settings.followingCleanup.activityUnknown');
+    });
+
+    it('returns neverPosted when null activity and postsCount is 0', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      const label = result.current.getLastActivityLabel(
+        makeEntry({ lastActivityAt: null, profile: { postsCount: 0 } }),
+      );
+      expect(label).toBe('settings.followingCleanup.neverPosted');
+    });
+
+    it('returns lastSeenToday for activity less than a day ago', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      const label = result.current.getLastActivityLabel(
+        makeEntry({ lastActivityAt: new Date(NOW - 1000).toISOString() }),
+      );
+      expect(label).toBe('settings.followingCleanup.lastSeenToday');
+    });
+
+    it('returns lastSeenOneDay for exactly one day ago', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      const label = result.current.getLastActivityLabel(
+        makeEntry({ lastActivityAt: new Date(NOW - DAY_MS).toISOString() }),
+      );
+      expect(label).toBe('settings.followingCleanup.lastSeenOneDay');
+    });
+
+    it('returns lastSeenDays for multiple days ago', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      const label = result.current.getLastActivityLabel(
+        makeEntry({ lastActivityAt: new Date(NOW - 5 * DAY_MS).toISOString() }),
+      );
+      expect(label).toBe('settings.followingCleanup.lastSeenDays');
+    });
+  });
+
+  describe('getFollowedAtLabel', () => {
+    it('returns null when followedAt is missing', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      expect(result.current.getFollowedAtLabel(makeEntry({ followedAt: null }))).toBeNull();
+    });
+
+    it('returns followedToday for less than a day', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      expect(
+        result.current.getFollowedAtLabel(makeEntry({ followedAt: new Date(NOW - 1000).toISOString() })),
+      ).toBe('settings.followingCleanup.followedToday');
+    });
+
+    it('returns followedOneDay for exactly one day', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      expect(
+        result.current.getFollowedAtLabel(makeEntry({ followedAt: new Date(NOW - DAY_MS).toISOString() })),
+      ).toBe('settings.followingCleanup.followedOneDay');
+    });
+
+    it('returns followedDays for under 30 days', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      expect(
+        result.current.getFollowedAtLabel(makeEntry({ followedAt: new Date(NOW - 10 * DAY_MS).toISOString() })),
+      ).toBe('settings.followingCleanup.followedDays');
+    });
+
+    it('returns followedMonths between 30 days and a year', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      expect(
+        result.current.getFollowedAtLabel(makeEntry({ followedAt: new Date(NOW - 90 * DAY_MS).toISOString() })),
+      ).toBe('settings.followingCleanup.followedMonths');
+    });
+
+    it('returns followedYears beyond a year', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      expect(
+        result.current.getFollowedAtLabel(makeEntry({ followedAt: new Date(NOW - 800 * DAY_MS).toISOString() })),
+      ).toBe('settings.followingCleanup.followedYears');
+    });
+  });
+
+  describe('getStatsLabel', () => {
+    it('returns null when no counts are present', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      expect(result.current.getStatsLabel(makeEntry({ profile: {} }))).toBeNull();
+    });
+
+    it('returns the stats key when at least one count is present', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      const label = result.current.getStatsLabel(
+        makeEntry({ profile: { followersCount: 1200, followsCount: 50, postsCount: 3400 } }),
+      );
+      expect(label).toBe('settings.followingCleanup.stats');
+    });
+
+    it('renders the line even when only one count is defined', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      const label = result.current.getStatsLabel(makeEntry({ profile: { postsCount: 0 } }));
+      expect(label).toBe('settings.followingCleanup.stats');
+    });
+  });
+});

--- a/apps/akari/__tests__/hooks/useFollowingCleanupSkips.test.tsx
+++ b/apps/akari/__tests__/hooks/useFollowingCleanupSkips.test.tsx
@@ -1,0 +1,115 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { MMKV } from 'react-native-mmkv';
+
+import { useFollowingCleanupSkips } from '@/hooks/useFollowingCleanupSkips';
+
+describe('useFollowingCleanupSkips', () => {
+  it('falls back to an empty set when stored value is not valid JSON', () => {
+    const storage = new MMKV({ id: 'following-cleanup-skips' });
+    storage.set('skips:did:plc:badjson', 'not-json{');
+    const { result } = renderHook(() => useFollowingCleanupSkips('did:plc:badjson'));
+    expect(result.current.skipped.size).toBe(0);
+  });
+
+  it('falls back to an empty set when stored value is not an array', () => {
+    const storage = new MMKV({ id: 'following-cleanup-skips' });
+    storage.set('skips:did:plc:notarray', JSON.stringify({ foo: 'bar' }));
+    const { result } = renderHook(() => useFollowingCleanupSkips('did:plc:notarray'));
+    expect(result.current.skipped.size).toBe(0);
+  });
+
+  it('reads a previously-persisted array and filters non-strings', () => {
+    const storage = new MMKV({ id: 'following-cleanup-skips' });
+    storage.set('skips:did:plc:persisted', JSON.stringify(['did:plc:keep', 42, null]));
+    const { result } = renderHook(() => useFollowingCleanupSkips('did:plc:persisted'));
+    expect(result.current.skipped.has('did:plc:keep')).toBe(true);
+    expect(result.current.skipped.size).toBe(1);
+  });
+
+  it('returns an empty set and no-ops when accountDid is undefined', () => {
+    const { result } = renderHook(() => useFollowingCleanupSkips(undefined));
+    expect(result.current.skipped.size).toBe(0);
+
+    act(() => {
+      result.current.skip('did:plc:x');
+      result.current.unskip('did:plc:x');
+      result.current.clearAll();
+    });
+    expect(result.current.skipped.size).toBe(0);
+  });
+
+  it('adds a did via skip and reflects it reactively', () => {
+    const { result } = renderHook(() => useFollowingCleanupSkips('did:plc:alpha'));
+    expect(result.current.skipped.has('did:plc:1')).toBe(false);
+
+    act(() => {
+      result.current.skip('did:plc:1');
+    });
+    expect(result.current.skipped.has('did:plc:1')).toBe(true);
+  });
+
+  it('does not duplicate or re-notify when skipping an already-skipped did', () => {
+    const { result } = renderHook(() => useFollowingCleanupSkips('did:plc:beta'));
+    act(() => {
+      result.current.skip('did:plc:dup');
+    });
+    const first = result.current.skipped;
+    act(() => {
+      result.current.skip('did:plc:dup');
+    });
+    expect(result.current.skipped).toBe(first);
+    expect(result.current.skipped.size).toBe(1);
+  });
+
+  it('removes a did via unskip', () => {
+    const { result } = renderHook(() => useFollowingCleanupSkips('did:plc:gamma'));
+    act(() => {
+      result.current.skip('did:plc:a');
+      result.current.skip('did:plc:b');
+    });
+    expect(result.current.skipped.size).toBe(2);
+
+    act(() => {
+      result.current.unskip('did:plc:a');
+    });
+    expect(result.current.skipped.has('did:plc:a')).toBe(false);
+    expect(result.current.skipped.has('did:plc:b')).toBe(true);
+  });
+
+  it('unskip of an absent did does not notify or change state', () => {
+    const { result } = renderHook(() => useFollowingCleanupSkips('did:plc:delta'));
+    act(() => {
+      result.current.skip('did:plc:present');
+    });
+    const snapshot = result.current.skipped;
+    act(() => {
+      result.current.unskip('did:plc:absent');
+    });
+    expect(result.current.skipped).toBe(snapshot);
+  });
+
+  it('clearAll empties the skip set', () => {
+    const { result } = renderHook(() => useFollowingCleanupSkips('did:plc:epsilon'));
+    act(() => {
+      result.current.skip('did:plc:a');
+      result.current.skip('did:plc:b');
+    });
+    expect(result.current.skipped.size).toBe(2);
+
+    act(() => {
+      result.current.clearAll();
+    });
+    expect(result.current.skipped.size).toBe(0);
+  });
+
+  it('keeps skip lists isolated per account', () => {
+    const a = renderHook(() => useFollowingCleanupSkips('did:plc:acctA'));
+    const b = renderHook(() => useFollowingCleanupSkips('did:plc:acctB'));
+
+    act(() => {
+      a.result.current.skip('did:plc:shared');
+    });
+    expect(a.result.current.skipped.has('did:plc:shared')).toBe(true);
+    expect(b.result.current.skipped.has('did:plc:shared')).toBe(false);
+  });
+});

--- a/apps/akari/__tests__/hooks/useNotifyAudience.test.tsx
+++ b/apps/akari/__tests__/hooks/useNotifyAudience.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook, act } from '@testing-library/react-native';
+
+import { useNotifyAudience } from '@/hooks/useNotifyAudience';
+
+describe('useNotifyAudience', () => {
+  it('defaults to "followers" when nothing is stored', () => {
+    const { result } = renderHook(() => useNotifyAudience());
+    expect(result.current.audience).toBe('followers');
+  });
+
+  it('updates the audience and reflects it on subsequent reads', () => {
+    const { result } = renderHook(() => useNotifyAudience());
+
+    act(() => {
+      result.current.setAudience('mutuals');
+    });
+    expect(result.current.audience).toBe('mutuals');
+
+    act(() => {
+      result.current.setAudience('no-one');
+    });
+    expect(result.current.audience).toBe('no-one');
+  });
+
+  it('notifies every mounted subscriber of a change', () => {
+    const a = renderHook(() => useNotifyAudience());
+    const b = renderHook(() => useNotifyAudience());
+
+    act(() => {
+      a.result.current.setAudience('anyone');
+    });
+
+    expect(a.result.current.audience).toBe('anyone');
+    expect(b.result.current.audience).toBe('anyone');
+  });
+});

--- a/apps/akari/__tests__/hooks/useProfileMenuItems.test.tsx
+++ b/apps/akari/__tests__/hooks/useProfileMenuItems.test.tsx
@@ -1,0 +1,390 @@
+import { renderHook, act } from '@testing-library/react-native';
+
+import { searchProfilePosts } from '@/components/profile/profileActions';
+import { useToast } from '@/contexts/ToastContext';
+import { useBlockUser } from '@/hooks/mutations/useBlockUser';
+import { useMuteUser } from '@/hooks/mutations/useMuteUser';
+import { useConfirm } from '@/hooks/useConfirm';
+import { useProfileMenuItems } from '@/hooks/useProfileMenuItems';
+import { useRequireAuth } from '@/hooks/useRequireAuth';
+
+import * as Clipboard from 'expo-clipboard';
+import * as Haptics from 'expo-haptics';
+
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: jest.fn(),
+}));
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  ImpactFeedbackStyle: { Light: 'light', Medium: 'medium' },
+}));
+
+jest.mock('@/components/profile/profileActions', () => ({
+  searchProfilePosts: jest.fn(),
+}));
+
+jest.mock('@/contexts/ToastContext', () => ({
+  useToast: jest.fn(),
+}));
+
+jest.mock('@/hooks/mutations/useBlockUser', () => ({
+  useBlockUser: jest.fn(),
+}));
+
+jest.mock('@/hooks/mutations/useMuteUser', () => ({
+  useMuteUser: jest.fn(),
+}));
+
+jest.mock('@/hooks/useConfirm', () => ({
+  useConfirm: jest.fn(),
+}));
+
+jest.mock('@/hooks/useRequireAuth', () => ({
+  useRequireAuth: jest.fn(),
+}));
+
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockShowToast = jest.fn();
+const mockConfirm = jest.fn();
+const mockPromptSignIn = jest.fn();
+const mockBlockMutateAsync = jest.fn();
+const mockMuteMutate = jest.fn();
+
+function setup(args: Parameters<typeof useProfileMenuItems>[0]) {
+  return renderHook(() => useProfileMenuItems(args));
+}
+
+const baseProfile = {
+  did: 'did:plc:alice',
+  handle: 'alice.test',
+  viewer: {},
+} as unknown as NonNullable<Parameters<typeof useProfileMenuItems>[0]['profile']>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useToast as jest.Mock).mockReturnValue({ showToast: mockShowToast });
+  (useConfirm as jest.Mock).mockReturnValue(mockConfirm);
+  (useRequireAuth as jest.Mock).mockReturnValue({
+    isGuest: false,
+    promptSignIn: mockPromptSignIn,
+  });
+  (useBlockUser as jest.Mock).mockReturnValue({ mutateAsync: mockBlockMutateAsync });
+  (useMuteUser as jest.Mock).mockReturnValue({ mutate: mockMuteMutate });
+  mockBlockMutateAsync.mockResolvedValue(undefined);
+});
+
+describe('useProfileMenuItems', () => {
+  it('returns only search + copy link for the user\'s own profile', () => {
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: true,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    expect(result.current.map((i) => i.key)).toEqual(['search', 'copyLink']);
+  });
+
+  it('returns the full menu for another profile', () => {
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    expect(result.current.map((i) => i.key)).toEqual([
+      'copyLink',
+      'search',
+      'addToLists',
+      'mute',
+      'block',
+      'report',
+    ]);
+  });
+
+  it('appends a "message on Germ" row when the callback is provided', () => {
+    const onMessageOnGerm = jest.fn();
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+      onMessageOnGerm,
+    });
+
+    const germItem = result.current.find((i) => i.key === 'messageOnGerm');
+    expect(germItem).toBeDefined();
+
+    act(() => {
+      germItem?.onPress?.();
+    });
+    expect(onMessageOnGerm).toHaveBeenCalled();
+    expect(Haptics.impactAsync).toHaveBeenCalledWith('light');
+  });
+
+  it('shows "unmute"/"unblock" labels when already muted/blocked', () => {
+    const blockedMuted = {
+      ...baseProfile,
+      viewer: { blocking: 'at://block', muted: true },
+    } as typeof baseProfile;
+
+    const { result } = setup({
+      profile: blockedMuted,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    expect(result.current.find((i) => i.key === 'mute')?.label).toBe('common.unmute');
+    expect(result.current.find((i) => i.key === 'block')?.label).toBe('common.unblock');
+  });
+
+  it('copies the profile link and toasts success', async () => {
+    (Clipboard.setStringAsync as jest.Mock).mockResolvedValueOnce(undefined);
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    const copy = result.current.find((i) => i.key === 'copyLink');
+    await act(async () => {
+      await copy?.onPress?.();
+    });
+
+    expect(Clipboard.setStringAsync).toHaveBeenCalledWith(
+      'https://bsky.app/profile/alice.test',
+    );
+    expect(mockShowToast).toHaveBeenCalledWith({
+      message: 'profile.linkCopied',
+      type: 'success',
+    });
+  });
+
+  it('confirms an error when the clipboard write throws', async () => {
+    (Clipboard.setStringAsync as jest.Mock).mockRejectedValueOnce(new Error('clipboard'));
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    const copy = result.current.find((i) => i.key === 'copyLink');
+    await act(async () => {
+      await copy?.onPress?.();
+    });
+
+    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'profile.linkCopyError' }),
+    );
+  });
+
+  it('confirms before copying when there is no handle', async () => {
+    const noHandle = { ...baseProfile, handle: undefined } as unknown as typeof baseProfile;
+    const { result } = setup({
+      profile: noHandle,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    const copy = result.current.find((i) => i.key === 'copyLink');
+    await act(async () => {
+      await copy?.onPress?.();
+    });
+
+    expect(Clipboard.setStringAsync).not.toHaveBeenCalled();
+    expect(mockConfirm).toHaveBeenCalled();
+  });
+
+  it('triggers profile post search', () => {
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    act(() => {
+      result.current.find((i) => i.key === 'search')?.onPress?.();
+    });
+    expect(searchProfilePosts).toHaveBeenCalledWith({ handle: 'alice.test' });
+  });
+
+  it('opens the list picker from "add to lists"', () => {
+    const onOpenListPicker = jest.fn();
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker,
+    });
+
+    act(() => {
+      result.current.find((i) => i.key === 'addToLists')?.onPress?.();
+    });
+    expect(onOpenListPicker).toHaveBeenCalled();
+  });
+
+  it('opens the report sheet for an authenticated user', () => {
+    const onOpenReportSheet = jest.fn();
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet,
+      onOpenListPicker: jest.fn(),
+    });
+
+    act(() => {
+      result.current.find((i) => i.key === 'report')?.onPress?.();
+    });
+    expect(onOpenReportSheet).toHaveBeenCalled();
+    expect(Haptics.impactAsync).toHaveBeenCalledWith('medium');
+  });
+
+  it('prompts sign-in instead of mutating for a guest', () => {
+    (useRequireAuth as jest.Mock).mockReturnValue({
+      isGuest: true,
+      promptSignIn: mockPromptSignIn,
+    });
+    const onOpenReportSheet = jest.fn();
+
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet,
+      onOpenListPicker: jest.fn(),
+    });
+
+    act(() => {
+      result.current.find((i) => i.key === 'block')?.onPress?.();
+    });
+    act(() => {
+      result.current.find((i) => i.key === 'mute')?.onPress?.();
+    });
+    act(() => {
+      result.current.find((i) => i.key === 'report')?.onPress?.();
+    });
+
+    expect(mockPromptSignIn).toHaveBeenCalledTimes(3);
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(onOpenReportSheet).not.toHaveBeenCalled();
+  });
+
+  it('confirms then blocks when the destructive button is pressed', async () => {
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    act(() => {
+      result.current.find((i) => i.key === 'block')?.onPress?.();
+    });
+
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+    const confirmArgs = mockConfirm.mock.calls[0][0];
+    const destructiveButton = confirmArgs.buttons.find(
+      (b: { style?: string }) => b.style === 'destructive',
+    );
+
+    await act(async () => {
+      await destructiveButton.onPress();
+    });
+
+    expect(mockBlockMutateAsync).toHaveBeenCalledWith({
+      did: 'did:plc:alice',
+      action: 'block',
+    });
+  });
+
+  it('unblocks (passing the existing block uri) when already blocking', async () => {
+    const blocked = {
+      ...baseProfile,
+      viewer: { blocking: 'at://existing-block' },
+    } as typeof baseProfile;
+
+    const { result } = setup({
+      profile: blocked,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    act(() => {
+      result.current.find((i) => i.key === 'block')?.onPress?.();
+    });
+    const destructiveButton = mockConfirm.mock.calls[0][0].buttons.find(
+      (b: { style?: string }) => b.style === 'destructive',
+    );
+
+    await act(async () => {
+      await destructiveButton.onPress();
+    });
+
+    expect(mockBlockMutateAsync).toHaveBeenCalledWith({
+      did: 'did:plc:alice',
+      blockUri: 'at://existing-block',
+      action: 'unblock',
+    });
+  });
+
+  it('toasts an error when the block mutation throws', async () => {
+    mockBlockMutateAsync.mockRejectedValueOnce(new Error('nope'));
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    act(() => {
+      result.current.find((i) => i.key === 'block')?.onPress?.();
+    });
+    const destructiveButton = mockConfirm.mock.calls[0][0].buttons.find(
+      (b: { style?: string }) => b.style === 'destructive',
+    );
+
+    await act(async () => {
+      await destructiveButton.onPress();
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error' }),
+    );
+  });
+
+  it('confirms then mutes when the destructive button is pressed', () => {
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    act(() => {
+      result.current.find((i) => i.key === 'mute')?.onPress?.();
+    });
+    const destructiveButton = mockConfirm.mock.calls[0][0].buttons.find(
+      (b: { style?: string }) => b.style === 'destructive',
+    );
+
+    act(() => {
+      destructiveButton.onPress();
+    });
+
+    expect(mockMuteMutate).toHaveBeenCalledWith({
+      actor: 'did:plc:alice',
+      action: 'mute',
+    });
+  });
+});

--- a/apps/akari/__tests__/hooks/useRateLimitWait.test.tsx
+++ b/apps/akari/__tests__/hooks/useRateLimitWait.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook, act } from '@testing-library/react-native';
+
+import { getRateLimitCooldownUntil } from '@/bluesky-api';
+import { useRateLimitWait } from '@/hooks/useRateLimitWait';
+
+jest.mock('@/bluesky-api', () => ({
+  getRateLimitCooldownUntil: jest.fn(),
+}));
+
+describe('useRateLimitWait', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns 0 when no pds url is supplied', () => {
+    const { result } = renderHook(() => useRateLimitWait(undefined));
+    expect(result.current).toBe(0);
+    expect(getRateLimitCooldownUntil).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 when the client is not rate-limited', () => {
+    (getRateLimitCooldownUntil as jest.Mock).mockReturnValue(undefined);
+    const { result } = renderHook(() => useRateLimitWait('https://pds.test'));
+    expect(result.current).toBe(0);
+  });
+
+  it('returns the remaining wait in milliseconds', () => {
+    // cooldown until t=5000, now is t=0 -> 5000ms remaining
+    (getRateLimitCooldownUntil as jest.Mock).mockReturnValue(5000);
+    const { result } = renderHook(() => useRateLimitWait('https://pds.test'));
+    expect(result.current).toBe(5000);
+  });
+
+  it('never returns a negative wait once the cooldown has passed', () => {
+    (getRateLimitCooldownUntil as jest.Mock).mockReturnValue(1000);
+    jest.setSystemTime(2000);
+    const { result } = renderHook(() => useRateLimitWait('https://pds.test'));
+    expect(result.current).toBe(0);
+  });
+
+  it('recomputes the remaining wait on each one-second tick', () => {
+    (getRateLimitCooldownUntil as jest.Mock).mockReturnValue(10_000);
+
+    const { result } = renderHook(() => useRateLimitWait('https://pds.test'));
+    expect(result.current).toBe(10_000);
+
+    // advance the clock 3s; the interval fires and the memo recomputes.
+    // advanceTimersByTime also moves the fake Date forward, so now=3000.
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(result.current).toBe(7000);
+  });
+
+  it('clears its interval on unmount', () => {
+    (getRateLimitCooldownUntil as jest.Mock).mockReturnValue(10_000);
+    const clearSpy = jest.spyOn(global, 'clearInterval');
+
+    const { unmount } = renderHook(() => useRateLimitWait('https://pds.test'));
+    unmount();
+
+    expect(clearSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/useSavedFeedsList.test.tsx
+++ b/apps/akari/__tests__/hooks/useSavedFeedsList.test.tsx
@@ -1,0 +1,127 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { useSavedFeedsList } from '@/hooks/useSavedFeedsList';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useFeeds } from '@/hooks/queries/useFeeds';
+import { useSavedFeeds } from '@/hooks/queries/usePreferences';
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useFeeds', () => ({
+  useFeeds: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/usePreferences', () => ({
+  useSavedFeeds: jest.fn(),
+}));
+
+describe('useSavedFeedsList', () => {
+  const refetchFeeds = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did:plc:me', handle: 'me.test', pdsUrl: 'https://pds' },
+    });
+    (useSavedFeeds as jest.Mock).mockReturnValue({ data: [], isLoading: false });
+    (useFeeds as jest.Mock).mockReturnValue({
+      data: { feeds: [] },
+      isLoading: false,
+      refetch: refetchFeeds,
+    });
+  });
+
+  it('passes the current account did and limit 50 to useFeeds', () => {
+    renderHook(() => useSavedFeedsList());
+    expect(useFeeds as jest.Mock).toHaveBeenCalledWith('did:plc:me', 50);
+  });
+
+  it('expands the synthetic following timeline entry into a feed-shaped record', () => {
+    (useSavedFeeds as jest.Mock).mockReturnValue({
+      data: [{ type: 'timeline', value: 'following' }],
+      isLoading: false,
+    });
+    const { result } = renderHook(() => useSavedFeedsList());
+    expect(result.current.allFeedsWithCreated).toHaveLength(1);
+    const following = result.current.allFeedsWithCreated[0];
+    expect(following.uri).toBe('following');
+    expect(following.displayName).toBe('Following');
+    expect(following.creator.did).toBe('did:plc:me');
+    expect(following.creator.handle).toBe('me.test');
+  });
+
+  it('uses empty strings for the following creator when no account is present', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: undefined });
+    (useSavedFeeds as jest.Mock).mockReturnValue({
+      data: [{ type: 'timeline', value: 'following' }],
+      isLoading: false,
+    });
+    (useFeeds as jest.Mock).mockReturnValue({
+      data: { feeds: [] },
+      isLoading: false,
+      refetch: refetchFeeds,
+    });
+    const { result } = renderHook(() => useSavedFeedsList());
+    expect(result.current.allFeedsWithCreated[0].creator.did).toBe('');
+    expect(result.current.allFeedsWithCreated[0].creator.handle).toBe('');
+  });
+
+  it('passes through feed metadata for saved feed entries', () => {
+    const metadata = { uri: 'at://feed/abc', displayName: 'Cool Feed' };
+    (useSavedFeeds as jest.Mock).mockReturnValue({
+      data: [{ type: 'feed', metadata }],
+      isLoading: false,
+    });
+    const { result } = renderHook(() => useSavedFeedsList());
+    expect(result.current.allFeedsWithCreated).toEqual([metadata]);
+  });
+
+  it('drops feed entries lacking metadata and unknown timeline values', () => {
+    (useSavedFeeds as jest.Mock).mockReturnValue({
+      data: [
+        { type: 'feed', metadata: undefined },
+        { type: 'timeline', value: 'whats-hot' },
+      ],
+      isLoading: false,
+    });
+    const { result } = renderHook(() => useSavedFeedsList());
+    expect(result.current.allFeedsWithCreated).toHaveLength(0);
+  });
+
+  it('concatenates created feeds after the saved feeds', () => {
+    const metadata = { uri: 'at://feed/saved', displayName: 'Saved' };
+    const created = { uri: 'at://feed/created', displayName: 'Created' };
+    (useSavedFeeds as jest.Mock).mockReturnValue({
+      data: [{ type: 'feed', metadata }],
+      isLoading: false,
+    });
+    (useFeeds as jest.Mock).mockReturnValue({
+      data: { feeds: [created] },
+      isLoading: false,
+      refetch: refetchFeeds,
+    });
+    const { result } = renderHook(() => useSavedFeedsList());
+    expect(result.current.allFeedsWithCreated).toEqual([metadata, created]);
+  });
+
+  it('surfaces loading flags and the refetch function', () => {
+    (useSavedFeeds as jest.Mock).mockReturnValue({ data: [], isLoading: true });
+    (useFeeds as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      refetch: refetchFeeds,
+    });
+    const { result } = renderHook(() => useSavedFeedsList());
+    expect(result.current.savedFeedsLoading).toBe(true);
+    expect(result.current.feedsLoading).toBe(true);
+    expect(result.current.refetchFeeds).toBe(refetchFeeds);
+  });
+
+  it('handles undefined savedFeeds without throwing', () => {
+    (useSavedFeeds as jest.Mock).mockReturnValue({ data: undefined, isLoading: false });
+    const { result } = renderHook(() => useSavedFeedsList());
+    expect(result.current.allFeedsWithCreated).toEqual([]);
+  });
+});

--- a/apps/akari/__tests__/utils/appLogoIcon.test.ts
+++ b/apps/akari/__tests__/utils/appLogoIcon.test.ts
@@ -1,0 +1,111 @@
+type Bridge = {
+  setAlternateIconName: jest.Mock;
+  getCurrentAlternateIconName: jest.Mock;
+  supportsAlternateIcons: jest.Mock;
+};
+
+function loadModule(os: string, bridge: Bridge | null) {
+  jest.doMock('react-native', () => ({
+    Platform: { OS: os },
+    NativeModules: bridge ? { AppLogoIconBridge: bridge } : {},
+  }));
+  return require('@/utils/appLogoIcon');
+}
+
+function makeBridge(): Bridge {
+  return {
+    setAlternateIconName: jest.fn().mockResolvedValue(true),
+    getCurrentAlternateIconName: jest.fn().mockResolvedValue(null),
+    supportsAlternateIcons: jest.fn().mockResolvedValue(true),
+  };
+}
+
+describe('appLogoIcon', () => {
+  let warnSpy: jest.SpyInstance;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  describe('applyHomescreenIcon', () => {
+    it('no-ops on web without touching native modules', async () => {
+      const { applyHomescreenIcon } = loadModule('web', null);
+      await expect(applyHomescreenIcon('default')).resolves.toBeUndefined();
+    });
+
+    it('soft no-ops on native when the bridge is unavailable and warns once', async () => {
+      const { applyHomescreenIcon } = loadModule('ios', null);
+      await expect(applyHomescreenIcon('default')).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('NativeModules.AppLogoIconBridge is undefined'),
+      );
+    });
+
+    it('passes null to the native bridge for the default variant', async () => {
+      const bridge = makeBridge();
+      const { applyHomescreenIcon } = loadModule('ios', bridge);
+      await applyHomescreenIcon('default');
+      expect(bridge.setAlternateIconName).toHaveBeenCalledWith(null);
+    });
+
+    it('passes the variant name to the native bridge for non-default variants', async () => {
+      const bridge = makeBridge();
+      const { applyHomescreenIcon } = loadModule('android', bridge);
+      await applyHomescreenIcon('pride' as never);
+      expect(bridge.setAlternateIconName).toHaveBeenCalledWith('pride');
+    });
+
+    it('swallows native bridge errors and warns', async () => {
+      const bridge = makeBridge();
+      bridge.setAlternateIconName.mockRejectedValue(new Error('backgrounded'));
+      const { applyHomescreenIcon } = loadModule('ios', bridge);
+      await expect(applyHomescreenIcon('dark' as never)).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[applyHomescreenIcon] failed',
+        expect.any(Error),
+      );
+    });
+  });
+
+  describe('supportsHomescreenIconSwap', () => {
+    it('returns false on web', async () => {
+      const { supportsHomescreenIconSwap } = loadModule('web', makeBridge());
+      await expect(supportsHomescreenIconSwap()).resolves.toBe(false);
+    });
+
+    it('returns false on native when the bridge is unavailable', async () => {
+      const { supportsHomescreenIconSwap } = loadModule('android', null);
+      await expect(supportsHomescreenIconSwap()).resolves.toBe(false);
+    });
+
+    it('delegates to the native bridge when available', async () => {
+      const bridge = makeBridge();
+      bridge.supportsAlternateIcons.mockResolvedValue(true);
+      const { supportsHomescreenIconSwap } = loadModule('ios', bridge);
+      await expect(supportsHomescreenIconSwap()).resolves.toBe(true);
+      expect(bridge.supportsAlternateIcons).toHaveBeenCalled();
+    });
+
+    it('returns the false value reported by the native bridge', async () => {
+      const bridge = makeBridge();
+      bridge.supportsAlternateIcons.mockResolvedValue(false);
+      const { supportsHomescreenIconSwap } = loadModule('android', bridge);
+      await expect(supportsHomescreenIconSwap()).resolves.toBe(false);
+    });
+
+    it('returns false when the native bridge throws', async () => {
+      const bridge = makeBridge();
+      bridge.supportsAlternateIcons.mockRejectedValue(new Error('nope'));
+      const { supportsHomescreenIconSwap } = loadModule('ios', bridge);
+      await expect(supportsHomescreenIconSwap()).resolves.toBe(false);
+    });
+  });
+});

--- a/apps/akari/__tests__/utils/followingCleanupController.test.ts
+++ b/apps/akari/__tests__/utils/followingCleanupController.test.ts
@@ -1,0 +1,679 @@
+import { QueryClient } from '@tanstack/react-query';
+
+import type { BlueskyProfile } from '@/bluesky-api';
+
+const mockIsRateLimitError = jest.fn();
+
+jest.mock('@/bluesky-api', () => ({
+  isRateLimitError: (...args: unknown[]) => mockIsRateLimitError(...args),
+}));
+
+import {
+  followingCleanupQueryKey,
+  getFollowingCleanupController,
+  initialFollowingCleanupState,
+} from '@/utils/followingCleanupController';
+
+type AnyController = {
+  getState: () => ReturnType<typeof initialFollowingCleanupState>;
+  start: (creds: { api: unknown; token: string }) => Promise<void>;
+  pause: () => void;
+  clear: () => void;
+  removeProfile: (did: string) => void;
+  restoreEntry: (entry: unknown) => void;
+};
+
+const ACCOUNT_DID = 'did:plc:me';
+
+function makeProfile(overrides: Partial<BlueskyProfile> & { did: string }): BlueskyProfile {
+  return {
+    handle: `${overrides.did}.test`,
+    ...overrides,
+  } as unknown as BlueskyProfile;
+}
+
+function makeFeedItem(opts: { postIndexedAt?: string; reasonIndexedAt?: string } = {}) {
+  return {
+    post: opts.postIndexedAt ? { indexedAt: opts.postIndexedAt } : undefined,
+    reason: opts.reasonIndexedAt ? { indexedAt: opts.reasonIndexedAt } : undefined,
+  };
+}
+
+/**
+ * Build a mock BlueskyApi. By default everything paginates a single page and
+ * then reports done (no cursor), so a `start()` call completes promptly.
+ */
+function makeApi(over: Partial<Record<string, jest.Mock>> = {}) {
+  return {
+    getFollows: jest.fn().mockResolvedValue({ follows: [], cursor: undefined }),
+    listFollowRecords: jest.fn().mockResolvedValue({ records: [], cursor: undefined }),
+    getProfiles: jest.fn().mockResolvedValue({ profiles: [] }),
+    getAuthorFeed: jest.fn().mockResolvedValue({ feed: [] }),
+    ...over,
+  };
+}
+
+function makeController(api: ReturnType<typeof makeApi>, did = ACCOUNT_DID) {
+  // Use a unique account DID per controller so the module-level registry
+  // doesn't hand back a controller from a previous test with stale state.
+  const queryClient = new QueryClient();
+  const setSpy = jest.spyOn(queryClient, 'setQueryData');
+  const ctrl = getFollowingCleanupController(queryClient, did) as unknown as AnyController;
+  return { ctrl, queryClient, setSpy, creds: { api, token: 'tok' } };
+}
+
+let uniqueCounter = 0;
+function uniqueDid() {
+  uniqueCounter += 1;
+  return `did:plc:acct-${uniqueCounter}`;
+}
+
+let warnSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  // jest.setup.js enables fake timers globally, but this controller leans on
+  // real setTimeout/setInterval polling to interleave its concurrent
+  // producers and workers. Run these tests against real timers.
+  jest.useRealTimers();
+  jest.clearAllMocks();
+  mockIsRateLimitError.mockReturnValue(false);
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
+describe('followingCleanupQueryKey', () => {
+  it('builds a stable key with the account did', () => {
+    expect(followingCleanupQueryKey('did:plc:x')).toEqual(['followingCleanup', 'did:plc:x']);
+  });
+
+  it('handles an undefined did', () => {
+    expect(followingCleanupQueryKey(undefined)).toEqual(['followingCleanup', undefined]);
+  });
+});
+
+describe('initialFollowingCleanupState', () => {
+  it('returns a fresh idle state', () => {
+    expect(initialFollowingCleanupState()).toEqual({
+      entries: {},
+      totalDiscovered: 0,
+      totalScanned: 0,
+      paginationDone: false,
+      runState: 'idle',
+    });
+  });
+
+  it('returns a new object each call', () => {
+    expect(initialFollowingCleanupState()).not.toBe(initialFollowingCleanupState());
+  });
+});
+
+describe('getFollowingCleanupController', () => {
+  it('returns the same instance for the same account did', () => {
+    const qc = new QueryClient();
+    const a = getFollowingCleanupController(qc, 'did:plc:reuse');
+    const b = getFollowingCleanupController(qc, 'did:plc:reuse');
+    expect(a).toBe(b);
+  });
+
+  it('returns different instances for different account dids', () => {
+    const qc = new QueryClient();
+    const a = getFollowingCleanupController(qc, 'did:plc:one');
+    const b = getFollowingCleanupController(qc, 'did:plc:two');
+    expect(a).not.toBe(b);
+  });
+
+  it('exposes an idle initial state', () => {
+    const qc = new QueryClient();
+    const ctrl = getFollowingCleanupController(qc, 'did:plc:fresh') as unknown as AnyController;
+    expect(ctrl.getState().runState).toBe('idle');
+  });
+});
+
+describe('FollowingCleanupController.start (happy path)', () => {
+  it('discovers, enriches and scans a single follow then completes', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:target';
+    const profile = makeProfile({ did: target });
+    const detailed = makeProfile({ did: target, followersCount: 10 });
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [profile], cursor: undefined }),
+      listFollowRecords: jest.fn().mockResolvedValueOnce({
+        records: [{ value: { subject: target, createdAt: '2024-01-01T00:00:00Z' } }],
+        cursor: undefined,
+      }),
+      getProfiles: jest.fn().mockResolvedValueOnce({ profiles: [detailed] }),
+      getAuthorFeed: jest.fn().mockResolvedValue({
+        feed: [makeFeedItem({ postIndexedAt: '2025-05-05T00:00:00Z' })],
+      }),
+    });
+    const { ctrl, setSpy } = makeController(api, did);
+
+    await ctrl.start({ api, token: 'tok' });
+
+    const state = ctrl.getState();
+    expect(state.runState).toBe('completed');
+    expect(state.paginationDone).toBe(true);
+    expect(state.totalDiscovered).toBe(1);
+    expect(state.totalScanned).toBe(1);
+    const entry = state.entries[target];
+    expect(entry.status).toBe('done');
+    expect(entry.lastActivityAt).toBe('2025-05-05T00:00:00Z');
+    expect(entry.followedAt).toBe('2024-01-01T00:00:00Z');
+    expect(entry.profile.followersCount).toBe(10);
+    // flush writes state to the query cache
+    expect(setSpy).toHaveBeenCalledWith(
+      followingCleanupQueryKey(did),
+      expect.objectContaining({ runState: expect.any(String) }),
+    );
+  });
+
+  it('prefers the reason.indexedAt (repost) over the post indexedAt', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:repost';
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+      getAuthorFeed: jest.fn().mockResolvedValue({
+        feed: [
+          makeFeedItem({
+            postIndexedAt: '2020-01-01T00:00:00Z',
+            reasonIndexedAt: '2025-09-09T00:00:00Z',
+          }),
+        ],
+      }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(ctrl.getState().entries[target].lastActivityAt).toBe('2025-09-09T00:00:00Z');
+  });
+
+  it('retries an empty author feed without the filter and records null activity', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:empty';
+    const getAuthorFeed = jest
+      .fn()
+      .mockResolvedValueOnce({ feed: [] })
+      .mockResolvedValueOnce({ feed: [] });
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+      getAuthorFeed,
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+
+    expect(getAuthorFeed).toHaveBeenCalledTimes(2);
+    // second call is the unfiltered retry (only 3 args)
+    expect(getAuthorFeed.mock.calls[1]).toEqual(['tok', target, 3]);
+    const entry = ctrl.getState().entries[target];
+    expect(entry.status).toBe('done');
+    expect(entry.lastActivityAt).toBeNull();
+  });
+
+  it('paginates multiple follows pages via the cursor', async () => {
+    const did = uniqueDid();
+    const p1 = makeProfile({ did: 'did:plc:p1' });
+    const p2 = makeProfile({ did: 'did:plc:p2' });
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [p1], cursor: 'next' })
+        .mockResolvedValueOnce({ follows: [p2], cursor: undefined }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+
+    const state = ctrl.getState();
+    expect(state.totalDiscovered).toBe(2);
+    expect(Object.keys(state.entries).toSorted()).toEqual(['did:plc:p1', 'did:plc:p2']);
+    // cursor was threaded into the second call
+    expect(api.getFollows.mock.calls[1][3]).toBe('next');
+  });
+
+  it('skips follows that were already discovered', async () => {
+    const did = uniqueDid();
+    const dup = makeProfile({ did: 'did:plc:dup' });
+    const api = makeApi({
+      getFollows: jest.fn().mockResolvedValueOnce({ follows: [dup, dup], cursor: undefined }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(ctrl.getState().totalDiscovered).toBe(1);
+  });
+
+  it('is a no-op when called while already running', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:slow';
+    let resolveFollows: (v: unknown) => void = () => {};
+    const api = makeApi({
+      getFollows: jest.fn().mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFollows = resolve;
+          }),
+      ),
+    });
+    const { ctrl } = makeController(api, did);
+    const first = ctrl.start({ api, token: 'tok' });
+    // second call should return immediately without launching new producers
+    await ctrl.start({ api, token: 'tok' });
+    expect(ctrl.getState().runState).toBe('running');
+    resolveFollows({ follows: [makeProfile({ did: target })], cursor: undefined });
+    await first;
+    expect(ctrl.getState().runState).toBe('completed');
+    expect(api.getFollows).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('FollowingCleanupController.start (follow records producer)', () => {
+  it('stashes orphan followedAt then attaches it when the profile is discovered', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:orphan';
+    // listFollowRecords resolves first (before getFollows) so the date is orphaned.
+    let releaseFollows: (v: unknown) => void = () => {};
+    const api = makeApi({
+      getFollows: jest.fn().mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseFollows = resolve;
+          }),
+      ),
+      listFollowRecords: jest.fn().mockResolvedValueOnce({
+        records: [{ value: { subject: target, createdAt: '2023-03-03T00:00:00Z' } }],
+        cursor: undefined,
+      }),
+    });
+    const { ctrl } = makeController(api, did);
+    const run = ctrl.start({ api, token: 'tok' });
+    // let the records producer run and stash the orphan date
+    await Promise.resolve();
+    await Promise.resolve();
+    releaseFollows({ follows: [makeProfile({ did: target })], cursor: undefined });
+    await run;
+    expect(ctrl.getState().entries[target].followedAt).toBe('2023-03-03T00:00:00Z');
+  });
+
+  it('ignores records missing a subject or createdAt', async () => {
+    const did = uniqueDid();
+    const api = makeApi({
+      listFollowRecords: jest.fn().mockResolvedValueOnce({
+        records: [
+          { value: { subject: undefined, createdAt: '2023-01-01T00:00:00Z' } },
+          { value: { subject: 'did:plc:nope', createdAt: undefined } },
+          { value: undefined },
+        ],
+        cursor: undefined,
+      }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(ctrl.getState().entries).toEqual({});
+  });
+
+  it('paginates follow records via cursor', async () => {
+    const did = uniqueDid();
+    const api = makeApi({
+      listFollowRecords: jest
+        .fn()
+        .mockResolvedValueOnce({ records: [], cursor: 'r2' })
+        .mockResolvedValueOnce({ records: [], cursor: undefined }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(api.listFollowRecords).toHaveBeenCalledTimes(2);
+    expect(api.listFollowRecords.mock.calls[1][3]).toBe('r2');
+  });
+});
+
+describe('FollowingCleanupController.start (profiles enrichment)', () => {
+  it('merges detailed profile data while preserving the viewer.following uri', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:merge';
+    const lightweight = makeProfile({
+      did: target,
+      viewer: { following: 'at://follow/1' },
+    } as Partial<BlueskyProfile> & { did: string });
+    const detailed = makeProfile({
+      did: target,
+      followersCount: 5,
+      viewer: { muted: false },
+    } as Partial<BlueskyProfile> & { did: string });
+    const api = makeApi({
+      getFollows: jest.fn().mockResolvedValueOnce({ follows: [lightweight], cursor: undefined }),
+      getProfiles: jest.fn().mockResolvedValueOnce({ profiles: [detailed] }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    const merged = ctrl.getState().entries[target].profile;
+    expect(merged.followersCount).toBe(5);
+    expect((merged.viewer as { following?: string }).following).toBe('at://follow/1');
+    expect((merged.viewer as { muted?: boolean }).muted).toBe(false);
+  });
+
+  it('ignores detailed entries without a did and unknown dids', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:known';
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+      getProfiles: jest.fn().mockResolvedValueOnce({
+        profiles: [
+          undefined,
+          { did: undefined },
+          makeProfile({ did: 'did:plc:stranger', followersCount: 99 }),
+        ],
+      }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    // stranger never discovered -> not in entries; known stays without counts
+    expect(ctrl.getState().entries['did:plc:stranger']).toBeUndefined();
+    expect(ctrl.getState().entries[target].profile.followersCount).toBeUndefined();
+  });
+});
+
+describe('FollowingCleanupController.start (error handling)', () => {
+  it('retries getFollows on a non-rate-limit error and logs a warning', async () => {
+    const did = uniqueDid();
+    mockIsRateLimitError.mockReturnValue(false);
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce({ follows: [], cursor: undefined }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(api.getFollows).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('does not warn for getFollows rate-limit errors', async () => {
+    const did = uniqueDid();
+    mockIsRateLimitError.mockReturnValue(true);
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('429'))
+        .mockResolvedValueOnce({ follows: [], cursor: undefined }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(api.getFollows).toHaveBeenCalledTimes(2);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('retries listFollowRecords on a non-rate-limit error', async () => {
+    const did = uniqueDid();
+    const api = makeApi({
+      listFollowRecords: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce({ records: [], cursor: undefined }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(api.listFollowRecords).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-queues a getProfiles batch on error and retries', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:retryprofile';
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+      getProfiles: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce({
+          profiles: [makeProfile({ did: target, followersCount: 7 })],
+        }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(api.getProfiles.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(ctrl.getState().entries[target].profile.followersCount).toBe(7);
+  });
+
+  it('marks an entry as error on a non-rate-limit author feed failure', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:feederr';
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+      getAuthorFeed: jest.fn().mockRejectedValue(new Error('feed boom')),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    const entry = ctrl.getState().entries[target];
+    expect(entry.status).toBe('error');
+    expect(ctrl.getState().totalScanned).toBe(1);
+  });
+
+  it('requeues a rate-limited author feed scan without counting it', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:feedrl';
+    // first author feed call rate-limits, second succeeds
+    mockIsRateLimitError.mockImplementation((err: unknown) => (err as Error).message === 'rl');
+    const getAuthorFeed = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('rl'))
+      .mockResolvedValue({ feed: [makeFeedItem({ postIndexedAt: '2025-01-01T00:00:00Z' })] });
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+      getAuthorFeed,
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    const entry = ctrl.getState().entries[target];
+    expect(entry.status).toBe('done');
+    // scanned only once despite the rate-limit requeue
+    expect(ctrl.getState().totalScanned).toBe(1);
+    expect(getAuthorFeed.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('FollowingCleanupController.start (credential guards)', () => {
+  it('completes immediately when start runs but producers find no creds set internally', async () => {
+    // Sanity: a normal empty run still completes.
+    const did = uniqueDid();
+    const api = makeApi();
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(ctrl.getState().runState).toBe('completed');
+  });
+});
+
+describe('FollowingCleanupController.start (resume after completion)', () => {
+  it('wipes state and rescans when start is called again after completion', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:rescan';
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValue({ follows: [makeProfile({ did: target })], cursor: undefined }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(ctrl.getState().runState).toBe('completed');
+    expect(ctrl.getState().totalDiscovered).toBe(1);
+
+    // Second run: completed state is wiped and rebuilt.
+    await ctrl.start({ api, token: 'tok' });
+    expect(ctrl.getState().runState).toBe('completed');
+    expect(ctrl.getState().totalDiscovered).toBe(1);
+    expect(ctrl.getState().totalScanned).toBe(1);
+  });
+});
+
+describe('FollowingCleanupController.pause', () => {
+  it('surfaces paused immediately when idle but data exists', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:pausable';
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+    });
+    const { ctrl, setSpy } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    setSpy.mockClear();
+    ctrl.pause();
+    expect(ctrl.getState().runState).toBe('paused');
+    expect(setSpy).toHaveBeenCalled();
+  });
+
+  it('does nothing when idle with no discovered data', () => {
+    const did = uniqueDid();
+    const { ctrl, setSpy } = makeController(makeApi(), did);
+    ctrl.pause();
+    expect(ctrl.getState().runState).toBe('idle');
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it('requests a graceful stop while running and ends in the paused state', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:running';
+    let releaseFollows: (v: unknown) => void = () => {};
+    const api = makeApi({
+      getFollows: jest.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            releaseFollows = resolve;
+          }),
+      ),
+    });
+    const { ctrl } = makeController(api, did);
+    const run = ctrl.start({ api, token: 'tok' });
+    await Promise.resolve();
+    ctrl.pause();
+    expect(ctrl.getState().runState).toBe('paused');
+    // unblock the in-flight getFollows so producers can observe pauseRequested
+    releaseFollows({ follows: [makeProfile({ did: target })], cursor: 'more' });
+    await run;
+    expect(ctrl.getState().runState).toBe('paused');
+  });
+
+  it('resumes a paused scan, re-enqueuing pending entries', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:resumeme';
+    let releaseFollows: (v: unknown) => void = () => {};
+    const api = makeApi({
+      getFollows: jest.fn().mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseFollows = resolve;
+          }),
+      ),
+      getAuthorFeed: jest
+        .fn()
+        .mockResolvedValue({ feed: [makeFeedItem({ postIndexedAt: '2025-02-02T00:00:00Z' })] }),
+    });
+    const { ctrl } = makeController(api, did);
+    const run = ctrl.start({ api, token: 'tok' });
+    await Promise.resolve();
+    ctrl.pause();
+    // page comes back with a cursor (pagination not done) but pauseRequested halts it
+    releaseFollows({ follows: [makeProfile({ did: target })], cursor: 'next' });
+    await run;
+    expect(ctrl.getState().runState).toBe('paused');
+
+    // Resume: producer now returns a final page and workers drain the queue.
+    api.getFollows.mockResolvedValue({ follows: [], cursor: undefined });
+    await ctrl.start({ api, token: 'tok' });
+    expect(ctrl.getState().runState).toBe('completed');
+    expect(ctrl.getState().entries[target].status).toBe('done');
+  });
+});
+
+describe('FollowingCleanupController.clear', () => {
+  it('resets all state to the initial idle state', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:clearme';
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+    });
+    const { ctrl, setSpy } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(ctrl.getState().totalDiscovered).toBe(1);
+    setSpy.mockClear();
+    ctrl.clear();
+    expect(ctrl.getState()).toEqual(initialFollowingCleanupState());
+    expect(setSpy).toHaveBeenCalled();
+  });
+});
+
+describe('FollowingCleanupController.removeProfile', () => {
+  it('removes an existing entry and flushes', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:removeme';
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+    });
+    const { ctrl, setSpy } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    setSpy.mockClear();
+    ctrl.removeProfile(target);
+    expect(ctrl.getState().entries[target]).toBeUndefined();
+    expect(setSpy).toHaveBeenCalled();
+  });
+
+  it('is a no-op for an unknown did', () => {
+    const did = uniqueDid();
+    const { ctrl, setSpy } = makeController(makeApi(), did);
+    ctrl.removeProfile('did:plc:ghost');
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('FollowingCleanupController.restoreEntry', () => {
+  it('re-inserts a previously removed entry', () => {
+    const did = uniqueDid();
+    const { ctrl, setSpy } = makeController(makeApi(), did);
+    const entry = {
+      profile: makeProfile({ did: 'did:plc:restored' }),
+      status: 'done' as const,
+      lastActivityAt: '2025-01-01T00:00:00Z',
+      followedAt: null,
+    };
+    ctrl.restoreEntry(entry);
+    expect(ctrl.getState().entries['did:plc:restored']).toBe(entry);
+    expect(setSpy).toHaveBeenCalled();
+  });
+
+  it('does not overwrite an entry that already exists', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:exists';
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    const original = ctrl.getState().entries[target];
+    ctrl.restoreEntry({
+      profile: makeProfile({ did: target }),
+      status: 'pending',
+      lastActivityAt: null,
+      followedAt: null,
+    });
+    expect(ctrl.getState().entries[target]).toBe(original);
+  });
+});

--- a/apps/akari/__tests__/utils/navigation.test.ts
+++ b/apps/akari/__tests__/utils/navigation.test.ts
@@ -1,0 +1,266 @@
+import { router, usePathname } from 'expo-router';
+import { Platform } from 'react-native';
+
+import {
+  useNavigateToFeed,
+  useNavigateToGallery,
+  useNavigateToPost,
+  useNavigateToProfile,
+  useProfileHref,
+} from '@/utils/navigation';
+
+// jest.setup.js installs a manual mock for @/utils/navigation (so component
+// tests get a stub). This suite exercises the real implementation, so opt out.
+jest.unmock('@/utils/navigation');
+
+jest.mock('expo-router', () => ({
+  router: { push: jest.fn() },
+  usePathname: jest.fn(),
+}));
+
+const originalPlatform = Platform.OS;
+
+/** Set the value usePathname() returns for the hook under test. */
+function mockPathname(pathname: string) {
+  (usePathname as jest.Mock).mockReturnValue(pathname);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Platform.OS = originalPlatform;
+});
+
+afterAll(() => {
+  Platform.OS = originalPlatform;
+});
+
+describe('useNavigateToPost', () => {
+  it('uses the top-level profile route on web', () => {
+    Platform.OS = 'web';
+    mockPathname('/anything');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).toHaveBeenCalledWith('/profile/alice.test/post/abc');
+  });
+
+  it('encodes actor and rKey', () => {
+    Platform.OS = 'web';
+    mockPathname('/anything');
+    useNavigateToPost()({ actor: 'did:plc:a/b', rKey: 'r k' });
+    expect(router.push).toHaveBeenCalledWith(
+      `/profile/${encodeURIComponent('did:plc:a/b')}/post/${encodeURIComponent('r k')}`,
+    );
+  });
+
+  it('uses the profile tab route on native when on the profile tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/profile/me.test');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).toHaveBeenCalledWith('/profile/alice.test/post/abc');
+  });
+
+  it('uses the collapsed user-profile route on native when on the index tab (root)', () => {
+    Platform.OS = 'ios';
+    mockPathname('/');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).toHaveBeenCalledWith('/user-profile/alice.test/post/abc');
+  });
+
+  it('treats /index paths as the index tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/index/something');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).toHaveBeenCalledWith('/user-profile/alice.test/post/abc');
+  });
+
+  it('treats collapsed /user-profile paths as the index tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/user-profile/bob.test');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).toHaveBeenCalledWith('/user-profile/alice.test/post/abc');
+  });
+
+  it('strips the (tabs) group prefix when detecting the tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/(tabs)/notifications');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).toHaveBeenCalledWith('/notifications/user-profile/alice.test/post/abc');
+  });
+
+  it('uses the per-tab variant for non-index, non-profile tabs', () => {
+    Platform.OS = 'ios';
+    mockPathname('/search/results');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).toHaveBeenCalledWith('/search/user-profile/alice.test/post/abc');
+  });
+
+  it('falls back to the index tab for unknown pathnames', () => {
+    Platform.OS = 'ios';
+    mockPathname('/totally-unknown');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).toHaveBeenCalledWith('/user-profile/alice.test/post/abc');
+  });
+
+  it('does not push when already on the same path (isSamePath guard)', () => {
+    Platform.OS = 'web';
+    mockPathname('/profile/alice.test/post/abc');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).not.toHaveBeenCalled();
+  });
+
+  it('ignores query strings and hashes when comparing paths', () => {
+    Platform.OS = 'web';
+    mockPathname('/profile/alice.test/post/abc?ref=x#top');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).not.toHaveBeenCalled();
+  });
+});
+
+describe('useNavigateToProfile', () => {
+  it('uses the top-level profile route on web', () => {
+    Platform.OS = 'web';
+    mockPathname('/anything');
+    useNavigateToProfile()({ actor: 'alice.test' });
+    expect(router.push).toHaveBeenCalledWith('/profile/alice.test');
+  });
+
+  it('uses the profile tab route on native when on the profile tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/profile/me.test');
+    useNavigateToProfile()({ actor: 'alice.test' });
+    expect(router.push).toHaveBeenCalledWith('/profile/alice.test');
+  });
+
+  it('uses the collapsed user-profile route on native when on the index tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/');
+    useNavigateToProfile()({ actor: 'alice.test' });
+    expect(router.push).toHaveBeenCalledWith('/user-profile/alice.test');
+  });
+
+  it('uses the per-tab variant for other tabs', () => {
+    Platform.OS = 'ios';
+    mockPathname('/messages/convo');
+    useNavigateToProfile()({ actor: 'alice.test' });
+    expect(router.push).toHaveBeenCalledWith('/messages/user-profile/alice.test');
+  });
+
+  it('does not push when already on the same profile path', () => {
+    Platform.OS = 'web';
+    mockPathname('/profile/alice.test');
+    useNavigateToProfile()({ actor: 'alice.test' });
+    expect(router.push).not.toHaveBeenCalled();
+  });
+});
+
+describe('useProfileHref', () => {
+  it('returns the top-level profile href on web', () => {
+    Platform.OS = 'web';
+    mockPathname('/anything');
+    expect(useProfileHref()('alice.test')).toBe('/profile/alice.test');
+  });
+
+  it('returns the profile tab href when on the profile tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/profile/me.test');
+    expect(useProfileHref()('alice.test')).toBe('/profile/alice.test');
+  });
+
+  it('returns the collapsed user-profile href when on the index tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/');
+    expect(useProfileHref()('alice.test')).toBe('/user-profile/alice.test');
+  });
+
+  it('returns the per-tab href for other tabs', () => {
+    Platform.OS = 'ios';
+    mockPathname('/bookmarks');
+    expect(useProfileHref()('alice.test')).toBe('/bookmarks/user-profile/alice.test');
+  });
+
+  it('encodes the actor', () => {
+    Platform.OS = 'web';
+    mockPathname('/anything');
+    expect(useProfileHref()('did:plc:a/b')).toBe(`/profile/${encodeURIComponent('did:plc:a/b')}`);
+  });
+
+  it('does not push (href-only helper)', () => {
+    Platform.OS = 'ios';
+    mockPathname('/');
+    useProfileHref()('alice.test');
+    expect(router.push).not.toHaveBeenCalled();
+  });
+});
+
+describe('useNavigateToFeed', () => {
+  it('uses the top-level profile feed route on web', () => {
+    Platform.OS = 'web';
+    mockPathname('/anything');
+    useNavigateToFeed()({ actor: 'alice.test', rKey: 'feed1' });
+    expect(router.push).toHaveBeenCalledWith('/profile/alice.test/feed/feed1');
+  });
+
+  it('uses the profile tab feed route on native when on the profile tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/profile/me.test');
+    useNavigateToFeed()({ actor: 'alice.test', rKey: 'feed1' });
+    expect(router.push).toHaveBeenCalledWith('/profile/alice.test/feed/feed1');
+  });
+
+  it('uses the collapsed user-profile feed route on the index tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/');
+    useNavigateToFeed()({ actor: 'alice.test', rKey: 'feed1' });
+    expect(router.push).toHaveBeenCalledWith('/user-profile/alice.test/feed/feed1');
+  });
+
+  it('uses the per-tab variant for other tabs', () => {
+    Platform.OS = 'ios';
+    mockPathname('/search/x');
+    useNavigateToFeed()({ actor: 'alice.test', rKey: 'feed1' });
+    expect(router.push).toHaveBeenCalledWith('/search/user-profile/alice.test/feed/feed1');
+  });
+
+  it('does not push when already on the same feed path', () => {
+    Platform.OS = 'web';
+    mockPathname('/profile/alice.test/feed/feed1');
+    useNavigateToFeed()({ actor: 'alice.test', rKey: 'feed1' });
+    expect(router.push).not.toHaveBeenCalled();
+  });
+});
+
+describe('useNavigateToGallery', () => {
+  it('uses the top-level profile gallery route on web', () => {
+    Platform.OS = 'web';
+    mockPathname('/anything');
+    useNavigateToGallery()({ actor: 'alice.test', rKey: 'gal1' });
+    expect(router.push).toHaveBeenCalledWith('/profile/alice.test/gallery/gal1');
+  });
+
+  it('uses the profile tab gallery route on native when on the profile tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/profile/me.test');
+    useNavigateToGallery()({ actor: 'alice.test', rKey: 'gal1' });
+    expect(router.push).toHaveBeenCalledWith('/profile/alice.test/gallery/gal1');
+  });
+
+  it('uses the collapsed user-profile gallery route on the index tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/');
+    useNavigateToGallery()({ actor: 'alice.test', rKey: 'gal1' });
+    expect(router.push).toHaveBeenCalledWith('/user-profile/alice.test/gallery/gal1');
+  });
+
+  it('uses the per-tab variant for other tabs', () => {
+    Platform.OS = 'ios';
+    mockPathname('/bookmarks');
+    useNavigateToGallery()({ actor: 'alice.test', rKey: 'gal1' });
+    expect(router.push).toHaveBeenCalledWith('/bookmarks/user-profile/alice.test/gallery/gal1');
+  });
+
+  it('does not push when already on the same gallery path', () => {
+    Platform.OS = 'web';
+    mockPathname('/profile/alice.test/gallery/gal1');
+    useNavigateToGallery()({ actor: 'alice.test', rKey: 'gal1' });
+    expect(router.push).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/utils/ozoneAvatars.test.ts
+++ b/apps/akari/__tests__/utils/ozoneAvatars.test.ts
@@ -1,0 +1,189 @@
+import {
+  fetchAvatarsByDid,
+  fetchProfilesByDid,
+  subjectDid,
+} from '@/utils/ozoneAvatars';
+import type { BlueskyApi } from '@/bluesky-api';
+
+function makeApi(getProfiles: jest.Mock): BlueskyApi {
+  return { getProfiles } as unknown as BlueskyApi;
+}
+
+describe('fetchAvatarsByDid', () => {
+  it('returns an empty map when no valid DIDs are supplied', async () => {
+    const getProfiles = jest.fn();
+    const out = await fetchAvatarsByDid(makeApi(getProfiles), 'jwt', []);
+    expect(out.size).toBe(0);
+    expect(getProfiles).not.toHaveBeenCalled();
+  });
+
+  it('filters out non-did entries and dedupes', async () => {
+    const getProfiles = jest.fn().mockResolvedValue({
+      profiles: [
+        { did: 'did:plc:a', avatar: 'https://cdn/a.jpg' },
+        { did: 'did:plc:b', avatar: 'https://cdn/b.jpg' },
+      ],
+    });
+    const out = await fetchAvatarsByDid(makeApi(getProfiles), 'jwt', [
+      'did:plc:a',
+      'did:plc:a',
+      'did:plc:b',
+      'not-a-did',
+      '',
+    ]);
+    expect(getProfiles).toHaveBeenCalledTimes(1);
+    expect(getProfiles).toHaveBeenCalledWith('jwt', ['did:plc:a', 'did:plc:b']);
+    expect(out.get('did:plc:a')).toBe('https://cdn/a.jpg');
+    expect(out.get('did:plc:b')).toBe('https://cdn/b.jpg');
+    expect(out.size).toBe(2);
+  });
+
+  it('returns empty map when all DIDs are invalid', async () => {
+    const getProfiles = jest.fn();
+    const out = await fetchAvatarsByDid(makeApi(getProfiles), 'jwt', [
+      'nope',
+      'also-nope',
+    ]);
+    expect(out.size).toBe(0);
+    expect(getProfiles).not.toHaveBeenCalled();
+  });
+
+  it('skips profiles missing a did or a string avatar', async () => {
+    const getProfiles = jest.fn().mockResolvedValue({
+      profiles: [
+        { did: 'did:plc:a', avatar: 'https://cdn/a.jpg' },
+        { did: 'did:plc:b' }, // no avatar
+        { did: 'did:plc:c', avatar: null }, // non-string avatar
+        { avatar: 'https://cdn/orphan.jpg' }, // no did
+      ],
+    });
+    const out = await fetchAvatarsByDid(makeApi(getProfiles), 'jwt', [
+      'did:plc:a',
+      'did:plc:b',
+      'did:plc:c',
+    ]);
+    expect(out.size).toBe(1);
+    expect(out.get('did:plc:a')).toBe('https://cdn/a.jpg');
+  });
+
+  it('chunks requests in batches of 25', async () => {
+    const dids = Array.from({ length: 60 }, (_, i) => `did:plc:${i}`);
+    const getProfiles = jest.fn().mockResolvedValue({ profiles: [] });
+    await fetchAvatarsByDid(makeApi(getProfiles), 'jwt', dids);
+    expect(getProfiles).toHaveBeenCalledTimes(3);
+    expect(getProfiles.mock.calls[0][1]).toHaveLength(25);
+    expect(getProfiles.mock.calls[1][1]).toHaveLength(25);
+    expect(getProfiles.mock.calls[2][1]).toHaveLength(10);
+  });
+
+  it('swallows errors and falls back to a partial/empty map', async () => {
+    const getProfiles = jest.fn().mockRejectedValue(new Error('boom'));
+    const out = await fetchAvatarsByDid(makeApi(getProfiles), 'jwt', ['did:plc:a']);
+    expect(out.size).toBe(0);
+  });
+
+  it('keeps results from successful chunks when a later chunk fails', async () => {
+    const dids = Array.from({ length: 26 }, (_, i) => `did:plc:${i}`);
+    const getProfiles = jest
+      .fn()
+      .mockResolvedValueOnce({
+        profiles: [{ did: 'did:plc:0', avatar: 'https://cdn/0.jpg' }],
+      })
+      .mockRejectedValueOnce(new Error('boom'));
+    const out = await fetchAvatarsByDid(makeApi(getProfiles), 'jwt', dids);
+    expect(out.get('did:plc:0')).toBe('https://cdn/0.jpg');
+    expect(out.size).toBe(1);
+  });
+});
+
+describe('fetchProfilesByDid', () => {
+  it('returns an empty map when no valid DIDs are supplied', async () => {
+    const getProfiles = jest.fn();
+    const out = await fetchProfilesByDid(makeApi(getProfiles), 'jwt', []);
+    expect(out.size).toBe(0);
+    expect(getProfiles).not.toHaveBeenCalled();
+  });
+
+  it('returns full profile-lite blobs and normalizes non-string fields to undefined', async () => {
+    const getProfiles = jest.fn().mockResolvedValue({
+      profiles: [
+        {
+          did: 'did:plc:a',
+          avatar: 'https://cdn/a.jpg',
+          handle: 'alice.test',
+          displayName: 'Alice',
+        },
+        {
+          did: 'did:plc:b',
+          avatar: 42, // non-string
+          handle: null, // non-string
+          displayName: undefined,
+        },
+        { handle: 'orphan.test' }, // no did -> skipped
+      ],
+    });
+    const out = await fetchProfilesByDid(makeApi(getProfiles), 'jwt', [
+      'did:plc:a',
+      'did:plc:b',
+    ]);
+    expect(out.size).toBe(2);
+    expect(out.get('did:plc:a')).toEqual({
+      avatar: 'https://cdn/a.jpg',
+      handle: 'alice.test',
+      displayName: 'Alice',
+    });
+    expect(out.get('did:plc:b')).toEqual({
+      avatar: undefined,
+      handle: undefined,
+      displayName: undefined,
+    });
+  });
+
+  it('chunks requests in batches of 25', async () => {
+    const dids = Array.from({ length: 51 }, (_, i) => `did:plc:${i}`);
+    const getProfiles = jest.fn().mockResolvedValue({ profiles: [] });
+    await fetchProfilesByDid(makeApi(getProfiles), 'jwt', dids);
+    expect(getProfiles).toHaveBeenCalledTimes(3);
+    expect(getProfiles.mock.calls[2][1]).toHaveLength(1);
+  });
+
+  it('swallows errors and returns an empty map', async () => {
+    const getProfiles = jest.fn().mockRejectedValue(new Error('boom'));
+    const out = await fetchProfilesByDid(makeApi(getProfiles), 'jwt', ['did:plc:a']);
+    expect(out.size).toBe(0);
+  });
+});
+
+describe('subjectDid', () => {
+  it('returns undefined for an undefined subject', () => {
+    expect(subjectDid(undefined)).toBeUndefined();
+  });
+
+  it('returns a direct did when present', () => {
+    expect(subjectDid({ did: 'did:plc:direct' })).toBe('did:plc:direct');
+  });
+
+  it('extracts the did from an at:// uri with a collection path', () => {
+    expect(
+      subjectDid({ uri: 'at://did:plc:xyz/app.bsky.feed.post/abc' }),
+    ).toBe('did:plc:xyz');
+  });
+
+  it('extracts the did from an at:// uri with no trailing slash', () => {
+    expect(subjectDid({ uri: 'at://did:plc:onlyrepo' })).toBe('did:plc:onlyrepo');
+  });
+
+  it('returns undefined when the uri is not an at:// uri', () => {
+    expect(subjectDid({ uri: 'https://example.com/foo' })).toBeUndefined();
+  });
+
+  it('returns undefined when neither did nor a usable uri is present', () => {
+    expect(subjectDid({ foo: 'bar' })).toBeUndefined();
+  });
+
+  it('prefers a direct did over a uri', () => {
+    expect(
+      subjectDid({ did: 'did:plc:direct', uri: 'at://did:plc:other/x/y' }),
+    ).toBe('did:plc:direct');
+  });
+});

--- a/apps/akari/__tests__/utils/recipeDefinitions.test.ts
+++ b/apps/akari/__tests__/utils/recipeDefinitions.test.ts
@@ -1,0 +1,78 @@
+import { resolveDietaryRestrictions, resolveRecipeDefinition } from '@/utils/recipeDefinitions';
+
+describe('resolveRecipeDefinition', () => {
+  it('returns "N/A" when the token is undefined', () => {
+    expect(resolveRecipeDefinition(undefined, 'cuisine')).toBe('N/A');
+  });
+
+  it('resolves cooking method tokens', () => {
+    expect(resolveRecipeDefinition('exchange.recipe.defs#cookingMethodAirFrying', 'cookingMethod')).toBe('Air Frying');
+    expect(resolveRecipeDefinition('exchange.recipe.defs#cookingMethodNoCook', 'cookingMethod')).toBe('No Cook');
+  });
+
+  it('resolves category tokens', () => {
+    expect(resolveRecipeDefinition('exchange.recipe.defs#categoryEntree', 'category')).toBe('Entrée');
+    expect(resolveRecipeDefinition('exchange.recipe.defs#categorySide', 'category')).toBe('Side Dish');
+  });
+
+  it('resolves cuisine tokens', () => {
+    expect(resolveRecipeDefinition('exchange.recipe.defs#cuisineItalian', 'cuisine')).toBe('Italian');
+    expect(resolveRecipeDefinition('exchange.recipe.defs#cuisineTexMex', 'cuisine')).toBe('Tex-Mex');
+  });
+
+  it('resolves diet tokens', () => {
+    expect(resolveRecipeDefinition('exchange.recipe.defs#dietVegan', 'diet')).toBe('Vegan');
+    expect(resolveRecipeDefinition('exchange.recipe.defs#dietDiabetic', 'diet')).toBe('Diabetic Friendly');
+  });
+
+  it('resolves attribution tokens', () => {
+    expect(resolveRecipeDefinition('exchange.recipe.defs#attributionTypeOriginal', 'attribution')).toBe('Original');
+    expect(resolveRecipeDefinition('exchange.recipe.defs#attributionTypeProduct', 'attribution')).toBe('Product');
+  });
+
+  it('resolves publication tokens', () => {
+    expect(resolveRecipeDefinition('exchange.recipe.defs#publicationTypeBook', 'publication')).toBe('Book');
+    expect(resolveRecipeDefinition('exchange.recipe.defs#publicationTypeMagazine', 'publication')).toBe('Magazine');
+  });
+
+  it('resolves license tokens', () => {
+    expect(resolveRecipeDefinition('exchange.recipe.defs#licensePublicDomain', 'license')).toBe('Public Domain');
+    expect(resolveRecipeDefinition('exchange.recipe.defs#licenseCreativeCommonsByNcSa', 'license')).toBe('CC BY-NC-SA 4.0');
+  });
+
+  it('returns the raw token when it is not found in the mapping', () => {
+    expect(resolveRecipeDefinition('exchange.recipe.defs#unknownToken', 'cuisine')).toBe(
+      'exchange.recipe.defs#unknownToken',
+    );
+  });
+
+  it('returns the raw token for an unrecognized type', () => {
+    // @ts-expect-error exercising the default branch with an invalid type
+    expect(resolveRecipeDefinition('some-token', 'bogus')).toBe('some-token');
+  });
+});
+
+describe('resolveDietaryRestrictions', () => {
+  it('returns an empty array when tokens is undefined', () => {
+    expect(resolveDietaryRestrictions(undefined)).toEqual([]);
+  });
+
+  it('returns an empty array when tokens is empty', () => {
+    expect(resolveDietaryRestrictions([])).toEqual([]);
+  });
+
+  it('resolves each token to its human-readable description', () => {
+    expect(
+      resolveDietaryRestrictions([
+        'exchange.recipe.defs#dietVegan',
+        'exchange.recipe.defs#dietGlutenFree',
+      ]),
+    ).toEqual(['Vegan', 'Gluten Free']);
+  });
+
+  it('passes unknown tokens through unchanged', () => {
+    expect(resolveDietaryRestrictions(['exchange.recipe.defs#dietUnknown'])).toEqual([
+      'exchange.recipe.defs#dietUnknown',
+    ]);
+  });
+});

--- a/apps/akari/__tests__/utils/systemLog.test.ts
+++ b/apps/akari/__tests__/utils/systemLog.test.ts
@@ -1,0 +1,119 @@
+import {
+  clearSystemLog,
+  getSystemLog,
+  installSystemLogConsoleHook,
+  recordEntry,
+  subscribeSystemLog,
+} from '@/utils/systemLog';
+
+describe('systemLog', () => {
+  beforeEach(() => {
+    clearSystemLog();
+  });
+
+  describe('recordEntry', () => {
+    it('appends an entry with level, message, and timestamp', () => {
+      const before = Date.now();
+      recordEntry('log', ['hello', 'world']);
+      const log = getSystemLog();
+      expect(log).toHaveLength(1);
+      expect(log[0].level).toBe('log');
+      expect(log[0].message).toBe('hello world');
+      expect(log[0].ts).toBeGreaterThanOrEqual(before);
+    });
+
+    it('serializes Error instances to their stack or message', () => {
+      const withStack = new Error('boom');
+      recordEntry('error', [withStack]);
+      expect(getSystemLog()[0].message).toBe(withStack.stack);
+    });
+
+    it('falls back to the error message when no stack is present', () => {
+      const noStack = new Error('no stack');
+      noStack.stack = undefined;
+      recordEntry('error', [noStack]);
+      expect(getSystemLog()[0].message).toBe('no stack');
+    });
+
+    it('JSON-stringifies plain objects', () => {
+      recordEntry('info', [{ a: 1 }, 42]);
+      expect(getSystemLog()[0].message).toBe('{"a":1} 42');
+    });
+
+    it('falls back to String() for non-serializable values', () => {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      recordEntry('warn', [circular]);
+      expect(getSystemLog()[0].message).toBe('[object Object]');
+    });
+
+    it('trims the buffer to the max capacity (200)', () => {
+      for (let i = 0; i < 250; i++) {
+        recordEntry('log', [`entry-${i}`]);
+      }
+      const log = getSystemLog();
+      expect(log).toHaveLength(200);
+      // Oldest entries shifted out; the first remaining is entry-50.
+      expect(log[0].message).toBe('entry-50');
+      expect(log[log.length - 1].message).toBe('entry-249');
+    });
+
+    it('notifies subscribers on each record', () => {
+      const listener = jest.fn();
+      subscribeSystemLog(listener);
+      recordEntry('log', ['a']);
+      recordEntry('log', ['b']);
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('subscribeSystemLog', () => {
+    it('returns an unsubscribe function that stops notifications', () => {
+      const listener = jest.fn();
+      const unsubscribe = subscribeSystemLog(listener);
+      recordEntry('log', ['first']);
+      unsubscribe();
+      recordEntry('log', ['second']);
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('clearSystemLog', () => {
+    it('empties the buffer and notifies subscribers', () => {
+      recordEntry('log', ['x']);
+      const listener = jest.fn();
+      subscribeSystemLog(listener);
+      clearSystemLog();
+      expect(getSystemLog()).toHaveLength(0);
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('installSystemLogConsoleHook', () => {
+    it('captures console.log/info/warn/error into the buffer', () => {
+      // The hook self-installs on import; calling again is a no-op.
+      installSystemLogConsoleHook();
+
+      console.log('captured-log');
+      console.info('captured-info');
+      console.warn('captured-warn');
+      console.error('captured-error');
+
+      const messages = getSystemLog().map((e) => `${e.level}:${e.message}`);
+      expect(messages).toContain('log:captured-log');
+      expect(messages).toContain('info:captured-info');
+      expect(messages).toContain('warn:captured-warn');
+      expect(messages).toContain('error:captured-error');
+    });
+
+    it('is idempotent across multiple installs', () => {
+      installSystemLogConsoleHook();
+      installSystemLogConsoleHook();
+      clearSystemLog();
+      console.log('once');
+      // Should only record a single entry, not double-wrapped.
+      const entries = getSystemLog().filter((e) => e.message === 'once');
+      expect(entries).toHaveLength(1);
+    });
+  });
+});

--- a/apps/akari/jest.setup.js
+++ b/apps/akari/jest.setup.js
@@ -10,6 +10,8 @@ jest.mock('react-native-mmkv', () => {
       const store = stores.get(storeKey);
       return {
         getString: (key) => store.get(key),
+        getBoolean: (key) => store.get(key),
+        getNumber: (key) => store.get(key),
         set: (key, value) => store.set(key, value),
         delete: (key) => store.delete(key),
         contains: (key) => store.has(key),


### PR DESCRIPTION
## What

Big coverage push across the akari app's previously-untested surface. **+569 tests** (akari suite 898 → 1467), 87 new test files.

### Pure utils (all ~95-100%)
`followingCleanupController` (the 219-stmt scan/filter/skip controller), `navigation`, `ozoneAvatars`, `appLogoIcon`, `systemLog`, `recipeDefinitions`.

### Query hooks
The ozone moderation set (admin/team/subject/events/queue/scheduled/comm-templates/label-options), grain/sifa/rpg/author feeds, following-cleanup derivations, and the misc data queries (lists, blocks, convo, bookmarks, interests, preferences, app-passwords, trending, …).

### Mutation hooks
The full `useUpdate*` preferences family, account / app-password / live-status / email / handle, and the content / list / convo / community-note mutations.

### Misc hooks
`useProfileMenuItems`, `useCreateAccount`, `useFavicon`, `useRateLimitWait`, `useNotifyAudience`, `useExternalMediaSettings`.

## How

All hook tests follow the established `renderHook` + `QueryClientProvider` (retry off) pattern with `@/bluesky-api` and dependency hooks mocked — no real network. Utils tested directly with external deps mocked.

Also adds `getBoolean`/`getNumber` to the in-memory MMKV mock in `jest.setup.js` so boolean/number-backed settings hooks work under test.

## Notes
- The remaining uncovered lines are mostly in-`queryFn` defensive `throw` guards that are unreachable because the query's `enabled` predicate already blocks those states, plus a few `__DEV__`-only `console.warn` arms.
- The new typecheck gate caught a handful of test-only type issues (babel-jest doesn't type-check); all fixed. Full gate is green: lint, `tsc` (15/15), tests (akari 1467 ✓).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lucid-softworks/codesmith/akari/pr/408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782669942&installation_id=136510994&pr_number=408&repository=lucid-softworks%2Fakari&return_to=https%3A%2F%2Fgithub.com%2Flucid-softworks%2Fakari%2Fpull%2F408&signature=c98cf4e772bdddc8f01cb81605ffc0922b614fb9814b375330e453c0e26b52d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->