### PR TITLE
test: extend akari coverage to more utils and hooks

### DIFF
--- a/apps/akari/__tests__/hooks/mutations/useBlockActorList.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useBlockActorList.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useBlockActorList } from '@/hooks/mutations/useBlockActorList';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockBlockActorList = jest.fn();
+const mockUnblockActorList = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    blockActorList: mockBlockActorList,
+    unblockActorList: mockUnblockActorList,
+  })),
+}));
+
+describe('useBlockActorList mutation hook', () => {
+  let invalidateSpy: jest.SpyInstance;
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockBlockActorList.mockResolvedValue({ uri: 'at://listblock' });
+    mockUnblockActorList.mockResolvedValue({});
+  });
+
+  it('blocks a moderation list and invalidates feeds', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlockActorList(), { wrapper });
+
+    result.current.mutate({ action: 'block', list: 'at://list' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockBlockActorList).toHaveBeenCalledWith('token', 'did:current', 'at://list');
+    expect(mockUnblockActorList).not.toHaveBeenCalled();
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['moderationLists'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['timeline'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['feed'] });
+  });
+
+  it('unblocks a moderation list by listblock uri', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlockActorList(), { wrapper });
+
+    result.current.mutate({ action: 'unblock', listblockUri: 'at://listblock' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockUnblockActorList).toHaveBeenCalledWith('token', 'at://listblock');
+    expect(mockBlockActorList).not.toHaveBeenCalled();
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlockActorList(), { wrapper });
+
+    result.current.mutate({ action: 'block', list: 'at://list' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockBlockActorList).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlockActorList(), { wrapper });
+
+    result.current.mutate({ action: 'block', list: 'at://list' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockBlockActorList).not.toHaveBeenCalled();
+  });
+
+  it('errors when did missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlockActorList(), { wrapper });
+
+    result.current.mutate({ action: 'block', list: 'at://list' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockBlockActorList).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useBookmarkPost.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useBookmarkPost.test.tsx
@@ -1,0 +1,230 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useBookmarkPost } from '@/hooks/mutations/useBookmarkPost';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useToast } from '@/contexts/ToastContext';
+import type { BlueskyFeedResponse, BlueskyPostView } from '@/bluesky-api';
+
+const mockCreateBookmark = jest.fn();
+const mockDeleteBookmark = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+// @/contexts/ToastContext and @/hooks/useTranslation are globally mocked in
+// jest.setup.js, so we read showToast off the shared mock rather than
+// re-mocking (a local mock would clobber the setup's beforeEach wiring).
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createBookmark: mockCreateBookmark,
+    deleteBookmark: mockDeleteBookmark,
+  })),
+}));
+
+const mockShowToast = () => (useToast() as unknown as { showToast: jest.Mock }).showToast;
+
+const postUri = 'at://post';
+
+const makePost = (bookmarked?: boolean): BlueskyPostView =>
+  ({
+    uri: postUri,
+    cid: 'cid',
+    author: {},
+    record: {},
+    indexedAt: '',
+    labels: [],
+    viewer: bookmarked === undefined ? {} : { bookmarked },
+  }) as unknown as BlueskyPostView;
+
+describe('useBookmarkPost mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockCreateBookmark.mockResolvedValue({});
+    mockDeleteBookmark.mockResolvedValue({});
+  });
+
+  it('bookmarks a post and optimistically updates caches', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const feedResponse = { feed: [{ post: makePost() }] } as unknown as BlueskyFeedResponse;
+    queryClient.setQueryData(['timeline'], feedResponse);
+    queryClient.setQueryData(['feed'], { pages: [feedResponse] });
+    queryClient.setQueryData(['authorFeed'], { pages: [feedResponse] });
+    queryClient.setQueryData(['post', postUri], makePost());
+    queryClient.setQueryData(['postThread', postUri], { thread: { post: makePost() } });
+
+    const { result } = renderHook(() => useBookmarkPost(), { wrapper });
+    result.current.mutate({ postUri, postCid: 'cid', action: 'bookmark' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockCreateBookmark).toHaveBeenCalledWith('token', postUri, 'cid');
+    const timeline = queryClient.getQueryData<BlueskyFeedResponse>(['timeline']);
+    expect(timeline?.feed[0].post.viewer?.bookmarked).toBe(true);
+    expect(queryClient.getQueryData<BlueskyPostView>(['post', postUri])?.viewer?.bookmarked).toBe(true);
+    expect(
+      queryClient.getQueryData<{ thread: { post: BlueskyPostView } }>(['postThread', postUri])
+        ?.thread.post.viewer?.bookmarked,
+    ).toBe(true);
+  });
+
+  it('patches inline reply.parent / reply.root and nested thread replies', async () => {
+    const { queryClient, wrapper } = createWrapper();
+
+    // Feed item where the bookmarked post is the inline parent + root of a reply.
+    const otherPost = { ...makePost(), uri: 'at://other', viewer: {} } as unknown as BlueskyPostView;
+    const timelineResponse = {
+      feed: [
+        {
+          post: otherPost,
+          reply: { parent: makePost(), root: makePost() },
+        },
+      ],
+    } as unknown as BlueskyFeedResponse;
+    queryClient.setQueryData(['timeline'], timelineResponse);
+    queryClient.setQueryData(['feed'], { pages: [timelineResponse] });
+
+    // Thread where the target lives as a nested reply rather than the root post.
+    queryClient.setQueryData(['postThread', 'at://root'], {
+      thread: {
+        post: { ...makePost(), uri: 'at://root', viewer: {} },
+        replies: [{ post: makePost(), replies: [{ post: makePost() }] }],
+      },
+    });
+
+    const { result } = renderHook(() => useBookmarkPost(), { wrapper });
+    result.current.mutate({ postUri, postCid: 'cid', action: 'bookmark' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const timeline = queryClient.getQueryData<BlueskyFeedResponse>(['timeline']);
+    expect(timeline?.feed[0].reply?.parent?.viewer?.bookmarked).toBe(true);
+    expect(timeline?.feed[0].reply?.root?.viewer?.bookmarked).toBe(true);
+
+    const thread = queryClient.getQueryData<any>(['postThread', 'at://root']);
+    expect(thread.thread.replies[0].post.viewer.bookmarked).toBe(true);
+    expect(thread.thread.replies[0].replies[0].post.viewer.bookmarked).toBe(true);
+  });
+
+  it('unbookmarks a post', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const feedResponse = { feed: [{ post: makePost(true) }] } as unknown as BlueskyFeedResponse;
+    queryClient.setQueryData(['timeline'], feedResponse);
+
+    const { result } = renderHook(() => useBookmarkPost(), { wrapper });
+    result.current.mutate({ postUri, postCid: 'cid', action: 'unbookmark' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockDeleteBookmark).toHaveBeenCalledWith('token', postUri);
+    const timeline = queryClient.getQueryData<BlueskyFeedResponse>(['timeline']);
+    expect(timeline?.feed[0].post.viewer?.bookmarked).toBe(false);
+  });
+
+  it('rolls back caches and toasts on error', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const feedResponse = { feed: [{ post: makePost() }] } as unknown as BlueskyFeedResponse;
+    queryClient.setQueryData(['timeline'], feedResponse);
+    queryClient.setQueryData(['post', postUri], makePost());
+    mockCreateBookmark.mockRejectedValueOnce(new Error('fail'));
+
+    const { result } = renderHook(() => useBookmarkPost(), { wrapper });
+    result.current.mutate({ postUri, postCid: 'cid', action: 'bookmark' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(queryClient.getQueryData<BlueskyPostView>(['post', postUri])?.viewer).toEqual({});
+    expect(mockShowToast()).toHaveBeenCalledWith({
+      type: 'error',
+      message: 'post.bookmarkFailed',
+    });
+  });
+
+  it('toasts the unbookmark failure message on error', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(['timeline'], {
+      feed: [{ post: makePost(true) }],
+    } as unknown as BlueskyFeedResponse);
+    mockDeleteBookmark.mockRejectedValueOnce(new Error('fail'));
+
+    const { result } = renderHook(() => useBookmarkPost(), { wrapper });
+    result.current.mutate({ postUri, postCid: 'cid', action: 'unbookmark' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(mockShowToast()).toHaveBeenCalledWith({
+      type: 'error',
+      message: 'post.unbookmarkFailed',
+    });
+  });
+
+  it('invalidates bookmarks on success', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useBookmarkPost(), { wrapper });
+    result.current.mutate({ postUri, postCid: 'cid', action: 'bookmark' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['bookmarks'] });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBookmarkPost(), { wrapper });
+
+    result.current.mutate({ postUri, postCid: 'cid', action: 'bookmark' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateBookmark).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBookmarkPost(), { wrapper });
+
+    result.current.mutate({ postUri, postCid: 'cid', action: 'bookmark' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateBookmark).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useClearAuthentication.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useClearAuthentication.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useClearAuthentication } from '@/hooks/mutations/useClearAuthentication';
+import { storage } from '@/utils/secureStorage';
+
+jest.mock('@/utils/secureStorage', () => ({
+  storage: { setItem: jest.fn(), getItem: jest.fn(), removeItem: jest.fn() },
+}));
+
+describe('useClearAuthentication mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('clears tokens from cache and storage and invalidates auth queries', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(['jwtToken'], 'old');
+    queryClient.setQueryData(['refreshToken'], 'old');
+    const spy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useClearAuthentication(), { wrapper });
+    result.current.mutate();
+
+    await waitFor(() => expect(queryClient.getQueryData(['jwtToken'])).toBeNull());
+    expect(queryClient.getQueryData(['refreshToken'])).toBeNull();
+    expect(storage.removeItem).toHaveBeenCalledWith('jwtToken');
+    expect(storage.removeItem).toHaveBeenCalledWith('refreshToken');
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['auth'] });
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useClearLiveStatus.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useClearLiveStatus.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useClearLiveStatus } from '@/hooks/mutations/useClearLiveStatus';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockClearActorStatus = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    clearActorStatus: mockClearActorStatus,
+  })),
+}));
+
+describe('useClearLiveStatus mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockClearActorStatus.mockResolvedValue(undefined);
+  });
+
+  it('clears the live status and invalidates profile caches', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useClearLiveStatus(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockClearActorStatus).toHaveBeenCalledWith('token', 'did');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['profile'] });
+  });
+
+  it('throws when the token is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useClearLiveStatus(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockClearActorStatus).not.toHaveBeenCalled();
+  });
+
+  it('throws when the DID is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { result } = renderHook(() => useClearLiveStatus(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockClearActorStatus).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PDS URL is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { result } = renderHook(() => useClearLiveStatus(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockClearActorStatus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useCreateAccount.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useCreateAccount.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useCreateAccount } from '@/hooks/mutations/useCreateAccount';
+
+const mockSetAuth = { mutateAsync: jest.fn() };
+const mockCreateAccount = jest.fn();
+const mockGetProfile = jest.fn();
+
+jest.mock('@/hooks/mutations/useSetAuthentication', () => ({
+  useSetAuthentication: jest.fn(() => mockSetAuth),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createAccount: mockCreateAccount,
+    getProfile: mockGetProfile,
+  })),
+}));
+
+describe('useCreateAccount mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateAccount.mockResolvedValue({
+      accessJwt: 'token',
+      refreshJwt: 'refresh',
+      did: 'did',
+      handle: 'handle',
+    });
+    mockGetProfile.mockResolvedValue({
+      did: 'did',
+      handle: 'handle',
+      displayName: 'Display Name',
+      avatar: 'https://avatar.test/img.png',
+      indexedAt: '2024-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('creates an account and stores auth data with profile metadata', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useCreateAccount(), { wrapper });
+
+    result.current.mutate({
+      email: 'a@b.com',
+      handle: 'handle',
+      password: 'pass',
+      inviteCode: 'code',
+      pdsUrl: 'https://pds',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockCreateAccount).toHaveBeenCalledWith({
+      email: 'a@b.com',
+      handle: 'handle',
+      password: 'pass',
+      inviteCode: 'code',
+    });
+    expect(mockGetProfile).toHaveBeenCalledWith('token', 'did');
+    expect(mockSetAuth.mutateAsync).toHaveBeenCalledWith({
+      token: 'token',
+      refreshToken: 'refresh',
+      did: 'did',
+      handle: 'handle',
+      pdsUrl: 'https://pds',
+      displayName: 'Display Name',
+      avatar: 'https://avatar.test/img.png',
+    });
+    expect(invalidateSpy).toHaveBeenCalled();
+  });
+
+  it('falls back to handle/null avatar when profile fetch fails', async () => {
+    const { wrapper } = createWrapper();
+    mockGetProfile.mockRejectedValueOnce(new Error('no profile'));
+    const { result } = renderHook(() => useCreateAccount(), { wrapper });
+
+    result.current.mutate({
+      email: 'a@b.com',
+      handle: 'handle',
+      password: 'pass',
+      pdsUrl: 'https://pds',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockSetAuth.mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ displayName: 'handle', avatar: null }),
+    );
+  });
+
+  it('surfaces an error when account creation fails', async () => {
+    const { wrapper } = createWrapper();
+    mockCreateAccount.mockRejectedValueOnce(new Error('taken'));
+    const { result } = renderHook(() => useCreateAccount(), { wrapper });
+
+    result.current.mutate({
+      email: 'a@b.com',
+      handle: 'handle',
+      password: 'pass',
+      pdsUrl: 'https://pds',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetAuth.mutateAsync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useCreateAppPassword.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useCreateAppPassword.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useCreateAppPassword } from '@/hooks/mutations/useCreateAppPassword';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockCreateAppPassword = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createAppPassword: mockCreateAppPassword,
+  })),
+}));
+
+describe('useCreateAppPassword mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockCreateAppPassword.mockResolvedValue({ name: 'cli', password: 'abcd-1234' });
+  });
+
+  it('creates a privileged app password and invalidates the list', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useCreateAppPassword(), { wrapper });
+
+    result.current.mutate({ name: 'cli', privileged: true });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreateAppPassword).toHaveBeenCalledWith('token', 'cli', true);
+    expect(result.current.data).toEqual({ name: 'cli', password: 'abcd-1234' });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['appPasswords'] });
+  });
+
+  it('defaults privileged to false when omitted', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateAppPassword(), { wrapper });
+
+    result.current.mutate({ name: 'cli' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreateAppPassword).toHaveBeenCalledWith('token', 'cli', false);
+  });
+
+  it('throws when the token is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useCreateAppPassword(), { wrapper });
+
+    result.current.mutate({ name: 'cli' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateAppPassword).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PDS URL is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { result } = renderHook(() => useCreateAppPassword(), { wrapper });
+
+    result.current.mutate({ name: 'cli' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateAppPassword).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useCreateLeaflet.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useCreateLeaflet.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useCreateLeaflet } from '@/hooks/mutations/useCreateLeaflet';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { apiForAccount } from '@/utils/blueskyApi';
+
+const mockFindOrCreatePublication = jest.fn();
+const mockCreateDocument = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+
+describe('useCreateLeaflet mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did:me', handle: 'me.test', displayName: 'Me', pdsUrl: 'https://pds' },
+    });
+    (apiForAccount as jest.Mock).mockReturnValue({
+      findOrCreateLeafletPublication: mockFindOrCreatePublication,
+      createLeafletDocument: mockCreateDocument,
+    });
+    mockFindOrCreatePublication.mockResolvedValue({ uri: 'at://pub', rkey: 'pubkey' });
+    mockCreateDocument.mockResolvedValue({ uri: 'at://doc', rkey: 'dockey' });
+  });
+
+  it('creates a leaflet and returns uri + public url, invalidating author caches', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const spy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useCreateLeaflet(), { wrapper });
+
+    result.current.mutate({ title: 'T', body: 'B' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockFindOrCreatePublication).toHaveBeenCalledWith('token', 'did:me', { name: 'Me' });
+    expect(mockCreateDocument).toHaveBeenCalledWith('token', 'did:me', {
+      title: 'T',
+      body: 'B',
+      publicationUri: 'at://pub',
+      author: 'did:me',
+    });
+    expect(result.current.data).toEqual({
+      uri: 'at://doc',
+      url: 'https://leaflet.pub/lish/did%3Ame/pubkey/dockey',
+    });
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['authorFeed', 'did:me'] });
+  });
+
+  it('falls back to handle for publication name when no displayName', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did:me', handle: 'me.test', pdsUrl: 'https://pds' },
+    });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateLeaflet(), { wrapper });
+
+    result.current.mutate({ title: 'T', body: 'B' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockFindOrCreatePublication).toHaveBeenCalledWith('token', 'did:me', { name: 'me.test' });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateLeaflet(), { wrapper });
+
+    result.current.mutate({ title: 'T', body: 'B' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockFindOrCreatePublication).not.toHaveBeenCalled();
+  });
+
+  it('errors when did missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateLeaflet(), { wrapper });
+
+    result.current.mutate({ title: 'T', body: 'B' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockFindOrCreatePublication).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:me' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateLeaflet(), { wrapper });
+
+    result.current.mutate({ title: 'T', body: 'B' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockFindOrCreatePublication).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useCreateList.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useCreateList.test.tsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useCreateList } from '@/hooks/mutations/useCreateList';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockCreateList = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createList: mockCreateList,
+  })),
+}));
+
+describe('useCreateList mutation hook', () => {
+  let invalidateSpy: jest.SpyInstance;
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockCreateList.mockResolvedValue({ uri: 'at://list' });
+  });
+
+  it('creates a curate list by default and invalidates lists', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateList(), { wrapper });
+
+    result.current.mutate({ name: 'My List', description: 'desc' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreateList).toHaveBeenCalledWith('token', 'did:current', {
+      name: 'My List',
+      description: 'desc',
+      purpose: 'app.bsky.graph.defs#curatelist',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['lists', 'https://pds', 'did:current', undefined],
+    });
+  });
+
+  it('honours an explicit purpose (modlist)', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateList(), { wrapper });
+
+    result.current.mutate({ name: 'Block List', purpose: 'app.bsky.graph.defs#modlist' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreateList).toHaveBeenCalledWith('token', 'did:current', {
+      name: 'Block List',
+      description: undefined,
+      purpose: 'app.bsky.graph.defs#modlist',
+    });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateList(), { wrapper });
+
+    result.current.mutate({ name: 'My List' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateList).not.toHaveBeenCalled();
+  });
+
+  it('errors when did missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateList(), { wrapper });
+
+    result.current.mutate({ name: 'My List' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateList).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateList(), { wrapper });
+
+    result.current.mutate({ name: 'My List' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateList).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useCreatePoll.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useCreatePoll.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useCreatePoll } from '@/hooks/mutations/useCreatePoll';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { pollEmbedUrlFromRecord } from '@/utils/tokimekiPoll';
+
+const mockCreatePoll = jest.fn();
+const mockCreatePost = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/utils/tokimekiPoll', () => ({
+  pollEmbedUrlFromRecord: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createPoll: mockCreatePoll,
+    createPost: mockCreatePost,
+  })),
+}));
+
+const input = {
+  question: 'Best color?',
+  options: ['Red', 'Blue'],
+  endsAt: '2026-06-01T00:00:00.000Z',
+  langs: ['en'],
+};
+
+describe('useCreatePoll mutation hook', () => {
+  let invalidateSpy: jest.SpyInstance;
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockCreatePoll.mockResolvedValue({ uri: 'at://poll' });
+    mockCreatePost.mockResolvedValue({ uri: 'at://post' });
+    (pollEmbedUrlFromRecord as jest.Mock).mockReturnValue('https://tokimeki/poll');
+  });
+
+  it('creates the poll record then a post embedding it', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreatePoll(), { wrapper });
+
+    result.current.mutate(input);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockCreatePoll).toHaveBeenCalledWith('token', 'did:current', {
+      options: ['Red', 'Blue'],
+      endsAt: '2026-06-01T00:00:00.000Z',
+    });
+    expect(pollEmbedUrlFromRecord).toHaveBeenCalledWith('at://poll', 2);
+    expect(mockCreatePost).toHaveBeenCalledWith('token', 'did:current', {
+      text: 'Best color?',
+      langs: ['en'],
+      externalEmbed: {
+        uri: 'https://tokimeki/poll',
+        title: 'Best color?',
+        description: 'Red / Blue',
+      },
+    });
+    expect(result.current.data).toEqual({
+      poll: { uri: 'at://poll' },
+      post: { uri: 'at://post' },
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['timeline'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['feed'] });
+  });
+
+  it('falls back to the poll uri when no embed url is derivable', async () => {
+    (pollEmbedUrlFromRecord as jest.Mock).mockReturnValue(null);
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreatePoll(), { wrapper });
+
+    result.current.mutate({ ...input, question: '' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockCreatePost).toHaveBeenCalledWith('token', 'did:current', {
+      text: '',
+      langs: ['en'],
+      externalEmbed: {
+        uri: 'at://poll',
+        title: 'Red / Blue',
+        description: 'Red / Blue',
+      },
+    });
+  });
+
+  it('errors when not signed in', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreatePoll(), { wrapper });
+
+    result.current.mutate(input);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreatePoll).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useCreateReview.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useCreateReview.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useCreateReview } from '@/hooks/mutations/useCreateReview';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import type { CreateReviewInput } from '@/bluesky-api';
+
+const mockCreateReview = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createReview: mockCreateReview,
+  })),
+}));
+
+describe('useCreateReview mutation hook', () => {
+  let invalidateSpy: jest.SpyInstance;
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  const review = { value: 4, item: 'at://item' } as unknown as CreateReviewInput;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockCreateReview.mockResolvedValue({ uri: 'at://review' });
+  });
+
+  it('creates a review and invalidates author posts + timeline', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateReview(), { wrapper });
+
+    result.current.mutate(review);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreateReview).toHaveBeenCalledWith('token', 'did:current', review);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['authorPosts'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['timeline'] });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateReview(), { wrapper });
+
+    result.current.mutate(review);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateReview).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateReview(), { wrapper });
+
+    result.current.mutate(review);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateReview).not.toHaveBeenCalled();
+  });
+
+  it('errors when did missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateReview(), { wrapper });
+
+    result.current.mutate(review);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateReview).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useDeactivateAccount.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useDeactivateAccount.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useDeactivateAccount } from '@/hooks/mutations/useDeactivateAccount';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockDeactivateAccount = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    deactivateAccount: mockDeactivateAccount,
+  })),
+}));
+
+describe('useDeactivateAccount mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockDeactivateAccount.mockResolvedValue(undefined);
+  });
+
+  it('deactivates the account with a scheduled delete date', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useDeactivateAccount(), { wrapper });
+
+    result.current.mutate('2030-01-01T00:00:00.000Z');
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockDeactivateAccount).toHaveBeenCalledWith('token', '2030-01-01T00:00:00.000Z');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['auth'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['session'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['profile', 'did'] });
+  });
+
+  it('deactivates without a delete date (reversible)', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeactivateAccount(), { wrapper });
+
+    result.current.mutate(undefined);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockDeactivateAccount).toHaveBeenCalledWith('token', undefined);
+  });
+
+  it('throws when the token is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useDeactivateAccount(), { wrapper });
+
+    result.current.mutate(undefined);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockDeactivateAccount).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PDS URL is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { result } = renderHook(() => useDeactivateAccount(), { wrapper });
+
+    result.current.mutate(undefined);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockDeactivateAccount).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useDeleteAccount.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useDeleteAccount.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useDeleteAccount, useRequestAccountDelete } from '@/hooks/mutations/useDeleteAccount';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockDeleteAccount = jest.fn();
+const mockRequestAccountDelete = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    deleteAccount: mockDeleteAccount,
+    requestAccountDelete: mockRequestAccountDelete,
+  })),
+}));
+
+describe('useDeleteAccount mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockDeleteAccount.mockResolvedValue(undefined);
+    mockRequestAccountDelete.mockResolvedValue(undefined);
+  });
+
+  describe('useRequestAccountDelete', () => {
+    it('emails a confirmation token and invalidates pds preferences', async () => {
+      const { queryClient, wrapper } = createWrapper();
+      const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+      const { result } = renderHook(() => useRequestAccountDelete(), { wrapper });
+
+      result.current.mutate();
+
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+      expect(mockRequestAccountDelete).toHaveBeenCalledWith('token');
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['preferences', 'https://pds', undefined],
+      });
+    });
+
+    it('throws when the token is missing', async () => {
+      const { wrapper } = createWrapper();
+      (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+      const { result } = renderHook(() => useRequestAccountDelete(), { wrapper });
+
+      result.current.mutate();
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+      expect(mockRequestAccountDelete).not.toHaveBeenCalled();
+    });
+
+    it('throws when the PDS URL is missing', async () => {
+      const { wrapper } = createWrapper();
+      (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+      const { result } = renderHook(() => useRequestAccountDelete(), { wrapper });
+
+      result.current.mutate();
+
+      await waitFor(() => {
+        expect(result.current.isError).toBe(true);
+      });
+      expect(mockRequestAccountDelete).not.toHaveBeenCalled();
+    });
+  });
+
+  it('deletes the account and invalidates every query', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useDeleteAccount(), { wrapper });
+
+    result.current.mutate({ password: 'pw', token: 'email-token' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockDeleteAccount).toHaveBeenCalledWith('did', 'pw', 'email-token');
+    expect(invalidateSpy).toHaveBeenCalledWith();
+  });
+
+  it('throws when the DID is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { result } = renderHook(() => useDeleteAccount(), { wrapper });
+
+    result.current.mutate({ password: 'pw', token: 'email-token' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockDeleteAccount).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PDS URL is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { result } = renderHook(() => useDeleteAccount(), { wrapper });
+
+    result.current.mutate({ password: 'pw', token: 'email-token' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockDeleteAccount).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useDraftMutations.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useDraftMutations.test.tsx
@@ -1,0 +1,154 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  useCreateDraft,
+  useUpdateDraft,
+  useDeleteDraft,
+} from '@/hooks/mutations/useDraftMutations';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { apiForAccount } from '@/utils/blueskyApi';
+import { DEFAULT_POST_CONTROLS } from '@/utils/postControls';
+import type { ComposerDraftState } from '@/utils/draftMapper';
+
+const mockCreateDraft = jest.fn();
+const mockUpdateDraft = jest.fn();
+const mockDeleteDraft = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+
+const PAYLOAD = {
+  posts: [{ text: 'hello', images: [] }],
+  controls: DEFAULT_POST_CONTROLS,
+};
+
+describe('draft mutation hooks', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did:me', pdsUrl: 'https://pds' },
+    });
+    (apiForAccount as jest.Mock).mockReturnValue({
+      createDraft: mockCreateDraft,
+      updateDraft: mockUpdateDraft,
+      deleteDraft: mockDeleteDraft,
+    });
+    mockCreateDraft.mockResolvedValue({ id: 'draft-1' });
+    mockUpdateDraft.mockResolvedValue(undefined);
+    mockDeleteDraft.mockResolvedValue(undefined);
+  });
+
+  describe('useCreateDraft', () => {
+    it('creates a draft and invalidates drafts cache', async () => {
+      const { queryClient, wrapper } = createWrapper();
+      const spy = jest.spyOn(queryClient, 'invalidateQueries');
+      const { result } = renderHook(() => useCreateDraft(), { wrapper });
+
+      result.current.mutate(PAYLOAD);
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockCreateDraft).toHaveBeenCalledWith('token', expect.objectContaining({ posts: expect.any(Array) }));
+      expect(result.current.data).toMatchObject({ id: 'draft-1', posts: PAYLOAD.posts });
+      expect(spy).toHaveBeenCalledWith({ queryKey: ['drafts', 'did:me'] });
+    });
+
+    it('errors when not authenticated', async () => {
+      (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(() => useCreateDraft(), { wrapper });
+
+      result.current.mutate(PAYLOAD);
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(mockCreateDraft).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useUpdateDraft', () => {
+    it('updates a draft and invalidates drafts cache', async () => {
+      const { queryClient, wrapper } = createWrapper();
+      const spy = jest.spyOn(queryClient, 'invalidateQueries');
+      const { result } = renderHook(() => useUpdateDraft(), { wrapper });
+
+      result.current.mutate({ id: 'draft-1', ...PAYLOAD });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockUpdateDraft).toHaveBeenCalledWith('token', 'draft-1', expect.any(Object));
+      expect(spy).toHaveBeenCalledWith({ queryKey: ['drafts', 'did:me'] });
+    });
+
+    it('errors when not authenticated', async () => {
+      (useCurrentAccount as jest.Mock).mockReturnValue({ data: {} });
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(() => useUpdateDraft(), { wrapper });
+
+      result.current.mutate({ id: 'draft-1', ...PAYLOAD });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(mockUpdateDraft).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useDeleteDraft', () => {
+    it('optimistically removes the draft and deletes it on the server', async () => {
+      const { queryClient, wrapper } = createWrapper();
+      const drafts: ComposerDraftState[] = [
+        { id: 'd1', posts: [], controls: DEFAULT_POST_CONTROLS, createdAt: '', updatedAt: '' },
+        { id: 'd2', posts: [], controls: DEFAULT_POST_CONTROLS, createdAt: '', updatedAt: '' },
+      ];
+      queryClient.setQueryData(['drafts', 'did:me'], drafts);
+
+      const { result } = renderHook(() => useDeleteDraft(), { wrapper });
+      result.current.mutate({ id: 'd1' });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(mockDeleteDraft).toHaveBeenCalledWith('token', 'd1');
+      expect(
+        queryClient.getQueryData<ComposerDraftState[]>(['drafts', 'did:me'])?.map((d) => d.id),
+      ).toEqual(['d2']);
+    });
+
+    it('rolls back optimistic removal on error', async () => {
+      const { queryClient, wrapper } = createWrapper();
+      const drafts: ComposerDraftState[] = [
+        { id: 'd1', posts: [], controls: DEFAULT_POST_CONTROLS, createdAt: '', updatedAt: '' },
+      ];
+      queryClient.setQueryData(['drafts', 'did:me'], drafts);
+      mockDeleteDraft.mockRejectedValueOnce(new Error('fail'));
+
+      const { result } = renderHook(() => useDeleteDraft(), { wrapper });
+      result.current.mutate({ id: 'd1' });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(
+        queryClient.getQueryData<ComposerDraftState[]>(['drafts', 'did:me'])?.map((d) => d.id),
+      ).toEqual(['d1']);
+    });
+
+    it('errors when not authenticated', async () => {
+      (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+      const { wrapper } = createWrapper();
+      const { result } = renderHook(() => useDeleteDraft(), { wrapper });
+
+      result.current.mutate({ id: 'd1' });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(mockDeleteDraft).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useEmitOzoneEvent.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useEmitOzoneEvent.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useEmitOzoneEvent } from '@/hooks/mutations/useEmitOzoneEvent';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+
+const mockEmitEvent = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyOzone', () => ({ ozoneForAccount: jest.fn() }));
+
+describe('useEmitOzoneEvent hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper, invalidateSpy };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({ emitEvent: mockEmitEvent });
+  });
+
+  it('emits an event defaulting createdBy to the current DID and invalidates ozone', async () => {
+    mockEmitEvent.mockResolvedValue({ id: 1 });
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useEmitOzoneEvent(), { wrapper });
+
+    const input = {
+      event: { $type: 'tools.ozone.moderation.defs#modEventComment', comment: 'hi' },
+      subject: { $type: 'com.atproto.admin.defs#repoRef', did: 'did:s' },
+    };
+    result.current.mutate(input as never);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockEmitEvent).toHaveBeenCalledWith('token', 'did:ozone', {
+      ...input,
+      createdBy: 'did:current',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['ozone'] });
+  });
+
+  it('honours an explicit createdBy', async () => {
+    mockEmitEvent.mockResolvedValue({ id: 2 });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useEmitOzoneEvent(), { wrapper });
+
+    const input = {
+      event: { $type: 'x' },
+      subject: { did: 'did:s' },
+      createdBy: 'did:explicit',
+    } as never;
+    result.current.mutate(input);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockEmitEvent).toHaveBeenCalledWith(
+      'token',
+      'did:ozone',
+      expect.objectContaining({ createdBy: 'did:explicit' }),
+    );
+  });
+
+  it('throws when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useEmitOzoneEvent(), { wrapper });
+
+    result.current.mutate({ event: { $type: 'x' }, subject: {} } as never);
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockEmitEvent).not.toHaveBeenCalled();
+  });
+
+  it('throws when no current DID and no explicit createdBy', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useEmitOzoneEvent(), { wrapper });
+
+    result.current.mutate({ event: { $type: 'x' }, subject: {} } as never);
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockEmitEvent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useGroupConvo.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useGroupConvo.test.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  useAddConvoMembers,
+  useRemoveConvoMembers,
+  useUpdateConvoName,
+  useMuteConvo,
+  useLeaveConvo,
+} from '@/hooks/mutations/useGroupConvo';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockAddConvoMembers = jest.fn();
+const mockRemoveConvoMembers = jest.fn();
+const mockUpdateConvoName = jest.fn();
+const mockMuteConvo = jest.fn();
+const mockUnmuteConvo = jest.fn();
+const mockLeaveConvo = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    addConvoMembers: mockAddConvoMembers,
+    removeConvoMembers: mockRemoveConvoMembers,
+    updateConvoName: mockUpdateConvoName,
+    muteConvo: mockMuteConvo,
+    unmuteConvo: mockUnmuteConvo,
+    leaveConvo: mockLeaveConvo,
+  })),
+}));
+
+describe('useGroupConvo mutation hooks', () => {
+  let invalidateSpy: jest.SpyInstance;
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockAddConvoMembers.mockResolvedValue({});
+    mockRemoveConvoMembers.mockResolvedValue({});
+    mockUpdateConvoName.mockResolvedValue({});
+    mockMuteConvo.mockResolvedValue({});
+    mockUnmuteConvo.mockResolvedValue({});
+    mockLeaveConvo.mockResolvedValue({});
+  });
+
+  it('adds convo members and invalidates conversation + message caches', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAddConvoMembers(), { wrapper });
+
+    result.current.mutate({ convoId: 'c1', dids: ['did:a', 'did:b'] });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockAddConvoMembers).toHaveBeenCalledWith('token', 'c1', ['did:a', 'did:b']);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['conversations'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['messages'] });
+  });
+
+  it('add convo members errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAddConvoMembers(), { wrapper });
+
+    result.current.mutate({ convoId: 'c1', dids: ['did:a'] });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockAddConvoMembers).not.toHaveBeenCalled();
+  });
+
+  it('add convo members errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAddConvoMembers(), { wrapper });
+
+    result.current.mutate({ convoId: 'c1', dids: ['did:a'] });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockAddConvoMembers).not.toHaveBeenCalled();
+  });
+
+  it('removes convo members', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRemoveConvoMembers(), { wrapper });
+
+    result.current.mutate({ convoId: 'c1', dids: ['did:a'] });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockRemoveConvoMembers).toHaveBeenCalledWith('token', 'c1', ['did:a']);
+  });
+
+  it('updates convo name', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateConvoName(), { wrapper });
+
+    result.current.mutate({ convoId: 'c1', name: 'New Name' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockUpdateConvoName).toHaveBeenCalledWith('token', 'c1', 'New Name');
+  });
+
+  it('mutes a conversation', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMuteConvo(), { wrapper });
+
+    result.current.mutate({ convoId: 'c1', action: 'mute' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockMuteConvo).toHaveBeenCalledWith('token', 'c1');
+    expect(mockUnmuteConvo).not.toHaveBeenCalled();
+  });
+
+  it('unmutes a conversation', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMuteConvo(), { wrapper });
+
+    result.current.mutate({ convoId: 'c1', action: 'unmute' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockUnmuteConvo).toHaveBeenCalledWith('token', 'c1');
+    expect(mockMuteConvo).not.toHaveBeenCalled();
+  });
+
+  it('leaves a conversation', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useLeaveConvo(), { wrapper });
+
+    result.current.mutate({ convoId: 'c1' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockLeaveConvo).toHaveBeenCalledWith('token', 'c1');
+  });
+
+  it('every hook errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const remove = renderHook(() => useRemoveConvoMembers(), { wrapper });
+    remove.result.current.mutate({ convoId: 'c1', dids: ['did:a'] });
+    const rename = renderHook(() => useUpdateConvoName(), { wrapper });
+    rename.result.current.mutate({ convoId: 'c1', name: 'x' });
+    const mute = renderHook(() => useMuteConvo(), { wrapper });
+    mute.result.current.mutate({ convoId: 'c1', action: 'mute' });
+    const leave = renderHook(() => useLeaveConvo(), { wrapper });
+    leave.result.current.mutate({ convoId: 'c1' });
+
+    await waitFor(() => {
+      expect(remove.result.current.isError).toBe(true);
+      expect(rename.result.current.isError).toBe(true);
+      expect(mute.result.current.isError).toBe(true);
+      expect(leave.result.current.isError).toBe(true);
+    });
+    expect(mockRemoveConvoMembers).not.toHaveBeenCalled();
+    expect(mockUpdateConvoName).not.toHaveBeenCalled();
+    expect(mockMuteConvo).not.toHaveBeenCalled();
+    expect(mockLeaveConvo).not.toHaveBeenCalled();
+  });
+
+  it('every hook errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+
+    const remove = renderHook(() => useRemoveConvoMembers(), { wrapper });
+    remove.result.current.mutate({ convoId: 'c1', dids: ['did:a'] });
+    const rename = renderHook(() => useUpdateConvoName(), { wrapper });
+    rename.result.current.mutate({ convoId: 'c1', name: 'x' });
+    const mute = renderHook(() => useMuteConvo(), { wrapper });
+    mute.result.current.mutate({ convoId: 'c1', action: 'unmute' });
+    const leave = renderHook(() => useLeaveConvo(), { wrapper });
+    leave.result.current.mutate({ convoId: 'c1' });
+
+    await waitFor(() => {
+      expect(remove.result.current.isError).toBe(true);
+      expect(rename.result.current.isError).toBe(true);
+      expect(mute.result.current.isError).toBe(true);
+      expect(leave.result.current.isError).toBe(true);
+    });
+    expect(mockUnmuteConvo).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useListMembership.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useListMembership.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useListMembership } from '@/hooks/mutations/useListMembership';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockAddToList = jest.fn();
+const mockRemoveFromList = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    addToList: mockAddToList,
+    removeFromList: mockRemoveFromList,
+  })),
+}));
+
+describe('useListMembership mutation hook', () => {
+  let invalidateSpy: jest.SpyInstance;
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockAddToList.mockResolvedValue({ uri: 'at://listitem' });
+    mockRemoveFromList.mockResolvedValue({});
+  });
+
+  it('adds a subject to a list and invalidates snapshots', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useListMembership(), { wrapper });
+
+    result.current.mutate({ action: 'add', listUri: 'at://list', subjectDid: 'did:subject' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockAddToList).toHaveBeenCalledWith('token', 'did:current', 'at://list', 'did:subject');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['listSnapshot', 'https://pds', 'at://list'],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['list', 'https://pds', 'at://list'],
+    });
+  });
+
+  it('removes a subject from a list by listitem uri', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useListMembership(), { wrapper });
+
+    result.current.mutate({
+      action: 'remove',
+      listItemUri: 'at://listitem',
+      listUri: 'at://list',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockRemoveFromList).toHaveBeenCalledWith('token', 'at://listitem');
+    expect(mockAddToList).not.toHaveBeenCalled();
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useListMembership(), { wrapper });
+
+    result.current.mutate({ action: 'add', listUri: 'at://list', subjectDid: 'did:subject' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockAddToList).not.toHaveBeenCalled();
+  });
+
+  it('errors when did missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useListMembership(), { wrapper });
+
+    result.current.mutate({ action: 'add', listUri: 'at://list', subjectDid: 'did:subject' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockAddToList).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useListMembership(), { wrapper });
+
+    result.current.mutate({ action: 'add', listUri: 'at://list', subjectDid: 'did:subject' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockAddToList).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useMessageReaction.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useMessageReaction.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useMessageReaction } from '@/hooks/mutations/useMessageReaction';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockAddReaction = jest.fn();
+const mockRemoveReaction = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    addReaction: mockAddReaction,
+    removeReaction: mockRemoveReaction,
+  })),
+}));
+
+const convoId = 'c1';
+const messagesKey = ['messages', convoId, 50, 'did:current'];
+
+const buildPage = (reactions: { value: string; sender: { did: string }; createdAt: string }[]) => ({
+  pages: [
+    {
+      messages: [{ id: 'm1', reactions }],
+      cursor: undefined,
+    },
+  ],
+  pageParams: [undefined],
+});
+
+describe('useMessageReaction mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockAddReaction.mockResolvedValue({});
+    mockRemoveReaction.mockResolvedValue({});
+  });
+
+  it('adds a reaction and optimistically patches the cache', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(messagesKey, buildPage([]));
+
+    const { result } = renderHook(() => useMessageReaction(), { wrapper });
+    result.current.mutate({ convoId, messageId: 'm1', value: '👍', action: 'add' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockAddReaction).toHaveBeenCalledWith('token', convoId, 'm1', '👍');
+    const data = queryClient.getQueryData<any>(messagesKey);
+    expect(data.pages[0].messages[0].reactions).toHaveLength(1);
+    expect(data.pages[0].messages[0].reactions[0]).toMatchObject({
+      value: '👍',
+      sender: { did: 'did:current' },
+    });
+  });
+
+  it('does not double-add an existing reaction', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(
+      messagesKey,
+      buildPage([{ value: '👍', sender: { did: 'did:current' }, createdAt: 'now' }]),
+    );
+
+    const { result } = renderHook(() => useMessageReaction(), { wrapper });
+    result.current.mutate({ convoId, messageId: 'm1', value: '👍', action: 'add' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const data = queryClient.getQueryData<any>(messagesKey);
+    expect(data.pages[0].messages[0].reactions).toHaveLength(1);
+  });
+
+  it('removes a reaction and optimistically patches the cache', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(
+      messagesKey,
+      buildPage([{ value: '👍', sender: { did: 'did:current' }, createdAt: 'now' }]),
+    );
+
+    const { result } = renderHook(() => useMessageReaction(), { wrapper });
+    result.current.mutate({ convoId, messageId: 'm1', value: '👍', action: 'remove' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockRemoveReaction).toHaveBeenCalledWith('token', convoId, 'm1', '👍');
+    const data = queryClient.getQueryData<any>(messagesKey);
+    expect(data.pages[0].messages[0].reactions).toHaveLength(0);
+  });
+
+  it('invalidates the message cache on error', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(messagesKey, buildPage([]));
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    mockAddReaction.mockRejectedValueOnce(new Error('fail'));
+
+    const { result } = renderHook(() => useMessageReaction(), { wrapper });
+    result.current.mutate({ convoId, messageId: 'm1', value: '👍', action: 'add' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(invalidateSpy).toHaveBeenCalled();
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMessageReaction(), { wrapper });
+
+    result.current.mutate({ convoId, messageId: 'm1', value: '👍', action: 'add' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockAddReaction).not.toHaveBeenCalled();
+  });
+
+  it('skips optimistic patch when there is no current did', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMessageReaction(), { wrapper });
+
+    // No did means mutationFn passes the pdsUrl guard but onMutate returns early;
+    // addReaction still fires since token + pdsUrl are present.
+    result.current.mutate({ convoId, messageId: 'm1', value: '👍', action: 'add' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockAddReaction).toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useMuteActorList.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useMuteActorList.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useMuteActorList } from '@/hooks/mutations/useMuteActorList';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockMuteActorList = jest.fn();
+const mockUnmuteActorList = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    muteActorList: mockMuteActorList,
+    unmuteActorList: mockUnmuteActorList,
+  })),
+}));
+
+describe('useMuteActorList mutation hook', () => {
+  let invalidateSpy: jest.SpyInstance;
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockMuteActorList.mockResolvedValue({});
+    mockUnmuteActorList.mockResolvedValue({});
+  });
+
+  it('mutes a moderation list and invalidates feeds', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMuteActorList(), { wrapper });
+
+    result.current.mutate({ list: 'at://list', action: 'mute' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockMuteActorList).toHaveBeenCalledWith('token', 'at://list');
+    expect(mockUnmuteActorList).not.toHaveBeenCalled();
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['moderationLists'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['timeline'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['feed'] });
+  });
+
+  it('unmutes a moderation list', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMuteActorList(), { wrapper });
+
+    result.current.mutate({ list: 'at://list', action: 'unmute' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockUnmuteActorList).toHaveBeenCalledWith('token', 'at://list');
+    expect(mockMuteActorList).not.toHaveBeenCalled();
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMuteActorList(), { wrapper });
+
+    result.current.mutate({ list: 'at://list', action: 'mute' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockMuteActorList).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMuteActorList(), { wrapper });
+
+    result.current.mutate({ list: 'at://list', action: 'mute' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockMuteActorList).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useMuteThread.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useMuteThread.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useMuteThread } from '@/hooks/mutations/useMuteThread';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { apiForAccount } from '@/utils/blueskyApi';
+
+const mockMuteThread = jest.fn();
+const mockUnmuteThread = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+
+describe('useMuteThread mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    (apiForAccount as jest.Mock).mockReturnValue({
+      muteThread: mockMuteThread,
+      unmuteThread: mockUnmuteThread,
+    });
+    mockMuteThread.mockResolvedValue({});
+    mockUnmuteThread.mockResolvedValue({});
+  });
+
+  it('mutes a thread and invalidates caches', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const spy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useMuteThread(), { wrapper });
+
+    result.current.mutate({ root: 'at://root', action: 'mute' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockMuteThread).toHaveBeenCalledWith('token', 'at://root');
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['postThread'] });
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['notifications'] });
+  });
+
+  it('unmutes a thread', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMuteThread(), { wrapper });
+
+    result.current.mutate({ root: 'at://root', action: 'unmute' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockUnmuteThread).toHaveBeenCalledWith('token', 'at://root');
+    expect(mockMuteThread).not.toHaveBeenCalled();
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMuteThread(), { wrapper });
+
+    result.current.mutate({ root: 'at://root', action: 'mute' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockMuteThread).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMuteThread(), { wrapper });
+
+    result.current.mutate({ root: 'at://root', action: 'mute' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockMuteThread).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useMuteUser.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useMuteUser.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useMuteUser } from '@/hooks/mutations/useMuteUser';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { apiForAccount } from '@/utils/blueskyApi';
+
+const mockMuteUser = jest.fn();
+const mockUnmuteUser = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+
+describe('useMuteUser mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    (apiForAccount as jest.Mock).mockReturnValue({
+      muteUser: mockMuteUser,
+      unmuteUser: mockUnmuteUser,
+    });
+    mockMuteUser.mockResolvedValue({});
+    mockUnmuteUser.mockResolvedValue({});
+  });
+
+  it('mutes a user and invalidates caches', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const spy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useMuteUser(), { wrapper });
+
+    result.current.mutate({ actor: 'did:actor', action: 'mute' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockMuteUser).toHaveBeenCalledWith('token', 'did:actor');
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['mutes'] });
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['timeline'] });
+  });
+
+  it('unmutes a user', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMuteUser(), { wrapper });
+
+    result.current.mutate({ actor: 'did:actor', action: 'unmute' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockUnmuteUser).toHaveBeenCalledWith('token', 'did:actor');
+    expect(mockMuteUser).not.toHaveBeenCalled();
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMuteUser(), { wrapper });
+
+    result.current.mutate({ actor: 'did:actor', action: 'mute' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockMuteUser).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMuteUser(), { wrapper });
+
+    result.current.mutate({ actor: 'did:actor', action: 'mute' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockMuteUser).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useOzoneTemplateMutations.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useOzoneTemplateMutations.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  useCreateOzoneTemplate,
+  useUpdateOzoneTemplate,
+  useDeleteOzoneTemplate,
+} from '@/hooks/mutations/useOzoneTemplateMutations';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+
+const mockCreateCommTemplate = jest.fn();
+const mockUpdateCommTemplate = jest.fn();
+const mockDeleteCommTemplate = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyOzone', () => ({ ozoneForAccount: jest.fn() }));
+
+describe('useOzoneTemplateMutations hooks', () => {
+  const templatesKey = ['ozone', 'templates', 'did:ozone'];
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper, invalidateSpy };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({
+      createCommTemplate: mockCreateCommTemplate,
+      updateCommTemplate: mockUpdateCommTemplate,
+      deleteCommTemplate: mockDeleteCommTemplate,
+    });
+  });
+
+  it('useCreateOzoneTemplate creates with createdBy and invalidates', async () => {
+    mockCreateCommTemplate.mockResolvedValue({ id: 't1' });
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useCreateOzoneTemplate(), { wrapper });
+
+    result.current.mutate({ name: 'Hi', contentMarkdown: 'body', lang: 'en' });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockCreateCommTemplate).toHaveBeenCalledWith('token', 'did:ozone', {
+      name: 'Hi',
+      contentMarkdown: 'body',
+      lang: 'en',
+      createdBy: 'did:current',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: templatesKey });
+  });
+
+  it('useCreateOzoneTemplate throws when session missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateOzoneTemplate(), { wrapper });
+    result.current.mutate({ name: 'Hi', contentMarkdown: 'body' });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('useUpdateOzoneTemplate updates with updatedBy and invalidates', async () => {
+    mockUpdateCommTemplate.mockResolvedValue({ id: 't1' });
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useUpdateOzoneTemplate(), { wrapper });
+
+    result.current.mutate({ id: 't1', name: 'New', disabled: true });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockUpdateCommTemplate).toHaveBeenCalledWith('token', 'did:ozone', {
+      id: 't1',
+      name: 'New',
+      disabled: true,
+      updatedBy: 'did:current',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: templatesKey });
+  });
+
+  it('useUpdateOzoneTemplate throws when PDS missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: undefined } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateOzoneTemplate(), { wrapper });
+    result.current.mutate({ id: 't1' });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('useDeleteOzoneTemplate deletes, returns id, and invalidates', async () => {
+    mockDeleteCommTemplate.mockResolvedValue(undefined);
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useDeleteOzoneTemplate(), { wrapper });
+
+    result.current.mutate('t1');
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockDeleteCommTemplate).toHaveBeenCalledWith('token', 'did:ozone', 't1');
+    expect(result.current.data).toBe('t1');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: templatesKey });
+  });
+
+  it('useDeleteOzoneTemplate throws when session missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeleteOzoneTemplate(), { wrapper });
+    result.current.mutate('t1');
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/usePinPost.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/usePinPost.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { usePinPost } from '@/hooks/mutations/usePinPost';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { apiForAccount } from '@/utils/blueskyApi';
+
+const mockSetPinnedPost = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+
+describe('usePinPost mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did:me', pdsUrl: 'https://pds' },
+    });
+    (apiForAccount as jest.Mock).mockReturnValue({ setPinnedPost: mockSetPinnedPost });
+    mockSetPinnedPost.mockResolvedValue({});
+  });
+
+  it('pins a post and invalidates profile + pinnedPost', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const spy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => usePinPost(), { wrapper });
+
+    result.current.mutate({ action: 'pin', uri: 'at://post', cid: 'cid' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockSetPinnedPost).toHaveBeenCalledWith('token', 'did:me', {
+      uri: 'at://post',
+      cid: 'cid',
+    });
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['profile'] });
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['pinnedPost'] });
+  });
+
+  it('unpins a post by passing null', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => usePinPost(), { wrapper });
+
+    result.current.mutate({ action: 'unpin' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockSetPinnedPost).toHaveBeenCalledWith('token', 'did:me', null);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => usePinPost(), { wrapper });
+
+    result.current.mutate({ action: 'unpin' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockSetPinnedPost).not.toHaveBeenCalled();
+  });
+
+  it('errors when did missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => usePinPost(), { wrapper });
+
+    result.current.mutate({ action: 'unpin' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockSetPinnedPost).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:me' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => usePinPost(), { wrapper });
+
+    result.current.mutate({ action: 'unpin' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockSetPinnedPost).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/usePostControls.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/usePostControls.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { usePostControls } from '@/hooks/mutations/usePostControls';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { apiForAccount } from '@/utils/blueskyApi';
+import { DEFAULT_POST_CONTROLS, type PostControls } from '@/utils/postControls';
+
+const mockSetThreadgate = jest.fn();
+const mockSetPostgate = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+
+describe('usePostControls mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did:me', pdsUrl: 'https://pds' },
+    });
+    (apiForAccount as jest.Mock).mockReturnValue({
+      setThreadgate: mockSetThreadgate,
+      setPostgate: mockSetPostgate,
+    });
+    mockSetThreadgate.mockResolvedValue({});
+    mockSetPostgate.mockResolvedValue({});
+  });
+
+  it('skips both writes when controls are default', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const spy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => usePostControls(), { wrapper });
+
+    result.current.mutate({ postUri: 'at://post', controls: DEFAULT_POST_CONTROLS });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockSetThreadgate).not.toHaveBeenCalled();
+    expect(mockSetPostgate).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['postThread'] });
+  });
+
+  it('writes threadgate when reply controls are non-default', async () => {
+    const { wrapper } = createWrapper();
+    const controls: PostControls = { replyAllow: { type: 'nobody' }, allowQuote: true };
+    const { result } = renderHook(() => usePostControls(), { wrapper });
+
+    result.current.mutate({ postUri: 'at://post', controls });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockSetThreadgate).toHaveBeenCalledWith('token', 'did:me', 'at://post', controls.replyAllow);
+    expect(mockSetPostgate).not.toHaveBeenCalled();
+  });
+
+  it('writes postgate when allowQuote is non-default', async () => {
+    const { wrapper } = createWrapper();
+    const controls: PostControls = { replyAllow: { type: 'everyone' }, allowQuote: false };
+    const { result } = renderHook(() => usePostControls(), { wrapper });
+
+    result.current.mutate({ postUri: 'at://post', controls });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockSetPostgate).toHaveBeenCalledWith('token', 'did:me', 'at://post', {
+      allowQuote: false,
+    });
+    expect(mockSetThreadgate).not.toHaveBeenCalled();
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => usePostControls(), { wrapper });
+
+    result.current.mutate({ postUri: 'at://post', controls: DEFAULT_POST_CONTROLS });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('errors when did missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => usePostControls(), { wrapper });
+
+    result.current.mutate({ postUri: 'at://post', controls: DEFAULT_POST_CONTROLS });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:me' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => usePostControls(), { wrapper });
+
+    result.current.mutate({ postUri: 'at://post', controls: DEFAULT_POST_CONTROLS });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useRateCommunityNote.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useRateCommunityNote.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useRateCommunityNote } from '@/hooks/mutations/useRateCommunityNote';
+
+describe('useRateCommunityNote stub hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('rates a community note and resolves ok', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRateCommunityNote(), { wrapper });
+
+    const input = {
+      noteId: 'note-1',
+      helpfulness: 'helpful' as const,
+      reasons: ['clear', 'sourced'],
+      comment: 'good note',
+    };
+    result.current.mutate(input);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual({ ok: true });
+    expect(logSpy).toHaveBeenCalledWith('[stub useRateCommunityNote]', input);
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useRegisterPushSubscription.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useRegisterPushSubscription.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useRegisterPushSubscription } from '@/hooks/mutations/useRegisterPushSubscription';
+
+describe('useRegisterPushSubscription mutation hook', () => {
+  const ORIGINAL_ENV = process.env.EXPO_PUBLIC_PUSH_REGISTRY_URL;
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.EXPO_PUBLIC_PUSH_REGISTRY_URL = 'https://registry.test/';
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      text: jest.fn().mockResolvedValue(''),
+    }) as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    process.env.EXPO_PUBLIC_PUSH_REGISTRY_URL = ORIGINAL_ENV;
+  });
+
+  it('posts the subscription payload to the trimmed registry url', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useRegisterPushSubscription(), { wrapper });
+
+    result.current.mutate({
+      did: 'did:plc:abc',
+      expoPushToken: 'expo-token',
+      platform: 'ios',
+      devicePushToken: 'device-token',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith('https://registry.test/subscriptions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        did: 'did:plc:abc',
+        expoPushToken: 'expo-token',
+        devicePushToken: 'device-token',
+        platform: 'ios',
+      }),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['notifications', 'preferences', 'did:plc:abc', undefined],
+    });
+  });
+
+  it('throws when the registry url is not configured', async () => {
+    delete process.env.EXPO_PUBLIC_PUSH_REGISTRY_URL;
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRegisterPushSubscription(), { wrapper });
+
+    result.current.mutate({ did: 'did', expoPushToken: 'expo-token', platform: 'ios' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('throws when the registry responds with a non-ok status', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+      text: jest.fn().mockResolvedValue('boom'),
+    }) as unknown as typeof fetch;
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRegisterPushSubscription(), { wrapper });
+
+    result.current.mutate({ did: 'did', expoPushToken: 'expo-token', platform: 'android' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(result.current.error?.message).toContain('500');
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useRemoveAccount.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useRemoveAccount.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useRemoveAccount } from '@/hooks/mutations/useRemoveAccount';
+import type { Account } from '@/types/account';
+import { storage } from '@/utils/secureStorage';
+
+jest.mock('@/utils/secureStorage', () => ({
+  storage: { setItem: jest.fn(), getItem: jest.fn(), removeItem: jest.fn() },
+}));
+
+describe('useRemoveAccount mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('removes the account and promotes the next as current', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const accounts = [
+      { did: '1', handle: 'h1' },
+      { did: '2', handle: 'h2' },
+    ] as Account[];
+    queryClient.setQueryData(['accounts'], accounts);
+    queryClient.setQueryData(['currentAccount'], accounts[0]);
+    (storage.getItem as jest.Mock).mockReturnValue(accounts);
+
+    const { result } = renderHook(() => useRemoveAccount(), { wrapper });
+    result.current.mutate('1');
+
+    await waitFor(() => expect(queryClient.getQueryData(['accounts'])).toEqual([accounts[1]]));
+    expect(queryClient.getQueryData(['currentAccount'])).toEqual(accounts[1]);
+    expect(storage.setItem).toHaveBeenCalledWith('currentAccount', accounts[1]);
+    expect(storage.setItem).toHaveBeenCalledWith('accounts', [accounts[1]]);
+  });
+
+  it('sets current account to null when removing the only account', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const accounts = [{ did: '1', handle: 'h1' }] as Account[];
+    queryClient.setQueryData(['accounts'], accounts);
+    queryClient.setQueryData(['currentAccount'], accounts[0]);
+    (storage.getItem as jest.Mock).mockReturnValue(accounts);
+
+    const { result } = renderHook(() => useRemoveAccount(), { wrapper });
+    result.current.mutate('1');
+
+    await waitFor(() => expect(queryClient.getQueryData(['accounts'])).toEqual([]));
+    expect(queryClient.getQueryData(['currentAccount'])).toBeNull();
+    expect(storage.setItem).toHaveBeenCalledWith('currentAccount', null);
+  });
+
+  it('leaves current account untouched when removing a different account', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const accounts = [
+      { did: '1', handle: 'h1' },
+      { did: '2', handle: 'h2' },
+    ] as Account[];
+    queryClient.setQueryData(['accounts'], accounts);
+    queryClient.setQueryData(['currentAccount'], accounts[0]);
+    (storage.getItem as jest.Mock).mockReturnValue(accounts);
+
+    const { result } = renderHook(() => useRemoveAccount(), { wrapper });
+    result.current.mutate('2');
+
+    await waitFor(() => expect(queryClient.getQueryData(['accounts'])).toEqual([accounts[0]]));
+    expect(queryClient.getQueryData(['currentAccount'])).toEqual(accounts[0]);
+    expect(storage.setItem).not.toHaveBeenCalledWith('currentAccount', expect.anything());
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useReport.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useReport.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useReport } from '@/hooks/mutations/useReport';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockCreateReport = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createReport: mockCreateReport,
+  })),
+}));
+
+describe('useReport mutation hook', () => {
+  let invalidateSpy: jest.SpyInstance;
+
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockCreateReport.mockResolvedValue({});
+  });
+
+  it('reports an account and invalidates the profile', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useReport(), { wrapper });
+
+    result.current.mutate({
+      subject: { type: 'account', did: 'did:bad' },
+      reasonType: 'reasonSpam',
+      reason: 'spammy',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreateReport).toHaveBeenCalledWith(
+      'token',
+      { did: 'did:bad' },
+      'reasonSpam',
+      'spammy',
+      undefined,
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['profile', 'did:bad'] });
+  });
+
+  it('reports a post and invalidates post + thread caches', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useReport(), { wrapper });
+
+    result.current.mutate({
+      subject: { type: 'post', uri: 'at://post', cid: 'cid' },
+      reasonType: 'reasonViolation',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreateReport).toHaveBeenCalledWith(
+      'token',
+      { uri: 'at://post', cid: 'cid' },
+      'reasonViolation',
+      undefined,
+      undefined,
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['post'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['postThread'] });
+  });
+
+  it('forwards a labeler did for an appeal', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useReport(), { wrapper });
+
+    result.current.mutate({
+      subject: { type: 'account', did: 'did:bad' },
+      reasonType: 'reasonAppeal',
+      labelerDid: 'did:labeler',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreateReport).toHaveBeenCalledWith(
+      'token',
+      { did: 'did:bad' },
+      'reasonAppeal',
+      undefined,
+      'did:labeler',
+    );
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useReport(), { wrapper });
+
+    result.current.mutate({
+      subject: { type: 'account', did: 'did:bad' },
+      reasonType: 'reasonSpam',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateReport).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useReport(), { wrapper });
+
+    result.current.mutate({
+      subject: { type: 'account', did: 'did:bad' },
+      reasonType: 'reasonSpam',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreateReport).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useRepostPost.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useRepostPost.test.tsx
@@ -1,0 +1,196 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useRepostPost } from '@/hooks/mutations/useRepostPost';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { apiForAccount } from '@/utils/blueskyApi';
+import type { BlueskyFeedResponse, BlueskyPostView } from '@/bluesky-api';
+
+const mockRepostPost = jest.fn();
+const mockUnrepostPost = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+
+describe('useRepostPost mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  const basePost = (uri: string): BlueskyPostView =>
+    ({
+      uri,
+      cid: 'cid',
+      author: {},
+      record: {},
+      indexedAt: '',
+      labels: [],
+      repostCount: 0,
+      viewer: {},
+    }) as unknown as BlueskyPostView;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did:me', pdsUrl: 'https://pds' },
+    });
+    (apiForAccount as jest.Mock).mockReturnValue({
+      repostPost: mockRepostPost,
+      unrepostPost: mockUnrepostPost,
+    });
+    mockRepostPost.mockResolvedValue({ uri: 'repost-uri' });
+    mockUnrepostPost.mockResolvedValue({});
+  });
+
+  it('reposts a post and optimistically updates timeline then finalizes uri', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const postUri = 'at://post';
+    const feed = { feed: [{ post: basePost(postUri) }] } as unknown as BlueskyFeedResponse;
+    queryClient.setQueryData(['timeline'], feed);
+
+    const { result } = renderHook(() => useRepostPost(), { wrapper });
+    result.current.mutate({ postUri, postCid: 'cid', action: 'repost' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockRepostPost).toHaveBeenCalledWith('token', postUri, 'cid', 'did:me');
+
+    const updated = queryClient.getQueryData<BlueskyFeedResponse>(['timeline']);
+    expect(updated?.feed[0].post.repostCount).toBe(1);
+    expect(updated?.feed[0].post.viewer?.repost).toBe('repost-uri');
+  });
+
+  it('optimistically patches feed pages, author feed, post, thread and reply views', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const postUri = 'at://post';
+
+    const timeline = {
+      feed: [
+        { post: basePost(postUri) },
+        {
+          post: basePost('at://child'),
+          reply: { parent: basePost(postUri), root: basePost(postUri) },
+        },
+      ],
+    } as unknown as BlueskyFeedResponse;
+    const page = { feed: [{ post: basePost(postUri) }] } as unknown as BlueskyFeedResponse;
+
+    queryClient.setQueryData(['timeline'], timeline);
+    queryClient.setQueryData(['feed', 'a'], { pages: [page] });
+    queryClient.setQueryData(['feed', 'bad'], { notPages: true });
+    queryClient.setQueryData(['authorFeed', 'a'], { pages: [page] });
+    queryClient.setQueryData(['post', postUri], basePost(postUri));
+    queryClient.setQueryData(['postThread', postUri], { thread: { post: basePost(postUri) } });
+
+    const { result } = renderHook(() => useRepostPost(), { wrapper });
+    result.current.mutate({ postUri, postCid: 'cid', action: 'repost' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const tl = queryClient.getQueryData<BlueskyFeedResponse>(['timeline']);
+    expect(tl?.feed[0].post.viewer?.repost).toBe('repost-uri');
+    expect(tl?.feed[1].reply?.parent?.viewer?.repost).toBe('repost-uri');
+    expect(tl?.feed[1].reply?.root?.viewer?.repost).toBe('repost-uri');
+
+    const feedData = queryClient.getQueryData<{ pages: BlueskyFeedResponse[] }>(['feed', 'a']);
+    expect(feedData?.pages[0].feed[0].post.viewer?.repost).toBe('repost-uri');
+
+    const authorData = queryClient.getQueryData<{ pages: BlueskyFeedResponse[] }>(['authorFeed', 'a']);
+    expect(authorData?.pages[0].feed[0].post.repostCount).toBe(1);
+
+    const postData = queryClient.getQueryData<BlueskyPostView>(['post', postUri]);
+    expect(postData?.viewer?.repost).toBe('repost-uri');
+
+    const threadData = queryClient.getQueryData<{ thread: { post: BlueskyPostView } }>([
+      'postThread',
+      postUri,
+    ]);
+    expect(threadData?.thread.post.viewer?.repost).toBe('repost-uri');
+  });
+
+  it('optimistically decrements repost count on unrepost', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const postUri = 'at://post';
+    const reposted = {
+      ...basePost(postUri),
+      repostCount: 2,
+      viewer: { repost: 'old' },
+    } as unknown as BlueskyPostView;
+    queryClient.setQueryData(['timeline'], {
+      feed: [{ post: reposted }],
+    } as unknown as BlueskyFeedResponse);
+
+    const { result } = renderHook(() => useRepostPost(), { wrapper });
+    result.current.mutate({ postUri, repostUri: 'old', action: 'unrepost' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const tl = queryClient.getQueryData<BlueskyFeedResponse>(['timeline']);
+    expect(tl?.feed[0].post.repostCount).toBe(1);
+    expect(tl?.feed[0].post.viewer?.repost).toBeUndefined();
+  });
+
+  it('unreposts a post', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRepostPost(), { wrapper });
+
+    result.current.mutate({ postUri: 'at://post', repostUri: 'repost-uri', action: 'unrepost' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockUnrepostPost).toHaveBeenCalledWith('token', 'repost-uri', 'did:me');
+  });
+
+  it('errors when postCid missing for repost', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRepostPost(), { wrapper });
+
+    result.current.mutate({ postUri: 'at://post', action: 'repost' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockRepostPost).not.toHaveBeenCalled();
+  });
+
+  it('errors when repostUri missing for unrepost', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRepostPost(), { wrapper });
+
+    result.current.mutate({ postUri: 'at://post', action: 'unrepost' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockUnrepostPost).not.toHaveBeenCalled();
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRepostPost(), { wrapper });
+
+    result.current.mutate({ postUri: 'at://post', postCid: 'cid', action: 'repost' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockRepostPost).not.toHaveBeenCalled();
+  });
+
+  it('rolls back timeline on error', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const postUri = 'at://post';
+    const feed = { feed: [{ post: basePost(postUri) }] } as unknown as BlueskyFeedResponse;
+    queryClient.setQueryData(['timeline'], feed);
+    const snapshot = queryClient.getQueryData(['timeline']);
+    mockRepostPost.mockRejectedValueOnce(new Error('fail'));
+
+    const { result } = renderHook(() => useRepostPost(), { wrapper });
+    result.current.mutate({ postUri, postCid: 'cid', action: 'repost' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(queryClient.getQueryData(['timeline'])).toEqual(snapshot);
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useRequestEmailUpdate.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useRequestEmailUpdate.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useRequestEmailUpdate } from '@/hooks/mutations/useRequestEmailUpdate';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockRequestEmailUpdate = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    requestEmailUpdate: mockRequestEmailUpdate,
+  })),
+}));
+
+describe('useRequestEmailUpdate mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockRequestEmailUpdate.mockResolvedValue({ tokenRequired: true });
+  });
+
+  it('requests an email update and invalidates preferences for the pds', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useRequestEmailUpdate(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockRequestEmailUpdate).toHaveBeenCalledWith('token');
+    expect(result.current.data).toEqual({ tokenRequired: true });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['preferences', 'https://pds', undefined],
+    });
+  });
+
+  it('throws when the token is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useRequestEmailUpdate(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockRequestEmailUpdate).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PDS URL is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { result } = renderHook(() => useRequestEmailUpdate(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockRequestEmailUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useRequestPasswordReset.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useRequestPasswordReset.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useRequestPasswordReset } from '@/hooks/mutations/useRequestPasswordReset';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { apiForAccount } from '@/utils/blueskyApi';
+
+const mockRequestPasswordReset = jest.fn();
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+
+describe('useRequestPasswordReset mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    (apiForAccount as jest.Mock).mockReturnValue({
+      requestPasswordReset: mockRequestPasswordReset,
+    });
+    mockRequestPasswordReset.mockResolvedValue(undefined);
+  });
+
+  it('requests a password reset for the given email', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRequestPasswordReset(), { wrapper });
+
+    result.current.mutate('user@example.com');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockRequestPasswordReset).toHaveBeenCalledWith('user@example.com');
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: {} });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRequestPasswordReset(), { wrapper });
+
+    result.current.mutate('user@example.com');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockRequestPasswordReset).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useRevokeAppPassword.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useRevokeAppPassword.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useRevokeAppPassword } from '@/hooks/mutations/useRevokeAppPassword';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockRevokeAppPassword = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    revokeAppPassword: mockRevokeAppPassword,
+  })),
+}));
+
+describe('useRevokeAppPassword mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockRevokeAppPassword.mockResolvedValue(undefined);
+  });
+
+  it('revokes the app password by name and returns the name', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useRevokeAppPassword(), { wrapper });
+
+    result.current.mutate('cli');
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockRevokeAppPassword).toHaveBeenCalledWith('token', 'cli');
+    expect(result.current.data).toBe('cli');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['appPasswords'] });
+  });
+
+  it('throws when the token is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useRevokeAppPassword(), { wrapper });
+
+    result.current.mutate('cli');
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockRevokeAppPassword).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PDS URL is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { result } = renderHook(() => useRevokeAppPassword(), { wrapper });
+
+    result.current.mutate('cli');
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockRevokeAppPassword).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useSendFeedInteraction.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useSendFeedInteraction.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useSendFeedInteraction } from '@/hooks/mutations/useSendFeedInteraction';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { apiForAccount } from '@/utils/blueskyApi';
+
+const mockSendInteractions = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+
+const FEED_GEN_URI = 'at://did:plc:gen/app.bsky.feed.generator/abc';
+
+describe('useSendFeedInteraction mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did:me', pdsUrl: 'https://pds' },
+    });
+    (apiForAccount as jest.Mock).mockReturnValue({ sendInteractions: mockSendInteractions });
+    mockSendInteractions.mockResolvedValue({});
+  });
+
+  it('extracts the feed gen DID and proxies the interaction', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const spy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useSendFeedInteraction(), { wrapper });
+
+    result.current.mutate({
+      feedUri: FEED_GEN_URI,
+      postUri: 'at://post',
+      event: 'app.bsky.feed.defs#interactionRequestMore',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockSendInteractions).toHaveBeenCalledWith('token', 'did:plc:gen', [
+      { event: 'app.bsky.feed.defs#interactionRequestMore', item: 'at://post' },
+    ]);
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['feed', FEED_GEN_URI, 'https://pds'] });
+  });
+
+  it('includes feedContext when provided', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSendFeedInteraction(), { wrapper });
+
+    result.current.mutate({
+      feedUri: FEED_GEN_URI,
+      postUri: 'at://post',
+      event: 'app.bsky.feed.defs#interactionSeen',
+      feedContext: 'ctx',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockSendInteractions).toHaveBeenCalledWith('token', 'did:plc:gen', [
+      { event: 'app.bsky.feed.defs#interactionSeen', item: 'at://post', feedContext: 'ctx' },
+    ]);
+  });
+
+  it('is a no-op for non feed-generator URIs', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSendFeedInteraction(), { wrapper });
+
+    result.current.mutate({
+      feedUri: 'following',
+      postUri: 'at://post',
+      event: 'app.bsky.feed.defs#interactionSeen',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockSendInteractions).not.toHaveBeenCalled();
+    expect(result.current.data).toBeNull();
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSendFeedInteraction(), { wrapper });
+
+    result.current.mutate({
+      feedUri: FEED_GEN_URI,
+      postUri: 'at://post',
+      event: 'app.bsky.feed.defs#interactionSeen',
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockSendInteractions).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:me' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSendFeedInteraction(), { wrapper });
+
+    result.current.mutate({
+      feedUri: FEED_GEN_URI,
+      postUri: 'at://post',
+      event: 'app.bsky.feed.defs#interactionSeen',
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockSendInteractions).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useSetAuthentication.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useSetAuthentication.test.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useSetAuthentication } from '@/hooks/mutations/useSetAuthentication';
+import type { Account } from '@/types/account';
+import { storage } from '@/utils/secureStorage';
+
+jest.mock('@/utils/secureStorage', () => ({
+  storage: { setItem: jest.fn(), getItem: jest.fn(), removeItem: jest.fn() },
+}));
+
+describe('useSetAuthentication mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sets all auth data in cache and storage, adding a new account', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    (storage.getItem as jest.Mock).mockReturnValue(undefined);
+    const { result } = renderHook(() => useSetAuthentication(), { wrapper });
+
+    result.current.mutate({
+      token: 't',
+      refreshToken: 'r',
+      did: 'did',
+      handle: 'handle',
+      pdsUrl: 'url',
+    });
+
+    await waitFor(() => expect(queryClient.getQueryData(['jwtToken'])).toBe('t'));
+    expect(queryClient.getQueryData(['refreshToken'])).toBe('r');
+    expect(queryClient.getQueryData(['currentAccount'])).toMatchObject({
+      did: 'did',
+      handle: 'handle',
+      jwtToken: 't',
+      refreshToken: 'r',
+      pdsUrl: 'url',
+    });
+    expect(queryClient.getQueryData(['accounts'])).toEqual([
+      expect.objectContaining({ did: 'did', handle: 'handle' }),
+    ]);
+    expect(storage.setItem).toHaveBeenCalledWith('jwtToken', 't');
+    expect(storage.setItem).toHaveBeenCalledWith('refreshToken', 'r');
+    expect(storage.setItem).toHaveBeenCalledWith(
+      'currentAccount',
+      expect.objectContaining({ did: 'did', handle: 'handle' }),
+    );
+    expect(storage.setItem).toHaveBeenCalledWith('accounts', [
+      expect.objectContaining({ did: 'did', handle: 'handle' }),
+    ]);
+  });
+
+  it('merges into an existing account with the same DID rather than appending', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const existing: Account = {
+      did: 'did',
+      handle: 'old',
+      jwtToken: 'oldT',
+      refreshToken: 'oldR',
+    } as Account;
+    queryClient.setQueryData(['accounts'], [existing]);
+    // Seed the currentAccount cache so the merge preserves prior display fields.
+    queryClient.setQueryData(['currentAccount'], { ...existing, displayName: 'Name', avatar: 'av' });
+    (storage.getItem as jest.Mock).mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useSetAuthentication(), { wrapper });
+    result.current.mutate({ token: 't', refreshToken: 'r', did: 'did', handle: 'new' });
+
+    await waitFor(() => expect(queryClient.getQueryData(['jwtToken'])).toBe('t'));
+    const accounts = queryClient.getQueryData<Account[]>(['accounts']);
+    expect(accounts).toHaveLength(1);
+    expect(accounts?.[0]).toMatchObject({
+      did: 'did',
+      handle: 'new',
+      jwtToken: 't',
+      displayName: 'Name',
+      avatar: 'av',
+    });
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useSetCurrentAccount.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useSetCurrentAccount.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useSetCurrentAccount } from '@/hooks/mutations/useSetCurrentAccount';
+import type { Account } from '@/types/account';
+import { storage } from '@/utils/secureStorage';
+
+jest.mock('@/utils/secureStorage', () => ({
+  storage: { setItem: jest.fn(), getItem: jest.fn(), removeItem: jest.fn() },
+}));
+
+describe('useSetCurrentAccount mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('stores the account in cache and secureStorage', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const { result } = renderHook(() => useSetCurrentAccount(), { wrapper });
+    const account = { did: '1', handle: 'h', jwtToken: 't', refreshToken: 'r' } as Account;
+
+    result.current.mutate(account);
+
+    await waitFor(() => expect(queryClient.getQueryData(['currentAccount'])).toEqual(account));
+    expect(storage.setItem).toHaveBeenCalledWith('currentAccount', account);
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useSetJwtToken.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useSetJwtToken.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useSetJwtToken } from '@/hooks/mutations/useSetJwtToken';
+import { storage } from '@/utils/secureStorage';
+
+jest.mock('@/utils/secureStorage', () => ({
+  storage: { setItem: jest.fn(), getItem: jest.fn(), removeItem: jest.fn() },
+}));
+
+describe('useSetJwtToken mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('stores the token in cache and secureStorage', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const { result } = renderHook(() => useSetJwtToken(), { wrapper });
+
+    result.current.mutate('abc');
+
+    await waitFor(() => expect(queryClient.getQueryData(['jwtToken'])).toBe('abc'));
+    expect(storage.setItem).toHaveBeenCalledWith('jwtToken', 'abc');
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useSetLiveStatus.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useSetLiveStatus.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useSetLiveStatus } from '@/hooks/mutations/useSetLiveStatus';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockSetActorStatus = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    setActorStatus: mockSetActorStatus,
+  })),
+}));
+
+describe('useSetLiveStatus mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockSetActorStatus.mockResolvedValue(undefined);
+  });
+
+  it('publishes a live status with the friendly service name as the card title', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useSetLiveStatus(), { wrapper });
+
+    result.current.mutate({ url: 'https://twitch.tv/someone', durationMinutes: 60 });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockSetActorStatus).toHaveBeenCalledWith('token', 'did', {
+      durationMinutes: 60,
+      createdAt: undefined,
+      external: {
+        uri: 'https://twitch.tv/someone',
+        title: 'Twitch',
+        description: 'https://twitch.tv/someone',
+      },
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['profile'] });
+  });
+
+  it('preserves createdAt when editing an existing status', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSetLiveStatus(), { wrapper });
+
+    result.current.mutate({
+      url: 'https://youtube.com/watch?v=x',
+      durationMinutes: 30,
+      createdAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockSetActorStatus).toHaveBeenCalledWith('token', 'did', {
+      durationMinutes: 30,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      external: {
+        uri: 'https://youtube.com/watch?v=x',
+        title: 'YouTube',
+        description: 'https://youtube.com/watch?v=x',
+      },
+    });
+  });
+
+  it('falls back to the raw url as title for an unparseable url', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSetLiveStatus(), { wrapper });
+
+    result.current.mutate({ url: 'not a url', durationMinutes: 15 });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockSetActorStatus).toHaveBeenCalledWith(
+      'token',
+      'did',
+      expect.objectContaining({
+        external: { uri: 'not a url', title: 'not a url', description: 'not a url' },
+      }),
+    );
+  });
+
+  it('throws when the token is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useSetLiveStatus(), { wrapper });
+
+    result.current.mutate({ url: 'https://twitch.tv/someone', durationMinutes: 60 });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetActorStatus).not.toHaveBeenCalled();
+  });
+
+  it('throws when the DID is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { result } = renderHook(() => useSetLiveStatus(), { wrapper });
+
+    result.current.mutate({ url: 'https://twitch.tv/someone', durationMinutes: 60 });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetActorStatus).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PDS URL is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { result } = renderHook(() => useSetLiveStatus(), { wrapper });
+
+    result.current.mutate({ url: 'https://twitch.tv/someone', durationMinutes: 60 });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetActorStatus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useSetRefreshToken.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useSetRefreshToken.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useSetRefreshToken } from '@/hooks/mutations/useSetRefreshToken';
+import { storage } from '@/utils/secureStorage';
+
+jest.mock('@/utils/secureStorage', () => ({
+  storage: { setItem: jest.fn(), getItem: jest.fn(), removeItem: jest.fn() },
+}));
+
+describe('useSetRefreshToken mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('stores the refresh token in cache and secureStorage', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const { result } = renderHook(() => useSetRefreshToken(), { wrapper });
+
+    result.current.mutate('def');
+
+    await waitFor(() => expect(queryClient.getQueryData(['refreshToken'])).toBe('def'));
+    expect(storage.setItem).toHaveBeenCalledWith('refreshToken', 'def');
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useSetSelectedFeed.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useSetSelectedFeed.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useSetSelectedFeed } from '@/hooks/mutations/useSetSelectedFeed';
+import { storage } from '@/utils/secureStorage';
+
+jest.mock('@/utils/secureStorage', () => ({
+  storage: { setItem: jest.fn(), getItem: jest.fn(), removeItem: jest.fn() },
+}));
+
+describe('useSetSelectedFeed mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('stores the selected feed in cache and secureStorage', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const { result } = renderHook(() => useSetSelectedFeed(), { wrapper });
+
+    result.current.mutate('at://feed');
+
+    await waitFor(() => expect(queryClient.getQueryData(['selectedFeed'])).toBe('at://feed'));
+    expect(storage.setItem).toHaveBeenCalledWith('selectedFeed', 'at://feed');
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useStartConvo.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useStartConvo.test.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useStartConvo } from '@/hooks/mutations/useStartConvo';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetConvoForMembers = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getConvoForMembers: mockGetConvoForMembers,
+  })),
+}));
+
+describe('useStartConvo mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper, invalidateSpy };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockGetConvoForMembers.mockResolvedValue({ convo: { id: 'convo-1' } });
+  });
+
+  it('resolves a conversation and returns the convo view', async () => {
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useStartConvo(), { wrapper });
+
+    result.current.mutate({ memberDids: ['did:peer'] });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetConvoForMembers).toHaveBeenCalledWith('token', ['did:peer']);
+    expect(result.current.data).toEqual({ id: 'convo-1' });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['conversations'] });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useStartConvo(), { wrapper });
+
+    result.current.mutate({ memberDids: ['did:peer'] });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetConvoForMembers).not.toHaveBeenCalled();
+  });
+
+  it('errors when pdsUrl missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:current' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useStartConvo(), { wrapper });
+
+    result.current.mutate({ memberDids: ['did:peer'] });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetConvoForMembers).not.toHaveBeenCalled();
+  });
+
+  it('errors when no member dids provided', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useStartConvo(), { wrapper });
+
+    result.current.mutate({ memberDids: [] });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetConvoForMembers).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useSubmitCommunityNote.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useSubmitCommunityNote.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  useSubmitCommunityNote,
+  useRequestCommunityNote,
+} from '@/hooks/mutations/useSubmitCommunityNote';
+
+describe('useSubmitCommunityNote stub hooks', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  it('submits a community note and resolves ok', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSubmitCommunityNote(), { wrapper });
+
+    const input = {
+      postUri: 'at://post',
+      body: 'context',
+      sources: ['https://src'],
+      classification: 'misleading' as const,
+    };
+    result.current.mutate(input);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual({ ok: true });
+    expect(logSpy).toHaveBeenCalledWith('[stub useSubmitCommunityNote]', input);
+  });
+
+  it('requests a community note and resolves ok', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRequestCommunityNote(), { wrapper });
+
+    const input = {
+      postUri: 'at://post',
+      reason: 'misinformation' as const,
+      comment: 'please review',
+    };
+    result.current.mutate(input);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual({ ok: true });
+    expect(logSpy).toHaveBeenCalledWith('[stub useRequestCommunityNote]', input);
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useSwitchAccount.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useSwitchAccount.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useSwitchAccount } from '@/hooks/mutations/useSwitchAccount';
+import type { Account } from '@/types/account';
+
+const mockSetAuth = jest.fn();
+const mockSetCurrent = jest.fn();
+
+jest.mock('@/hooks/mutations/useSetAuthentication', () => ({
+  useSetAuthentication: () => ({ mutateAsync: mockSetAuth }),
+}));
+jest.mock('@/hooks/mutations/useSetCurrentAccount', () => ({
+  useSetCurrentAccount: () => ({ mutateAsync: mockSetCurrent }),
+}));
+
+describe('useSwitchAccount mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSetAuth.mockResolvedValue(undefined);
+    mockSetCurrent.mockResolvedValue(undefined);
+  });
+
+  it('sets current account, applies auth data, and invalidates account-scoped caches', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const spy = jest.spyOn(queryClient, 'invalidateQueries');
+    const account = {
+      did: '3',
+      handle: 'h3',
+      jwtToken: 't',
+      refreshToken: 'r',
+      pdsUrl: 'url',
+    } as Account;
+
+    const { result } = renderHook(() => useSwitchAccount(), { wrapper });
+    result.current.mutate(account);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockSetCurrent).toHaveBeenCalledWith(account);
+    expect(mockSetAuth).toHaveBeenCalledWith({
+      token: 't',
+      refreshToken: 'r',
+      did: '3',
+      handle: 'h3',
+      pdsUrl: 'url',
+      displayName: null,
+      avatar: null,
+    });
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['timeline'] });
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['notifications'] });
+    expect(spy).toHaveBeenCalledWith({ queryKey: ['profile', '3'] });
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateAccountAppView.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateAccountAppView.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateAccountAppView } from '@/hooks/mutations/useUpdateAccountAppView';
+import { storage } from '@/utils/secureStorage';
+
+jest.mock('@/utils/secureStorage', () => ({
+  storage: {
+    setItem: jest.fn(),
+    getItem: jest.fn(),
+    removeItem: jest.fn(),
+  },
+}));
+
+describe('useUpdateAccountAppView mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('persists the override to the accounts list and current account', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const setQueryDataSpy = jest.spyOn(queryClient, 'setQueryData');
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    const accounts = [
+      { did: 'a1', handle: 'h1' },
+      { did: 'a2', handle: 'h2' },
+    ];
+    const current = { did: 'a1', handle: 'h1' };
+    (storage.getItem as jest.Mock).mockImplementation((key: string) => {
+      if (key === 'accounts') return accounts;
+      if (key === 'currentAccount') return current;
+      return null;
+    });
+
+    const override = { did: 'did:appview' } as any;
+    const { result } = renderHook(() => useUpdateAccountAppView(), { wrapper });
+
+    result.current.mutate({ did: 'a1', override });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const expectedAccounts = [
+      { did: 'a1', handle: 'h1', appView: override },
+      { did: 'a2', handle: 'h2' },
+    ];
+    expect(storage.setItem).toHaveBeenCalledWith('accounts', expectedAccounts);
+    expect(setQueryDataSpy).toHaveBeenCalledWith(['accounts'], expectedAccounts);
+    expect(storage.setItem).toHaveBeenCalledWith('currentAccount', {
+      did: 'a1',
+      handle: 'h1',
+      appView: override,
+    });
+    expect(setQueryDataSpy).toHaveBeenCalledWith(['currentAccount'], {
+      did: 'a1',
+      handle: 'h1',
+      appView: override,
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith();
+  });
+
+  it('does not touch the current account when a different DID is updated', async () => {
+    const { wrapper } = createWrapper();
+    const accounts = [{ did: 'a1', handle: 'h1' }];
+    const current = { did: 'a2', handle: 'h2' };
+    (storage.getItem as jest.Mock).mockImplementation((key: string) => {
+      if (key === 'accounts') return accounts;
+      if (key === 'currentAccount') return current;
+      return null;
+    });
+
+    const { result } = renderHook(() => useUpdateAccountAppView(), { wrapper });
+
+    result.current.mutate({ did: 'a1', override: undefined });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(storage.setItem).toHaveBeenCalledWith('accounts', [
+      { did: 'a1', handle: 'h1', appView: undefined },
+    ]);
+    expect(storage.setItem).not.toHaveBeenCalledWith('currentAccount', expect.anything());
+  });
+
+  it('handles an empty stored accounts list', async () => {
+    const { wrapper } = createWrapper();
+    (storage.getItem as jest.Mock).mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useUpdateAccountAppView(), { wrapper });
+
+    result.current.mutate({ did: 'a1', override: undefined });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(storage.setItem).toHaveBeenCalledWith('accounts', []);
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateAccountAutomated.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateAccountAutomated.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateAccountAutomated } from '@/hooks/mutations/useUpdateAccountAutomated';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockSetAccountAutomated = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    setAccountAutomated: mockSetAccountAutomated,
+  })),
+}));
+
+describe('useUpdateAccountAutomated mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockSetAccountAutomated.mockResolvedValue(undefined);
+  });
+
+  it('sets the automated self-label and invalidates the profile', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateAccountAutomated(), { wrapper });
+
+    result.current.mutate(true);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockSetAccountAutomated).toHaveBeenCalledWith('token', 'did', true);
+    expect(result.current.data).toBe(true);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['profile'] });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateAccountAutomated(), { wrapper });
+
+    result.current.mutate(true);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetAccountAutomated).not.toHaveBeenCalled();
+  });
+
+  it('errors when DID missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateAccountAutomated(), { wrapper });
+
+    result.current.mutate(true);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetAccountAutomated).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateAccountAutomated(), { wrapper });
+
+    result.current.mutate(true);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetAccountAutomated).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateAdultContentPref.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateAdultContentPref.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateAdultContentPref } from '@/hooks/mutations/useUpdateAdultContentPref';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#adultContentPref';
+
+describe('useUpdateAdultContentPref mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('toggles the adult-content slot and puts the merged list back', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const other = { $type: 'app.bsky.actor.defs#interestsPref', tags: ['art'] };
+    mockGetPreferences.mockResolvedValueOnce({
+      preferences: [other, { $type: PREF_TYPE, enabled: false }],
+    });
+    const { result } = renderHook(() => useUpdateAdultContentPref(), { wrapper });
+
+    result.current.mutate(true);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [other, { $type: PREF_TYPE, enabled: true }]);
+    expect(result.current.data).toBe(true);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('inserts the pref when none exists', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateAdultContentPref(), { wrapper });
+
+    result.current.mutate(false);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [{ $type: PREF_TYPE, enabled: false }]);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateAdultContentPref(), { wrapper });
+
+    result.current.mutate(true);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateAdultContentPref(), { wrapper });
+
+    result.current.mutate(true);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateAiPreferences.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateAiPreferences.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  buildAiPreferencesRecord,
+  useUpdateAiPreferences,
+} from '@/hooks/mutations/useUpdateAiPreferences';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockPutAiPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    putAiPreferences: mockPutAiPreferences,
+  })),
+}));
+
+const queryKey = ['aiPreferences', 'did', 'https://pds'];
+
+describe('useUpdateAiPreferences mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockPutAiPreferences.mockResolvedValue(undefined);
+  });
+
+  it('writes the record and stores it in the cache on success', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const record = buildAiPreferencesRecord({ training: true }, null);
+    const { result } = renderHook(() => useUpdateAiPreferences(), { wrapper });
+
+    result.current.mutate(record);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutAiPreferences).toHaveBeenCalledWith('token', 'did', record);
+    expect(queryClient.getQueryData(queryKey)).toEqual(record);
+    expect(result.current.data).toEqual(record);
+  });
+
+  it('rolls back to the previous cache value on error', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const previous = buildAiPreferencesRecord({ embedding: true }, null);
+    queryClient.setQueryData(queryKey, previous);
+    mockPutAiPreferences.mockRejectedValueOnce(new Error('fail'));
+    const next = buildAiPreferencesRecord({ embedding: false }, null);
+    const { result } = renderHook(() => useUpdateAiPreferences(), { wrapper });
+
+    result.current.mutate(next);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(queryClient.getQueryData(queryKey)).toEqual(previous);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateAiPreferences(), { wrapper });
+
+    result.current.mutate(buildAiPreferencesRecord({}, null));
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockPutAiPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateAiPreferences(), { wrapper });
+
+    result.current.mutate(buildAiPreferencesRecord({}, null));
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockPutAiPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when DID missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateAiPreferences(), { wrapper });
+
+    result.current.mutate(buildAiPreferencesRecord({}, null));
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockPutAiPreferences).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildAiPreferencesRecord helper', () => {
+  it('defaults every category to opt-out when no current record', () => {
+    const record = buildAiPreferencesRecord({}, null);
+    expect(record.$type).toBe('community.lexicon.preference.ai');
+    expect(record.preferences.embedding.allow).toBe(false);
+    expect(record.preferences.inference.allow).toBe(false);
+    expect(record.preferences.syntheticContent.allow).toBe(false);
+    expect(record.preferences.training.allow).toBe(false);
+    expect(record.scope).toEqual({ $type: 'community.lexicon.preference.ai#globalScope' });
+  });
+
+  it('layers changes on top of the existing record', () => {
+    const current = buildAiPreferencesRecord({ training: true, embedding: true }, null);
+    const record = buildAiPreferencesRecord({ embedding: false }, current);
+    expect(record.preferences.training.allow).toBe(true);
+    expect(record.preferences.embedding.allow).toBe(false);
+  });
+
+  it('skips change keys whose value is undefined', () => {
+    const current = buildAiPreferencesRecord({ training: true }, null);
+    const record = buildAiPreferencesRecord({ training: undefined }, current);
+    // undefined change is a no-op; the existing flag survives.
+    expect(record.preferences.training.allow).toBe(true);
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateContentLanguages.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateContentLanguages.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateContentLanguages } from '@/hooks/mutations/useUpdateContentLanguages';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#contentLanguagesPref';
+
+describe('useUpdateContentLanguages mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('swaps the content-languages slot and puts the merged list back', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const other = { $type: 'app.bsky.actor.defs#adultContentPref', enabled: true };
+    mockGetPreferences.mockResolvedValueOnce({
+      preferences: [other, { $type: PREF_TYPE, languages: ['en'] }],
+    });
+    const { result } = renderHook(() => useUpdateContentLanguages(), { wrapper });
+
+    result.current.mutate((current) => [...current, 'fr']);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      other,
+      { $type: PREF_TYPE, languages: ['en', 'fr'] },
+    ]);
+    expect(result.current.data).toEqual(['en', 'fr']);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('defaults to an empty list when no existing pref', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateContentLanguages(), { wrapper });
+
+    result.current.mutate(() => ['de']);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [{ $type: PREF_TYPE, languages: ['de'] }]);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateContentLanguages(), { wrapper });
+
+    result.current.mutate(() => ['en']);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateContentLanguages(), { wrapper });
+
+    result.current.mutate(() => ['en']);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('surfaces putPreferences errors', async () => {
+    const { wrapper } = createWrapper();
+    mockPutPreferences.mockRejectedValueOnce(new Error('boom'));
+    const { result } = renderHook(() => useUpdateContentLanguages(), { wrapper });
+
+    result.current.mutate(() => ['en']);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateEmail.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateEmail.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateEmail } from '@/hooks/mutations/useUpdateEmail';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockUpdateEmail = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    updateEmail: mockUpdateEmail,
+  })),
+}));
+
+describe('useUpdateEmail mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockUpdateEmail.mockResolvedValue(undefined);
+  });
+
+  it('updates the email with a confirmation token and invalidates session', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateEmail(), { wrapper });
+
+    result.current.mutate({ email: 'new@b.com', token: 'email-token' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockUpdateEmail).toHaveBeenCalledWith('token', 'new@b.com', 'email-token');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['session'] });
+  });
+
+  it('updates the email without a token', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateEmail(), { wrapper });
+
+    result.current.mutate({ email: 'new@b.com' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockUpdateEmail).toHaveBeenCalledWith('token', 'new@b.com', undefined);
+  });
+
+  it('throws when the token is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useUpdateEmail(), { wrapper });
+
+    result.current.mutate({ email: 'new@b.com' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockUpdateEmail).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PDS URL is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { result } = renderHook(() => useUpdateEmail(), { wrapper });
+
+    result.current.mutate({ email: 'new@b.com' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockUpdateEmail).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateFeedViewPref.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateFeedViewPref.test.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateFeedViewPref } from '@/hooks/mutations/useUpdateFeedViewPref';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#feedViewPref';
+
+describe('useUpdateFeedViewPref mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('merges the patch onto the existing entry for the feed', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const otherFeed = { $type: PREF_TYPE, feed: 'at://feed/x', hideReplies: true };
+    const existing = { $type: PREF_TYPE, feed: 'home', hideReplies: true, hideReposts: false };
+    mockGetPreferences.mockResolvedValueOnce({ preferences: [otherFeed, existing] });
+    const { result } = renderHook(() => useUpdateFeedViewPref(), { wrapper });
+
+    result.current.mutate({ feed: 'home', patch: { hideReposts: true } });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    // other-feed entry preserved; the home entry merged.
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      otherFeed,
+      { $type: PREF_TYPE, feed: 'home', hideReplies: true, hideReposts: true },
+    ]);
+    expect(result.current.data).toEqual({
+      $type: PREF_TYPE,
+      feed: 'home',
+      hideReplies: true,
+      hideReposts: true,
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('inserts a new entry when the feed has none', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateFeedViewPref(), { wrapper });
+
+    result.current.mutate({ feed: 'home', patch: { hideReplies: true } });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      { $type: PREF_TYPE, feed: 'home', hideReplies: true },
+    ]);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateFeedViewPref(), { wrapper });
+
+    result.current.mutate({ feed: 'home', patch: {} });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateFeedViewPref(), { wrapper });
+
+    result.current.mutate({ feed: 'home', patch: {} });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateHandle.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateHandle.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateHandle } from '@/hooks/mutations/useUpdateHandle';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockUpdateHandle = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    updateHandle: mockUpdateHandle,
+  })),
+}));
+
+describe('useUpdateHandle mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did', pdsUrl: 'https://pds' },
+    });
+    mockUpdateHandle.mockResolvedValue(undefined);
+  });
+
+  it('updates the handle, returns it, and invalidates identity caches', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateHandle(), { wrapper });
+
+    result.current.mutate('newhandle.bsky.social');
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockUpdateHandle).toHaveBeenCalledWith('token', 'newhandle.bsky.social');
+    expect(result.current.data).toBe('newhandle.bsky.social');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['session'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['profile'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['currentAccount'] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['accounts'] });
+  });
+
+  it('surfaces the error when the PDS rejects the handle', async () => {
+    const { wrapper } = createWrapper();
+    mockUpdateHandle.mockRejectedValueOnce(new Error('handle unavailable'));
+    const { result } = renderHook(() => useUpdateHandle(), { wrapper });
+
+    result.current.mutate('taken.bsky.social');
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(result.current.error?.message).toBe('handle unavailable');
+  });
+
+  it('throws when the token is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { result } = renderHook(() => useUpdateHandle(), { wrapper });
+
+    result.current.mutate('newhandle.bsky.social');
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockUpdateHandle).not.toHaveBeenCalled();
+  });
+
+  it('throws when the PDS URL is missing', async () => {
+    const { wrapper } = createWrapper();
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { result } = renderHook(() => useUpdateHandle(), { wrapper });
+
+    result.current.mutate('newhandle.bsky.social');
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockUpdateHandle).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateInterests.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateInterests.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateInterests } from '@/hooks/mutations/useUpdateInterests';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#interestsPref';
+
+describe('useUpdateInterests mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('swaps the interests slot and puts the merged list back', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const other = { $type: 'app.bsky.actor.defs#adultContentPref', enabled: false };
+    mockGetPreferences.mockResolvedValueOnce({
+      preferences: [other, { $type: PREF_TYPE, tags: ['art'] }],
+    });
+    const { result } = renderHook(() => useUpdateInterests(), { wrapper });
+
+    result.current.mutate((current) => [...current, 'music']);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      other,
+      { $type: PREF_TYPE, tags: ['art', 'music'] },
+    ]);
+    expect(result.current.data).toEqual(['art', 'music']);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('defaults to an empty list when no existing pref', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateInterests(), { wrapper });
+
+    result.current.mutate(() => ['tech']);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [{ $type: PREF_TYPE, tags: ['tech'] }]);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateInterests(), { wrapper });
+
+    result.current.mutate(() => ['x']);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateInterests(), { wrapper });
+
+    result.current.mutate(() => ['x']);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateLabelersPref.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateLabelersPref.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateLabelersPref } from '@/hooks/mutations/useUpdateLabelersPref';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#labelersPref';
+
+describe('useUpdateLabelersPref mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('swaps the labelers slot and puts the merged list back', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const other = { $type: 'app.bsky.actor.defs#adultContentPref', enabled: false };
+    mockGetPreferences.mockResolvedValueOnce({
+      preferences: [other, { $type: PREF_TYPE, labelers: [{ did: 'did:a' }] }],
+    });
+    const { result } = renderHook(() => useUpdateLabelersPref(), { wrapper });
+
+    result.current.mutate((current) => [...current, { did: 'did:b' }]);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      other,
+      { $type: PREF_TYPE, labelers: [{ did: 'did:a' }, { did: 'did:b' }] },
+    ]);
+    expect(result.current.data).toEqual([{ did: 'did:a' }, { did: 'did:b' }]);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('defaults to an empty list when no existing pref', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateLabelersPref(), { wrapper });
+
+    result.current.mutate(() => [{ did: 'did:c' }]);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      { $type: PREF_TYPE, labelers: [{ did: 'did:c' }] },
+    ]);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateLabelersPref(), { wrapper });
+
+    result.current.mutate(() => []);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateLabelersPref(), { wrapper });
+
+    result.current.mutate(() => []);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateLoggedOutVisibility.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateLoggedOutVisibility.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateLoggedOutVisibility } from '@/hooks/mutations/useUpdateLoggedOutVisibility';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockSetLoggedOutVisibilityDiscouraged = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    setLoggedOutVisibilityDiscouraged: mockSetLoggedOutVisibilityDiscouraged,
+  })),
+}));
+
+describe('useUpdateLoggedOutVisibility mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockSetLoggedOutVisibilityDiscouraged.mockResolvedValue(undefined);
+  });
+
+  it('sets the no-unauthenticated label and invalidates the profile', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdateLoggedOutVisibility(), { wrapper });
+
+    result.current.mutate(true);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockSetLoggedOutVisibilityDiscouraged).toHaveBeenCalledWith('token', 'did', true);
+    expect(result.current.data).toBe(true);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['profile'] });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateLoggedOutVisibility(), { wrapper });
+
+    result.current.mutate(false);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetLoggedOutVisibilityDiscouraged).not.toHaveBeenCalled();
+  });
+
+  it('errors when DID missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateLoggedOutVisibility(), { wrapper });
+
+    result.current.mutate(false);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetLoggedOutVisibilityDiscouraged).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateLoggedOutVisibility(), { wrapper });
+
+    result.current.mutate(false);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockSetLoggedOutVisibilityDiscouraged).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateMutedWords.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateMutedWords.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateMutedWords } from '@/hooks/mutations/useUpdateMutedWords';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#mutedWordsPref';
+
+describe('useUpdateMutedWords mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('swaps the muted-words slot and puts the merged list back', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const other = { $type: 'app.bsky.actor.defs#adultContentPref', enabled: false };
+    const existingWord = { value: 'spoiler', targets: ['content'] };
+    mockGetPreferences.mockResolvedValueOnce({
+      preferences: [other, { $type: PREF_TYPE, items: [existingWord] }],
+    });
+    const newWord = { value: 'politics', targets: ['content'] };
+    const { result } = renderHook(() => useUpdateMutedWords(), { wrapper });
+
+    result.current.mutate((current) => [...current, newWord] as any);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      other,
+      { $type: PREF_TYPE, items: [existingWord, newWord] },
+    ]);
+    expect(result.current.data).toEqual([existingWord, newWord]);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('defaults to an empty list when no existing pref', async () => {
+    const { wrapper } = createWrapper();
+    const word = { value: 'x', targets: ['content'] };
+    const { result } = renderHook(() => useUpdateMutedWords(), { wrapper });
+
+    result.current.mutate(() => [word] as any);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [{ $type: PREF_TYPE, items: [word] }]);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateMutedWords(), { wrapper });
+
+    result.current.mutate(() => []);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateMutedWords(), { wrapper });
+
+    result.current.mutate(() => []);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateNotificationPreferences.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateNotificationPreferences.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateNotificationPreferences } from '@/hooks/mutations/useUpdateNotificationPreferences';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockPutNotificationPreferencesV2 = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    putNotificationPreferencesV2: mockPutNotificationPreferencesV2,
+  })),
+}));
+
+describe('useUpdateNotificationPreferences mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockPutNotificationPreferencesV2.mockResolvedValue({});
+  });
+
+  it('patches notification preferences and invalidates the per-did prefs key', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const patch = { like: { list: true, push: false } } as any;
+    const { result } = renderHook(() => useUpdateNotificationPreferences(), { wrapper });
+
+    result.current.mutate(patch);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutNotificationPreferencesV2).toHaveBeenCalledWith('token', patch);
+    expect(result.current.data).toEqual(patch);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['notifications', 'preferences', 'did', undefined],
+    });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateNotificationPreferences(), { wrapper });
+
+    result.current.mutate({});
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockPutNotificationPreferencesV2).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateNotificationPreferences(), { wrapper });
+
+    result.current.mutate({});
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockPutNotificationPreferencesV2).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdatePersonalDetails.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdatePersonalDetails.test.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdatePersonalDetails } from '@/hooks/mutations/useUpdatePersonalDetails';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#personalDetailsPref';
+
+describe('useUpdatePersonalDetails mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('writes the birthDate and puts the merged list back', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const other = { $type: 'app.bsky.actor.defs#adultContentPref', enabled: false };
+    mockGetPreferences.mockResolvedValueOnce({
+      preferences: [other, { $type: PREF_TYPE, birthDate: '1990-01-01' }],
+    });
+    const { result } = renderHook(() => useUpdatePersonalDetails(), { wrapper });
+
+    result.current.mutate({ birthDate: '2000-12-31' });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      other,
+      { $type: PREF_TYPE, birthDate: '2000-12-31' },
+    ]);
+    expect(result.current.data).toBe('2000-12-31');
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('omits birthDate when not provided', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdatePersonalDetails(), { wrapper });
+
+    result.current.mutate({});
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [{ $type: PREF_TYPE }]);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdatePersonalDetails(), { wrapper });
+
+    result.current.mutate({ birthDate: '2000-01-01' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdatePersonalDetails(), { wrapper });
+
+    result.current.mutate({ birthDate: '2000-01-01' });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdatePostInteractionSettings.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdatePostInteractionSettings.test.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdatePostInteractionSettings } from '@/hooks/mutations/useUpdatePostInteractionSettings';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#postInteractionSettingsPref';
+
+describe('useUpdatePostInteractionSettings mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('encodes anyone-mode with no rules and allowed quotes', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const input = {
+      mode: 'anyone' as const,
+      followers: false,
+      following: false,
+      mentioned: false,
+      allowQuotes: true,
+      allowedLists: [],
+    };
+    const { result } = renderHook(() => useUpdatePostInteractionSettings(), { wrapper });
+
+    result.current.mutate(input);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    // no threadgate rules (undefined) and quotes allowed -> empty pref body.
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [{ $type: PREF_TYPE }]);
+    expect(result.current.data).toEqual(input);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('encodes nobody-mode as an empty allow-rules array', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdatePostInteractionSettings(), { wrapper });
+
+    result.current.mutate({
+      mode: 'nobody',
+      followers: true,
+      following: true,
+      mentioned: true,
+      allowQuotes: true,
+      allowedLists: ['at://list/1'],
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      { $type: PREF_TYPE, threadgateAllowRules: [] },
+    ]);
+  });
+
+  it('encodes follower/following/mention/list rules and disables quotes', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdatePostInteractionSettings(), { wrapper });
+
+    result.current.mutate({
+      mode: 'anyone',
+      followers: true,
+      following: true,
+      mentioned: true,
+      allowQuotes: false,
+      allowedLists: ['at://list/1', 'at://list/2'],
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      {
+        $type: PREF_TYPE,
+        threadgateAllowRules: [
+          { $type: 'app.bsky.feed.threadgate#followerRule' },
+          { $type: 'app.bsky.feed.threadgate#followingRule' },
+          { $type: 'app.bsky.feed.threadgate#mentionRule' },
+          { $type: 'app.bsky.feed.threadgate#listRule', list: 'at://list/1' },
+          { $type: 'app.bsky.feed.threadgate#listRule', list: 'at://list/2' },
+        ],
+        postgateEmbeddingRules: [{ $type: 'app.bsky.feed.postgate#disableRule' }],
+      },
+    ]);
+  });
+
+  it('replaces an existing pref slot, preserving others', async () => {
+    const { wrapper } = createWrapper();
+    const other = { $type: 'app.bsky.actor.defs#adultContentPref', enabled: false };
+    mockGetPreferences.mockResolvedValueOnce({
+      preferences: [other, { $type: PREF_TYPE, threadgateAllowRules: [] }],
+    });
+    const { result } = renderHook(() => useUpdatePostInteractionSettings(), { wrapper });
+
+    result.current.mutate({
+      mode: 'anyone',
+      followers: false,
+      following: false,
+      mentioned: false,
+      allowQuotes: true,
+      allowedLists: [],
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [other, { $type: PREF_TYPE }]);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdatePostInteractionSettings(), { wrapper });
+
+    result.current.mutate({
+      mode: 'anyone',
+      followers: false,
+      following: false,
+      mentioned: false,
+      allowQuotes: true,
+      allowedLists: [],
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdatePostInteractionSettings(), { wrapper });
+
+    result.current.mutate({
+      mode: 'anyone',
+      followers: false,
+      following: false,
+      mentioned: false,
+      allowQuotes: true,
+      allowedLists: [],
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateSavedFeeds.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateSavedFeeds.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateSavedFeeds } from '@/hooks/mutations/useUpdateSavedFeeds';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#savedFeedsPrefV2';
+
+describe('useUpdateSavedFeeds mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('rewrites the saved-feeds slot and puts the merged list back', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const other = { $type: 'app.bsky.actor.defs#adultContentPref', enabled: false };
+    const existingItem = { id: '1', type: 'feed', value: 'at://feed/1', pinned: true };
+    mockGetPreferences.mockResolvedValueOnce({
+      preferences: [other, { $type: PREF_TYPE, items: [existingItem] }],
+    });
+    const newItem = { id: '2', type: 'feed', value: 'at://feed/2', pinned: false };
+    const { result } = renderHook(() => useUpdateSavedFeeds(), { wrapper });
+
+    result.current.mutate((current) => [...current, newItem] as any);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      other,
+      { $type: PREF_TYPE, items: [existingItem, newItem] },
+    ]);
+    expect(result.current.data).toEqual([existingItem, newItem]);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('defaults to an empty list when no existing pref', async () => {
+    const { wrapper } = createWrapper();
+    const item = { id: '1', type: 'feed', value: 'at://feed/1', pinned: true };
+    const { result } = renderHook(() => useUpdateSavedFeeds(), { wrapper });
+
+    result.current.mutate(() => [item] as any);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [{ $type: PREF_TYPE, items: [item] }]);
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateSavedFeeds(), { wrapper });
+
+    result.current.mutate(() => []);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateSavedFeeds(), { wrapper });
+
+    result.current.mutate(() => []);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useUpdateThreadPreferences.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useUpdateThreadPreferences.test.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUpdateThreadPreferences } from '@/hooks/mutations/useUpdateThreadPreferences';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetPreferences = jest.fn();
+const mockPutPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getPreferences: mockGetPreferences,
+    putPreferences: mockPutPreferences,
+  })),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#threadViewPref';
+
+describe('useUpdateThreadPreferences mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did', pdsUrl: 'https://pds' } });
+    mockGetPreferences.mockResolvedValue({ preferences: [] });
+    mockPutPreferences.mockResolvedValue({});
+  });
+
+  it('writes thread view prefs and puts the merged list back', async () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const other = { $type: 'app.bsky.actor.defs#adultContentPref', enabled: false };
+    mockGetPreferences.mockResolvedValueOnce({
+      preferences: [other, { $type: PREF_TYPE, sort: 'oldest', prioritizeFollowedUsers: false }],
+    });
+    const input = { sort: 'hotness' as const, prioritizeFollowedUsers: true };
+    const { result } = renderHook(() => useUpdateThreadPreferences(), { wrapper });
+
+    result.current.mutate(input);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockPutPreferences).toHaveBeenCalledWith('token', [
+      other,
+      { $type: PREF_TYPE, sort: 'hotness', prioritizeFollowedUsers: true },
+    ]);
+    expect(result.current.data).toEqual(input);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['preferences'] });
+  });
+
+  it('errors when token missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateThreadPreferences(), { wrapper });
+
+    result.current.mutate({ sort: 'hotness', prioritizeFollowedUsers: false });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+
+  it('errors when PDS URL missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did' } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateThreadPreferences(), { wrapper });
+
+    result.current.mutate({ sort: 'hotness', prioritizeFollowedUsers: false });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useVotePoll.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useVotePoll.test.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useVotePoll } from '@/hooks/mutations/useVotePoll';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { recordLocalVote, clearLocalVote, type PollVotes } from '@/hooks/queries/usePoll';
+
+const mockCreatePollVote = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/usePoll', () => ({
+  recordLocalVote: jest.fn(),
+  clearLocalVote: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    createPollVote: mockCreatePollVote,
+  })),
+}));
+
+const poll = { uri: 'at://poll', cid: 'cid' };
+
+describe('useVotePoll mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    mockCreatePollVote.mockResolvedValue({ uri: 'at://vote' });
+  });
+
+  it('casts a vote and records it locally', async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useVotePoll(), { wrapper });
+
+    result.current.mutate({ poll, optionIndex: 1 });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockCreatePollVote).toHaveBeenCalledWith('token', 'did:current', {
+      poll,
+      optionIndex: 1,
+    });
+    expect(recordLocalVote).toHaveBeenCalledWith('at://poll', 'did:current', 1);
+  });
+
+  it('optimistically bumps the tally cache for a first-time vote', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const key = ['pollVotes', 'at://poll', 'did:current'];
+    queryClient.setQueryData<PollVotes>(key, {
+      counts: [2, 0],
+      total: 2,
+      sampled: 2,
+      myOptionIndex: null,
+    });
+
+    const { result } = renderHook(() => useVotePoll(), { wrapper });
+    result.current.mutate({ poll, optionIndex: 1 });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const updated = queryClient.getQueryData<PollVotes>(key);
+    expect(updated).toEqual({
+      counts: [2, 1],
+      total: 3,
+      sampled: 3,
+      myOptionIndex: 1,
+    });
+  });
+
+  it('does not re-bump when the viewer already voted', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const key = ['pollVotes', 'at://poll', 'did:current'];
+    queryClient.setQueryData<PollVotes>(key, {
+      counts: [1, 1],
+      total: 2,
+      sampled: 2,
+      myOptionIndex: 0,
+    });
+
+    const { result } = renderHook(() => useVotePoll(), { wrapper });
+    result.current.mutate({ poll, optionIndex: 1 });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(queryClient.getQueryData<PollVotes>(key)).toEqual({
+      counts: [1, 1],
+      total: 2,
+      sampled: 2,
+      myOptionIndex: 0,
+    });
+  });
+
+  it('rolls back the optimistic vote on error', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    const key = ['pollVotes', 'at://poll', 'did:current'];
+    const previous: PollVotes = { counts: [2, 0], total: 2, sampled: 2, myOptionIndex: null };
+    queryClient.setQueryData<PollVotes>(key, previous);
+    mockCreatePollVote.mockRejectedValueOnce(new Error('fail'));
+
+    const { result } = renderHook(() => useVotePoll(), { wrapper });
+    result.current.mutate({ poll, optionIndex: 1 });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(clearLocalVote).toHaveBeenCalledWith('at://poll', 'did:current');
+    expect(queryClient.getQueryData<PollVotes>(key)).toEqual(previous);
+  });
+
+  it('errors when not signed in', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useVotePoll(), { wrapper });
+
+    result.current.mutate({ poll, optionIndex: 0 });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockCreatePollVote).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/mutations/useWipeAllData.test.tsx
+++ b/apps/akari/__tests__/hooks/mutations/useWipeAllData.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useWipeAllData } from '@/hooks/mutations/useWipeAllData';
+import { storage } from '@/utils/secureStorage';
+
+jest.mock('@/utils/secureStorage', () => ({
+  storage: { setItem: jest.fn(), getItem: jest.fn(), removeItem: jest.fn() },
+}));
+
+describe('useWipeAllData mutation hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('removes all storage keys and clears the query cache', async () => {
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(['accounts'], [{ did: '1' }]);
+    queryClient.setQueryData(['currentAccount'], { did: '1' });
+    queryClient.setQueryData(['jwtToken'], 't');
+    queryClient.setQueryData(['refreshToken'], 'r');
+
+    const { result } = renderHook(() => useWipeAllData(), { wrapper });
+    result.current.mutate();
+
+    await waitFor(() => expect(queryClient.getQueryData(['accounts'])).toBeUndefined());
+    expect(queryClient.getQueryData(['currentAccount'])).toBeUndefined();
+    expect(queryClient.getQueryData(['jwtToken'])).toBeUndefined();
+    expect(queryClient.getQueryData(['refreshToken'])).toBeUndefined();
+    expect(storage.removeItem).toHaveBeenCalledWith('accounts');
+    expect(storage.removeItem).toHaveBeenCalledWith('currentAccount');
+    expect(storage.removeItem).toHaveBeenCalledWith('jwtToken');
+    expect(storage.removeItem).toHaveBeenCalledWith('refreshToken');
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useAcceptLabelerDids.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useAcceptLabelerDids.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react-native';
+
+import { useAcceptLabelerDids } from '@/hooks/queries/useAcceptLabelerDids';
+import { usePreferences } from '@/hooks/queries/usePreferences';
+
+jest.mock('@/hooks/queries/usePreferences', () => ({ usePreferences: jest.fn() }));
+
+describe('useAcceptLabelerDids hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an empty array when preferences are unavailable', () => {
+    (usePreferences as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAcceptLabelerDids(), { wrapper });
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('extracts labeler DIDs from the labelersPref preference', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: {
+        preferences: [
+          { $type: 'app.bsky.actor.defs#savedFeedsPrefV2', items: [] },
+          {
+            $type: 'app.bsky.actor.defs#labelersPref',
+            labelers: [{ did: 'did:labeler:1' }, { did: 'did:labeler:2' }, {}],
+          },
+        ],
+      },
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAcceptLabelerDids(), { wrapper });
+
+    expect(result.current).toEqual(['did:labeler:1', 'did:labeler:2']);
+  });
+
+  it('returns a stable reference across renders when preferences are unchanged', () => {
+    const data = {
+      preferences: [
+        { $type: 'app.bsky.actor.defs#labelersPref', labelers: [{ did: 'did:x' }] },
+      ],
+    };
+    (usePreferences as jest.Mock).mockReturnValue({ data });
+    const { wrapper } = createWrapper();
+
+    const { result, rerender } = renderHook(() => useAcceptLabelerDids(), { wrapper });
+    const first = result.current;
+    rerender({});
+    expect(result.current).toBe(first);
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useAiPreferences.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useAiPreferences.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useAiPreferences } from '@/hooks/queries/useAiPreferences';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetAiPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getAiPreferences: mockGetAiPreferences,
+  })),
+}));
+
+describe('useAiPreferences query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+  });
+
+  it('fetches the AI preferences record', async () => {
+    const record = { value: { allowAi: true } };
+    mockGetAiPreferences.mockResolvedValueOnce(record);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAiPreferences(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetAiPreferences).toHaveBeenCalledWith('token', 'did:me');
+    expect(result.current.data).toEqual(record);
+  });
+
+  it('returns null for accounts without a record', async () => {
+    mockGetAiPreferences.mockResolvedValueOnce(null);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAiPreferences(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toBeNull();
+  });
+
+  it('is disabled when token is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAiPreferences(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetAiPreferences).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when did is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAiPreferences(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetAiPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useAkariMembers.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useAkariMembers.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useAkariMembers, useIsAkariMember } from '@/hooks/queries/useAkariMembers';
+import { apiForPublicAppView } from '@/utils/blueskyApi';
+
+const mockGetList = jest.fn();
+
+jest.mock('@/utils/blueskyApi', () => ({
+  apiForPublicAppView: jest.fn(),
+}));
+
+describe('useAkariMembers query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (apiForPublicAppView as jest.Mock).mockReturnValue({ getList: mockGetList });
+  });
+
+  it('walks the cursor, dedupes DIDs, and builds a Set + members array', async () => {
+    mockGetList
+      .mockResolvedValueOnce({
+        items: [
+          { subject: { did: 'did:a', handle: 'a' } },
+          { subject: { did: 'did:b', handle: 'b' } },
+        ],
+        cursor: 'page2',
+      })
+      .mockResolvedValueOnce({
+        items: [
+          { subject: { did: 'did:b', handle: 'b' } }, // duplicate, skipped
+          { subject: { did: 'did:c', handle: 'c' } },
+          { subject: undefined }, // no did, skipped
+        ],
+        cursor: undefined,
+      });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAkariMembers(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetList).toHaveBeenCalledTimes(2);
+    expect(mockGetList).toHaveBeenNthCalledWith(
+      1,
+      '',
+      expect.stringContaining('app.bsky.graph.list'),
+      100,
+      undefined,
+    );
+    expect(mockGetList).toHaveBeenNthCalledWith(
+      2,
+      '',
+      expect.any(String),
+      100,
+      'page2',
+    );
+    expect(result.current.data?.dids).toBeInstanceOf(Set);
+    expect([...(result.current.data?.dids ?? [])]).toEqual(['did:a', 'did:b', 'did:c']);
+    expect(result.current.data?.members).toHaveLength(3);
+  });
+
+  it('handles a missing items array', async () => {
+    mockGetList.mockResolvedValueOnce({ cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAkariMembers(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data?.dids.size).toBe(0);
+    expect(result.current.data?.members).toEqual([]);
+  });
+});
+
+describe('useIsAkariMember', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (apiForPublicAppView as jest.Mock).mockReturnValue({ getList: mockGetList });
+  });
+
+  it('returns false when no did is provided', () => {
+    mockGetList.mockResolvedValue({ items: [], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useIsAkariMember(undefined), { wrapper });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true once the did is in the loaded member set', async () => {
+    mockGetList.mockResolvedValue({
+      items: [{ subject: { did: 'did:member', handle: 'm' } }],
+      cursor: undefined,
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useIsAkariMember('did:member'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current).toBe(true);
+    });
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useAppPasswords.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useAppPasswords.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useAppPasswords } from '@/hooks/queries/useAppPasswords';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockListAppPasswords = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    listAppPasswords: mockListAppPasswords,
+  })),
+}));
+
+describe('useAppPasswords query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+  });
+
+  it('lists app passwords and unwraps the passwords array', async () => {
+    const passwords = [{ name: 'phone', createdAt: '2024-01-01T00:00:00Z' }];
+    mockListAppPasswords.mockResolvedValueOnce({ passwords });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAppPasswords(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockListAppPasswords).toHaveBeenCalledWith('token');
+    expect(result.current.data).toEqual(passwords);
+  });
+
+  it('is disabled when token is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAppPasswords(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockListAppPasswords).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when pdsUrl is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:me' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAppPasswords(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockListAppPasswords).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useAuthorRecipes.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useAuthorRecipes.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useAuthorRecipes } from '@/hooks/queries/useAuthorRecipes';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { usePdsUrl } from '@/hooks/queries/usePdsUrl';
+
+const mockGetActorRecipes = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/usePdsUrl', () => ({
+  usePdsUrl: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getActorRecipes: mockGetActorRecipes,
+  })),
+}));
+
+describe('useAuthorRecipes query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (usePdsUrl as jest.Mock).mockReturnValue({ data: 'https://pds', isLoading: false });
+  });
+
+  it('fetches recipes and flattens pages across fetchNextPage', async () => {
+    mockGetActorRecipes
+      .mockResolvedValueOnce({ records: [{ uri: 'r1' }], cursor: 'next' })
+      .mockResolvedValueOnce({ records: [{ uri: 'r2' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRecipes('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorRecipes).toHaveBeenCalledWith('token', 'alice', 5, undefined);
+    expect(result.current.data).toEqual([{ uri: 'r1' }]);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ uri: 'r1' }, { uri: 'r2' }]);
+    });
+    expect(mockGetActorRecipes).toHaveBeenLastCalledWith('token', 'alice', 5, 'next');
+  });
+
+  it('defaults the limit to 50', async () => {
+    mockGetActorRecipes.mockResolvedValueOnce({ records: [], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRecipes('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorRecipes).toHaveBeenCalledWith('token', 'alice', 50, undefined);
+  });
+
+  it('is disabled when there is no token', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRecipes('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorRecipes).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when there is no identifier', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRecipes(undefined, 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorRecipes).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when the PDS URL is still loading', async () => {
+    (usePdsUrl as jest.Mock).mockReturnValue({ data: 'https://pds', isLoading: true });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRecipes('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorRecipes).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useAuthorRepos.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useAuthorRepos.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useAuthorRepos } from '@/hooks/queries/useAuthorRepos';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetActorRepos = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getActorRepos: mockGetActorRepos,
+  })),
+}));
+
+describe('useAuthorRepos query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+  });
+
+  it('fetches repos and flattens pages across fetchNextPage', async () => {
+    mockGetActorRepos
+      .mockResolvedValueOnce({ records: [{ uri: 'repo1' }], cursor: 'next' })
+      .mockResolvedValueOnce({ records: [{ uri: 'repo2' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRepos('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorRepos).toHaveBeenCalledWith('token', 'alice', 5, undefined);
+    expect(result.current.data).toEqual([{ uri: 'repo1' }]);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ uri: 'repo1' }, { uri: 'repo2' }]);
+    });
+    expect(mockGetActorRepos).toHaveBeenLastCalledWith('token', 'alice', 5, 'next');
+  });
+
+  it('defaults the limit to 50', async () => {
+    mockGetActorRepos.mockResolvedValueOnce({ records: [], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRepos('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorRepos).toHaveBeenCalledWith('token', 'alice', 50, undefined);
+  });
+
+  it('throws when the PDS URL is missing at fetch time', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: {} });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRepos('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect((result.current.error as Error).message).toBe('No PDS URL available');
+    expect(mockGetActorRepos).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when there is no token', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRepos('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorRepos).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when there is no identifier', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorRepos(undefined, 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorRepos).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useAuthorReposts.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useAuthorReposts.test.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useAuthorReposts } from '@/hooks/queries/useAuthorReposts';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useAppViewEnabled } from '@/hooks/useAppViewEnabled';
+import { useAcceptLabelerDids } from '@/hooks/queries/useAcceptLabelerDids';
+
+const mockGetAuthorFeed = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewEnabled', () => ({
+  useAppViewEnabled: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useAcceptLabelerDids', () => ({
+  useAcceptLabelerDids: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getAuthorFeed: mockGetAuthorFeed,
+  })),
+}));
+
+const repostReason = { $type: 'app.bsky.feed.defs#reasonRepost' };
+
+describe('useAuthorReposts query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+    (useAcceptLabelerDids as jest.Mock).mockReturnValue(['did:labeler']);
+  });
+
+  it('keeps only reposts, dedupes by uri, and flattens pages', async () => {
+    mockGetAuthorFeed
+      .mockResolvedValueOnce({
+        feed: [
+          { post: { uri: 'a' }, reason: repostReason },
+          { post: { uri: 'b' } }, // not a repost, dropped
+          { post: { uri: 'a' }, reason: repostReason }, // duplicate, deduped
+        ],
+        cursor: 'next',
+      })
+      .mockResolvedValueOnce({
+        feed: [{ post: { uri: 'c' }, reason: repostReason }],
+        cursor: undefined,
+      });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorReposts('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetAuthorFeed).toHaveBeenCalledWith(
+      'token',
+      'alice',
+      5,
+      undefined,
+      undefined,
+      ['did:labeler'],
+    );
+    expect(result.current.data).toEqual([{ uri: 'a' }]);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ uri: 'a' }, { uri: 'c' }]);
+    });
+    expect(mockGetAuthorFeed).toHaveBeenLastCalledWith(
+      'token',
+      'alice',
+      5,
+      'next',
+      undefined,
+      ['did:labeler'],
+    );
+  });
+
+  it('uses the guest path with an empty token when no token is present', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    mockGetAuthorFeed.mockResolvedValueOnce({
+      feed: [{ post: { uri: 'a' }, reason: repostReason }],
+      cursor: undefined,
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorReposts('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetAuthorFeed).toHaveBeenCalledWith(
+      '',
+      'alice',
+      5,
+      undefined,
+      undefined,
+      ['did:labeler'],
+    );
+    expect(result.current.data).toEqual([{ uri: 'a' }]);
+  });
+
+  it('uses the guest path when the account has no PDS URL', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: {} });
+    mockGetAuthorFeed.mockResolvedValueOnce({
+      feed: [{ post: { uri: 'a' }, reason: repostReason }],
+      cursor: undefined,
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorReposts('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetAuthorFeed).toHaveBeenCalledWith(
+      '',
+      'alice',
+      5,
+      undefined,
+      undefined,
+      ['did:labeler'],
+    );
+  });
+
+  it('throws when no identifier is provided', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useAuthorReposts(undefined, 5), { wrapper });
+
+    const fetchResult = await result.current.fetchNextPage();
+    expect((fetchResult.error as Error).message).toBe('No identifier provided');
+    expect(mockGetAuthorFeed).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useBlocks.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useBlocks.test.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useBlocks } from '@/hooks/queries/useBlocks';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useAppViewEnabled } from '@/hooks/useAppViewEnabled';
+import { getAuthor, pdsListRecords } from '@/hooks/queries/microcosm';
+
+const mockGetBlocks = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewEnabled', () => ({
+  useAppViewEnabled: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+}));
+
+jest.mock('@/hooks/queries/microcosm', () => ({
+  getAuthor: jest.fn(),
+  pdsListRecords: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getBlocks: mockGetBlocks,
+  })),
+}));
+
+describe('useBlocks query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+    (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+  });
+
+  it('fetches blocks through the AppView when enabled', async () => {
+    const response = { blocks: [{ did: 'did:blocked' }], cursor: undefined };
+    mockGetBlocks.mockResolvedValueOnce(response);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBlocks(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetBlocks).toHaveBeenCalledWith('token', 50, undefined);
+    expect(result.current.data?.pages[0]).toEqual(response);
+  });
+
+  it('hydrates blocks from the PDS when the AppView is disabled (microcosm path)', async () => {
+    (useAppViewEnabled as jest.Mock).mockReturnValue(false);
+    (pdsListRecords as jest.Mock).mockResolvedValueOnce({
+      records: [
+        {
+          uri: 'at://did:me/app.bsky.graph.block/1',
+          value: { subject: 'did:blocked', createdAt: '2024-01-01T00:00:00Z' },
+        },
+      ],
+      cursor: 'next',
+    });
+    (getAuthor as jest.Mock).mockResolvedValueOnce({
+      did: 'did:blocked',
+      handle: 'blocked.test',
+      displayName: 'Blocked',
+      avatar: 'a.jpg',
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBlocks(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(pdsListRecords).toHaveBeenCalledWith({
+      pdsUrl: 'https://pds',
+      repo: 'did:me',
+      collection: 'app.bsky.graph.block',
+      limit: 50,
+      cursor: undefined,
+    });
+    expect(mockGetBlocks).not.toHaveBeenCalled();
+    expect(result.current.data?.pages[0]).toEqual({
+      blocks: [
+        {
+          did: 'did:blocked',
+          handle: 'blocked.test',
+          displayName: 'Blocked',
+          avatar: 'a.jpg',
+          indexedAt: '2024-01-01T00:00:00Z',
+          viewer: { blocking: 'at://did:me/app.bsky.graph.block/1' },
+          labels: [],
+        },
+      ],
+      cursor: 'next',
+    });
+  });
+
+  it('is disabled when token is missing and AppView enabled', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBlocks(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetBlocks).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when did is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBlocks(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useBookmarks.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useBookmarks.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useBookmarks } from '@/hooks/queries/useBookmarks';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useAcceptLabelerDids } from '@/hooks/queries/useAcceptLabelerDids';
+import { useAppViewEnabled } from '@/hooks/useAppViewEnabled';
+import { readAppViewEnabled } from '@/hooks/useAppViewSettings';
+
+const mockGetBookmarks = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useAcceptLabelerDids', () => ({
+  useAcceptLabelerDids: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewEnabled', () => ({
+  useAppViewEnabled: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewEnabled: jest.fn(),
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getBookmarks: mockGetBookmarks,
+  })),
+}));
+
+describe('useBookmarks query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+    (useAcceptLabelerDids as jest.Mock).mockReturnValue(['did:labeler']);
+    (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+    (readAppViewEnabled as jest.Mock).mockReturnValue(true);
+  });
+
+  it('fetches bookmarks and paginates by cursor', async () => {
+    mockGetBookmarks
+      .mockResolvedValueOnce({ bookmarks: [{ uri: 'a' }], cursor: 'next' })
+      .mockResolvedValueOnce({ bookmarks: [{ uri: 'b' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBookmarks(10), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetBookmarks).toHaveBeenCalledWith('token', 10, undefined, ['did:labeler']);
+    expect(result.current.data?.pages[0]).toEqual({ bookmarks: [{ uri: 'a' }], cursor: 'next' });
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.pages).toHaveLength(2);
+    });
+    expect(mockGetBookmarks).toHaveBeenLastCalledWith('token', 10, 'next', ['did:labeler']);
+  });
+
+  it('uses the default limit of 50 when omitted', async () => {
+    mockGetBookmarks.mockResolvedValueOnce({ bookmarks: [], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBookmarks(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetBookmarks).toHaveBeenCalledWith('token', 50, undefined, ['did:labeler']);
+  });
+
+  it('throws AppViewRequiredError when the AppView is disabled', async () => {
+    (readAppViewEnabled as jest.Mock).mockReturnValue(false);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBookmarks(10), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect((result.current.error as Error).message).toContain('bookmarks');
+    expect(mockGetBookmarks).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when token is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBookmarks(10), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetBookmarks).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when did is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useBookmarks(10), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetBookmarks).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useCommunityNote.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useCommunityNote.test.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useCommunityNote } from '@/hooks/queries/useCommunityNote';
+
+describe('useCommunityNote query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  it('resolves to null (stub implementation) when given a postUri', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useCommunityNote('at://post/1'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toBeNull();
+  });
+
+  it('is disabled when postUri is undefined', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useCommunityNote(undefined), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(result.current.isPending).toBe(true);
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useCommunityNotesContributor.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useCommunityNotesContributor.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  useMyContributorProfile,
+  useNotesPendingRating,
+  usePendingPostsNeedingNotes,
+} from '@/hooks/queries/useCommunityNotesContributor';
+
+describe('useCommunityNotesContributor query hooks', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  it('usePendingPostsNeedingNotes resolves to an empty array', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePendingPostsNeedingNotes(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('useNotesPendingRating resolves to an empty array', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useNotesPendingRating(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('useMyContributorProfile resolves to a zeroed summary', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useMyContributorProfile(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toMatchObject({
+      notesWritten: 0,
+      helpfulRate: 0,
+      ratingsGiven: 0,
+      recentNotes: [],
+    });
+    expect(typeof result.current.data?.joinedAt).toBe('string');
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useContentLanguages.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useContentLanguages.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { useContentLanguages } from '@/hooks/queries/useContentLanguages';
+import { usePreferences } from '@/hooks/queries/usePreferences';
+
+jest.mock('@/hooks/queries/usePreferences', () => ({
+  usePreferences: jest.fn(),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#contentLanguagesPref';
+
+describe('useContentLanguages query hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an empty list when there is no data', () => {
+    (usePreferences as jest.Mock).mockReturnValue({ data: undefined, isLoading: true });
+
+    const { result } = renderHook(() => useContentLanguages());
+
+    expect(result.current.data).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns an empty list when the pref is absent', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: 'other' }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useContentLanguages());
+
+    expect(result.current.data).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('returns the languages from the pref', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: PREF_TYPE, languages: ['en', 'ja'] }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useContentLanguages());
+
+    expect(result.current.data).toEqual(['en', 'ja']);
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useConvo.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useConvo.test.tsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useConvo } from '@/hooks/queries/useConvo';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useAppViewEnabled } from '@/hooks/useAppViewEnabled';
+import { readAppViewEnabled } from '@/hooks/useAppViewSettings';
+
+const mockGetConvo = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewEnabled', () => ({
+  useAppViewEnabled: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewEnabled: jest.fn(),
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getConvo: mockGetConvo,
+  })),
+}));
+
+describe('useConvo query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+    (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+    (readAppViewEnabled as jest.Mock).mockReturnValue(true);
+  });
+
+  it('fetches and transforms a one-on-one conversation', async () => {
+    mockGetConvo.mockResolvedValueOnce({
+      convo: {
+        id: 'convo-1',
+        members: [
+          { did: 'did:me', handle: 'me' },
+          { did: 'did:other', handle: 'alice', displayName: 'Alice', avatar: 'a.jpg', verification: 'v' },
+        ],
+        lastMessage: { text: 'hi', sentAt: '2023-01-01T00:00:00Z' },
+        unreadCount: 2,
+        status: 'accepted',
+        muted: false,
+      },
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useConvo('convo-1'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetConvo).toHaveBeenCalledWith('token', 'convo-1');
+    expect(result.current.data).toEqual({
+      id: 'convo-1',
+      convoId: 'convo-1',
+      handle: 'alice',
+      displayName: 'Alice',
+      avatar: 'a.jpg',
+      verification: 'v',
+      members: [
+        { did: 'did:other', handle: 'alice', displayName: 'Alice', avatar: 'a.jpg', verification: 'v' },
+      ],
+      isGroup: false,
+      lastMessage: 'hi',
+      timestamp: new Date('2023-01-01T00:00:00Z').toLocaleDateString(),
+      unreadCount: 2,
+      status: 'accepted',
+      muted: false,
+    });
+  });
+
+  it('flags group conversations and falls back to handle/no-message defaults', async () => {
+    mockGetConvo.mockResolvedValueOnce({
+      convo: {
+        id: 'convo-2',
+        members: [
+          { did: 'did:me', handle: 'me' },
+          { did: 'did:a', handle: 'alice' },
+          { did: 'did:b', handle: 'bob' },
+        ],
+        unreadCount: 0,
+        status: 'request',
+        muted: true,
+      },
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useConvo('convo-2'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data?.isGroup).toBe(true);
+    expect(result.current.data?.displayName).toBe('alice');
+    expect(result.current.data?.lastMessage).toBe('No messages yet');
+    expect(result.current.data?.timestamp).toBe('No messages');
+  });
+
+  it('errors when no other member is found', async () => {
+    mockGetConvo.mockResolvedValue({
+      convo: {
+        id: 'convo-3',
+        members: [{ did: 'did:me', handle: 'me' }],
+        unreadCount: 0,
+        status: 'accepted',
+        muted: false,
+      },
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useConvo('convo-3'), { wrapper });
+
+    await waitFor(
+      () => {
+        expect(result.current.isError).toBe(true);
+      },
+      { timeout: 5000 },
+    );
+    expect((result.current.error as Error).message).toBe('No other member found in conversation');
+  });
+
+  it('throws AppViewRequiredError when the AppView is disabled', async () => {
+    (readAppViewEnabled as jest.Mock).mockReturnValue(false);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useConvo('convo-1'), { wrapper });
+
+    await waitFor(
+      () => {
+        expect(result.current.isError).toBe(true);
+      },
+      { timeout: 5000 },
+    );
+    expect((result.current.error as Error).message).toContain('conversations');
+    expect(mockGetConvo).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when convoId is missing', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useConvo(undefined), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetConvo).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when token is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useConvo('convo-1'), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetConvo).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useDrafts.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useDrafts.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useDrafts } from '@/hooks/queries/useDrafts';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { apiForPdsUrl } from '@/utils/blueskyApi';
+import { draftViewToComposerState } from '@/utils/draftMapper';
+
+const mockGetDrafts = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForPdsUrl: jest.fn() }));
+jest.mock('@/utils/draftMapper', () => ({ draftViewToComposerState: jest.fn() }));
+
+describe('useDrafts query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did:me', pdsUrl: 'https://pds' },
+    });
+    (apiForPdsUrl as jest.Mock).mockReturnValue({ getDrafts: mockGetDrafts });
+    (draftViewToComposerState as jest.Mock).mockImplementation((v) => v);
+  });
+
+  it('fetches drafts and sorts them newest-first by updatedAt', async () => {
+    mockGetDrafts.mockResolvedValue({
+      drafts: [
+        { id: '1', updatedAt: '2024-01-01T00:00:00Z' },
+        { id: '2', updatedAt: '2024-03-01T00:00:00Z' },
+        { id: '3', updatedAt: '2024-02-01T00:00:00Z' },
+      ],
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useDrafts(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(apiForPdsUrl).toHaveBeenCalledWith('https://pds');
+    expect(mockGetDrafts).toHaveBeenCalledWith('token', { limit: 100 });
+    expect(result.current.data?.map((d) => d.id)).toEqual(['2', '3', '1']);
+  });
+
+  it('is disabled when token is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useDrafts(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetDrafts).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when the enabled flag is false', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useDrafts(false), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetDrafts).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when pdsUrl or did is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:me' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useDrafts(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetDrafts).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useGrainGalleries.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useGrainGalleries.test.tsx
@@ -1,0 +1,244 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import {
+  useGrainGalleries,
+  useGrainGalleryItems,
+  useGrainPhotos,
+  useGrainPhotoExif,
+  indexGrainPhotosByUri,
+  indexGrainExifByPhotoUri,
+  groupGalleryItems,
+} from '@/hooks/queries/useGrainGalleries';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { usePdsUrl } from '@/hooks/queries/usePdsUrl';
+
+const mockGetActorGalleries = jest.fn();
+const mockGetActorGrainGalleryItems = jest.fn();
+const mockGetActorGrainPhotos = jest.fn();
+const mockGetActorGrainPhotoExif = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/usePdsUrl', () => ({
+  usePdsUrl: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getActorGalleries: mockGetActorGalleries,
+    getActorGrainGalleryItems: mockGetActorGrainGalleryItems,
+    getActorGrainPhotos: mockGetActorGrainPhotos,
+    getActorGrainPhotoExif: mockGetActorGrainPhotoExif,
+  })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+  (usePdsUrl as jest.Mock).mockReturnValue({ data: 'https://pds', isLoading: false });
+});
+
+describe('useGrainGalleries query hook', () => {
+
+  it('fetches galleries and flattens pages across fetchNextPage', async () => {
+    mockGetActorGalleries
+      .mockResolvedValueOnce({ records: [{ uri: 'a' }], cursor: 'next' })
+      .mockResolvedValueOnce({ records: [{ uri: 'b' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainGalleries('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorGalleries).toHaveBeenCalledWith('token', 'alice', 5, undefined);
+    expect(result.current.data).toEqual([{ uri: 'a' }]);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ uri: 'a' }, { uri: 'b' }]);
+    });
+    expect(mockGetActorGalleries).toHaveBeenLastCalledWith('token', 'alice', 5, 'next');
+  });
+
+  it('uses the default limit of 30 when none is provided', async () => {
+    mockGetActorGalleries.mockResolvedValueOnce({ records: [], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainGalleries('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorGalleries).toHaveBeenCalledWith('token', 'alice', 30, undefined);
+  });
+
+  it('is disabled when there is no token', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainGalleries('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorGalleries).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when there is no identifier', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainGalleries(undefined, 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorGalleries).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when the PDS URL is missing', async () => {
+    (usePdsUrl as jest.Mock).mockReturnValue({ data: undefined, isLoading: false });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainGalleries('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorGalleries).not.toHaveBeenCalled();
+  });
+
+  it('is disabled while the PDS URL is still loading', async () => {
+    (usePdsUrl as jest.Mock).mockReturnValue({ data: 'https://pds', isLoading: true });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainGalleries('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorGalleries).not.toHaveBeenCalled();
+  });
+});
+
+describe('useGrainGalleryItems query hook', () => {
+  it('paginates and accumulates items until the cursor runs out', async () => {
+    mockGetActorGrainGalleryItems
+      .mockResolvedValueOnce({ records: [{ uri: 'i1' }], cursor: 'c1' })
+      .mockResolvedValueOnce({ records: [{ uri: 'i2' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainGalleryItems('alice', 50), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorGrainGalleryItems).toHaveBeenNthCalledWith(1, 'token', 'alice', 50, undefined);
+    expect(mockGetActorGrainGalleryItems).toHaveBeenNthCalledWith(2, 'token', 'alice', 50, 'c1');
+    expect(result.current.data).toEqual([{ uri: 'i1' }, { uri: 'i2' }]);
+  });
+
+  it('is disabled without a token', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainGalleryItems('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorGrainGalleryItems).not.toHaveBeenCalled();
+  });
+});
+
+describe('useGrainPhotos query hook', () => {
+  it('paginates and accumulates photos until the cursor runs out', async () => {
+    mockGetActorGrainPhotos
+      .mockResolvedValueOnce({ records: [{ uri: 'p1' }], cursor: 'c1' })
+      .mockResolvedValueOnce({ records: [{ uri: 'p2' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainPhotos('alice', 50), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual([{ uri: 'p1' }, { uri: 'p2' }]);
+  });
+
+  it('is disabled when the identifier is missing', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainPhotos(undefined), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorGrainPhotos).not.toHaveBeenCalled();
+  });
+});
+
+describe('useGrainPhotoExif query hook', () => {
+  it('fetches a single page of exif records', async () => {
+    mockGetActorGrainPhotoExif.mockResolvedValueOnce({ records: [{ uri: 'x1' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useGrainPhotoExif('alice', 50), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorGrainPhotoExif).toHaveBeenCalledWith('token', 'alice', 50, undefined);
+    expect(result.current.data).toEqual([{ uri: 'x1' }]);
+  });
+});
+
+describe('grain helper functions', () => {
+  it('indexGrainPhotosByUri maps photos by uri and tolerates undefined', () => {
+    expect(indexGrainPhotosByUri(undefined).size).toBe(0);
+    const map = indexGrainPhotosByUri([
+      { uri: 'a' },
+      { uri: 'b' },
+    ] as never);
+    expect(map.get('a')).toEqual({ uri: 'a' });
+    expect(map.size).toBe(2);
+  });
+
+  it('indexGrainExifByPhotoUri keys by the described photo uri, skipping records without one', () => {
+    expect(indexGrainExifByPhotoUri(undefined).size).toBe(0);
+    const map = indexGrainExifByPhotoUri([
+      { uri: 'exif1', value: { photo: 'photoA' } },
+      { uri: 'exif2', value: {} },
+    ] as never);
+    expect(map.get('photoA')).toEqual({ uri: 'exif1', value: { photo: 'photoA' } });
+    expect(map.size).toBe(1);
+  });
+
+  it('groupGalleryItems buckets by gallery uri and sorts each bucket by position', () => {
+    expect(groupGalleryItems(undefined).size).toBe(0);
+    const map = groupGalleryItems([
+      { uri: 'i1', value: { gallery: 'g1', position: 2 } },
+      { uri: 'i2', value: { gallery: 'g1', position: 1 } },
+      { uri: 'i3', value: { gallery: 'g2' } },
+    ] as never);
+    expect(map.get('g1')?.map((item) => item.uri)).toEqual(['i2', 'i1']);
+    expect(map.get('g2')?.map((item) => item.uri)).toEqual(['i3']);
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useInterests.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useInterests.test.tsx
@@ -1,0 +1,47 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { useInterests } from '@/hooks/queries/useInterests';
+import { usePreferences } from '@/hooks/queries/usePreferences';
+
+jest.mock('@/hooks/queries/usePreferences', () => ({
+  usePreferences: jest.fn(),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#interestsPref';
+
+describe('useInterests query hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an empty list when there is no data', () => {
+    (usePreferences as jest.Mock).mockReturnValue({ data: undefined, isLoading: true });
+
+    const { result } = renderHook(() => useInterests());
+
+    expect(result.current.data).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns an empty list when the pref is absent', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: 'other' }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useInterests());
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('returns the tags from the pref', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: PREF_TYPE, tags: ['art', 'tech'] }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useInterests());
+
+    expect(result.current.data).toEqual(['art', 'tech']);
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useIsGuest.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useIsGuest.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react-native';
+
+import { useIsGuest } from '@/hooks/queries/useIsGuest';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+
+describe('useIsGuest hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns false when both account and token are present', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:me' } });
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useIsGuest(), { wrapper });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when the account is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: undefined });
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useIsGuest(), { wrapper });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns true when the token is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:me' } });
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useIsGuest(), { wrapper });
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useKeytraceClaims.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useKeytraceClaims.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useKeytraceClaims } from '@/hooks/queries/useKeytraceClaims';
+import { getClaimsForHandle } from '@keytrace/claims';
+
+jest.mock('@keytrace/claims', () => ({
+  getClaimsForHandle: jest.fn(),
+}));
+
+describe('useKeytraceClaims query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('fetches claims for a handle and selects the claims field', async () => {
+    const claims = [{ type: 'github', value: 'alice' }];
+    (getClaimsForHandle as jest.Mock).mockResolvedValue({ claims, other: 'x' });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useKeytraceClaims('alice.bsky.social'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(getClaimsForHandle).toHaveBeenCalledWith('alice.bsky.social');
+    expect(result.current.data).toEqual(claims);
+  });
+
+  it('is disabled when no handle is provided', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useKeytraceClaims(undefined), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getClaimsForHandle).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useLabelers.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useLabelers.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useLabelers, BSKY_DEFAULT_LABELER_DID } from '@/hooks/queries/useLabelers';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { usePreferences } from '@/hooks/queries/usePreferences';
+import { useAppViewEnabled } from '@/hooks/useAppViewEnabled';
+import { getAuthor } from '@/hooks/queries/microcosm';
+
+const mockGetLabelerServices = jest.fn();
+const mockGetRecord = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/usePreferences', () => ({
+  usePreferences: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewEnabled', () => ({
+  useAppViewEnabled: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+}));
+
+jest.mock('@/hooks/queries/microcosm', () => ({
+  getAuthor: jest.fn(),
+}));
+
+jest.mock('@/slingshot-api', () => ({
+  SlingshotApi: jest.fn(() => ({
+    getRecord: (...args: unknown[]) => mockGetRecord(...args),
+  })),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({ getLabelerServices: mockGetLabelerServices })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+  (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+  (usePreferences as jest.Mock).mockReturnValue({ data: { preferences: [] } });
+  (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+});
+
+describe('useLabelers query hook', () => {
+  it('fetches labeler services through the AppView, including subscribed and default DIDs', async () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: {
+        preferences: [
+          {
+            $type: 'app.bsky.actor.defs#labelersPref',
+            labelers: [{ did: 'did:custom' }],
+          },
+        ],
+      },
+    });
+    mockGetLabelerServices.mockResolvedValueOnce({ views: [{ uri: 'labeler-view' }] });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLabelers(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetLabelerServices).toHaveBeenCalledWith('token', [
+      BSKY_DEFAULT_LABELER_DID,
+      'did:custom',
+    ]);
+    expect(result.current.data).toEqual([{ uri: 'labeler-view' }]);
+  });
+
+  it('hydrates labeler views from slingshot when the AppView is disabled (microcosm path)', async () => {
+    (useAppViewEnabled as jest.Mock).mockReturnValue(false);
+    mockGetRecord.mockResolvedValueOnce({
+      uri: 'at://did:plc:ar7c4by46qjdydhdevvrndac/app.bsky.labeler.service/self',
+      cid: 'cid1',
+      value: { createdAt: '2024-01-01T00:00:00Z', reasonTypes: ['spam'] },
+    });
+    (getAuthor as jest.Mock).mockResolvedValueOnce({
+      did: BSKY_DEFAULT_LABELER_DID,
+      handle: 'mod.bsky.app',
+      displayName: 'Mod',
+      avatar: 'a.jpg',
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLabelers(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetRecord).toHaveBeenCalled();
+    expect(mockGetLabelerServices).not.toHaveBeenCalled();
+    expect(result.current.data).toEqual([
+      {
+        uri: 'at://did:plc:ar7c4by46qjdydhdevvrndac/app.bsky.labeler.service/self',
+        cid: 'cid1',
+        creator: {
+          did: BSKY_DEFAULT_LABELER_DID,
+          handle: 'mod.bsky.app',
+          displayName: 'Mod',
+          avatar: 'a.jpg',
+        },
+        indexedAt: '2024-01-01T00:00:00Z',
+        policies: undefined,
+        reasonTypes: ['spam'],
+        subjectTypes: undefined,
+      },
+    ]);
+  });
+
+  it('drops a labeler that has no service record (microcosm path)', async () => {
+    (useAppViewEnabled as jest.Mock).mockReturnValue(false);
+    mockGetRecord.mockRejectedValueOnce(new Error('not found'));
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLabelers(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('is disabled when AppView is enabled but token is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLabelers(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetLabelerServices).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useLinks.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useLinks.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useLinks } from '@/hooks/queries/useLinks';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useProfile } from '@/hooks/queries/useProfile';
+import { getPdsUrlFromDid } from '@/bluesky-api';
+
+const mockGetActorLinkatBoards = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useProfile', () => ({
+  useProfile: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  getPdsUrlFromDid: jest.fn(),
+  BlueskyApi: jest.fn(() => ({ getActorLinkatBoards: mockGetActorLinkatBoards })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+  (useProfile as jest.Mock).mockReturnValue({ data: { did: 'did:target' } });
+  (getPdsUrlFromDid as jest.Mock).mockResolvedValue('https://target.pds');
+});
+
+describe('useLinks query hook', () => {
+  it('resolves the target PDS and flattens link records across pages', async () => {
+    mockGetActorLinkatBoards
+      .mockResolvedValueOnce({ records: [{ uri: 'l1' }], cursor: 'next' })
+      .mockResolvedValueOnce({ records: [{ uri: 'l2' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLinks('alice', 10), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(getPdsUrlFromDid).toHaveBeenCalledWith('did:target');
+    expect(mockGetActorLinkatBoards).toHaveBeenCalledWith('token', 'did:target', 10, undefined);
+    expect(result.current.data).toEqual([{ uri: 'l1' }]);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ uri: 'l1' }, { uri: 'l2' }]);
+    });
+    expect(mockGetActorLinkatBoards).toHaveBeenLastCalledWith('token', 'did:target', 10, 'next');
+  });
+
+  it('is disabled when no identifier is provided', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLinks(undefined), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetActorLinkatBoards).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when the profile DID is not yet resolved', () => {
+    (useProfile as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLinks('alice'), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('errors when the PDS URL cannot be resolved', async () => {
+    (getPdsUrlFromDid as jest.Mock).mockResolvedValueOnce(null);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLinks('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetActorLinkatBoards).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useLists.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useLists.test.tsx
@@ -1,0 +1,289 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useLists, useListMembership } from '@/hooks/queries/useLists';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useAppViewEnabled } from '@/hooks/useAppViewEnabled';
+import {
+  getActorListsPage,
+  resolveIdentifierToDid,
+  resolvePdsUrl,
+} from '@/hooks/queries/microcosm';
+
+const mockGetLists = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewEnabled', () => ({
+  useAppViewEnabled: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+}));
+
+jest.mock('@/hooks/queries/microcosm', () => ({
+  getActorListsPage: jest.fn(),
+  resolveIdentifierToDid: jest.fn(),
+  resolvePdsUrl: jest.fn(),
+}));
+
+const mockGetList = jest.fn();
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getLists: mockGetLists,
+    getList: mockGetList,
+  })),
+}));
+
+describe('useLists query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+    (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+  });
+
+  it('fetches lists through the AppView for an explicit actor', async () => {
+    const response = { lists: [{ uri: 'at://list/1' }], cursor: undefined };
+    mockGetLists.mockResolvedValueOnce(response);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLists('did:actor'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetLists).toHaveBeenCalledWith('token', 'did:actor', 50, undefined);
+    expect(result.current.data?.pages[0]).toEqual(response);
+  });
+
+  it('defaults to the current user did when no actor is given', async () => {
+    mockGetLists.mockResolvedValueOnce({ lists: [], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLists(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetLists).toHaveBeenCalledWith('token', 'did:me', 50, undefined);
+  });
+
+  it('uses the known PDS for the current user on the microcosm path', async () => {
+    (useAppViewEnabled as jest.Mock).mockReturnValue(false);
+    (resolveIdentifierToDid as jest.Mock).mockResolvedValueOnce('did:me');
+    const response = { lists: [{ uri: 'at://list/1' }], cursor: undefined };
+    (getActorListsPage as jest.Mock).mockResolvedValueOnce(response);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLists('did:me'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(resolvePdsUrl).not.toHaveBeenCalled();
+    expect(getActorListsPage).toHaveBeenCalledWith({
+      did: 'did:me',
+      pdsUrl: 'https://pds',
+      limit: 50,
+      cursor: undefined,
+    });
+    expect(mockGetLists).not.toHaveBeenCalled();
+    expect(result.current.data?.pages[0]).toEqual(response);
+  });
+
+  it('resolves the PDS via DID document for other actors on the microcosm path', async () => {
+    (useAppViewEnabled as jest.Mock).mockReturnValue(false);
+    (resolveIdentifierToDid as jest.Mock).mockResolvedValueOnce('did:other');
+    (resolvePdsUrl as jest.Mock).mockResolvedValueOnce('https://other-pds');
+    (getActorListsPage as jest.Mock).mockResolvedValueOnce({ lists: [], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLists('did:other'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(resolvePdsUrl).toHaveBeenCalledWith('did:other');
+    expect(getActorListsPage).toHaveBeenCalledWith({
+      did: 'did:other',
+      pdsUrl: 'https://other-pds',
+      limit: 50,
+      cursor: undefined,
+    });
+  });
+
+  it('errors when the PDS cannot be resolved on the microcosm path', async () => {
+    (useAppViewEnabled as jest.Mock).mockReturnValue(false);
+    (resolveIdentifierToDid as jest.Mock).mockResolvedValueOnce('did:other');
+    (resolvePdsUrl as jest.Mock).mockResolvedValueOnce(undefined);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLists('did:other'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect((result.current.error as Error).message).toContain("Couldn't resolve PDS URL");
+  });
+
+  it('is disabled when there is no target', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLists(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetLists).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when token is missing and AppView enabled', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLists('did:actor'), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetLists).not.toHaveBeenCalled();
+  });
+});
+
+describe('useListMembership', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+    (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+  });
+
+  it('reports membership and the listitem uri when the subject is found', async () => {
+    mockGetList.mockResolvedValueOnce({
+      items: [
+        { uri: 'at://listitem/1', subject: { did: 'did:subject' } },
+        { uri: 'at://listitem/2', subject: { did: 'did:other' } },
+      ],
+      cursor: undefined,
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useListMembership('at://list/1', 'did:subject'),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isMember).toBe(true);
+    });
+    expect(mockGetList).toHaveBeenCalledWith('token', 'at://list/1', 50, undefined);
+    expect(result.current.listItemUri).toBe('at://listitem/1');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('walks pages until the subject is found', async () => {
+    mockGetList
+      .mockResolvedValueOnce({
+        items: [{ uri: 'at://listitem/1', subject: { did: 'did:other' } }],
+        cursor: 'next',
+      })
+      .mockResolvedValueOnce({
+        items: [{ uri: 'at://listitem/2', subject: { did: 'did:subject' } }],
+        cursor: undefined,
+      });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useListMembership('at://list/1', 'did:subject'),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isMember).toBe(true);
+    });
+    expect(result.current.listItemUri).toBe('at://listitem/2');
+    expect(mockGetList).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports no membership when the subject is absent and pages are exhausted', async () => {
+    mockGetList.mockResolvedValueOnce({
+      items: [{ uri: 'at://listitem/1', subject: { did: 'did:other' } }],
+      cursor: undefined,
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useListMembership('at://list/1', 'did:subject'),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.isMember).toBe(false);
+    expect(result.current.listItemUri).toBeUndefined();
+  });
+
+  it('is not a member when no subject is provided', async () => {
+    mockGetList.mockResolvedValueOnce({
+      items: [{ uri: 'at://listitem/1', subject: { did: 'did:other' } }],
+      cursor: undefined,
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useListMembership('at://list/1', undefined),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.isMember).toBe(false);
+    expect(result.current.listItemUri).toBeUndefined();
+  });
+
+  it('is disabled when no list uri is provided', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useListMembership(undefined, 'did:subject'),
+      { wrapper },
+    );
+
+    expect(result.current.isMember).toBe(false);
+    expect(mockGetList).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useLiveNow.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useLiveNow.test.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useLiveNow } from '@/hooks/queries/useLiveNow';
+
+describe('useLiveNow query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    (global.fetch as jest.Mock | undefined)?.mockReset?.();
+  });
+
+  it('fetches the live config and returns the liveNow array', async () => {
+    const liveNow = [{ did: 'did:plc:abc', domains: ['twitch.tv'] }];
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ liveNow }),
+    }) as unknown as typeof fetch;
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLiveNow(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://api.bsky.app/xrpc/app.bsky.unspecced.getConfig',
+      { headers: { 'atproto-proxy': 'did:web:api.bsky.app#bsky_appview' } },
+    );
+    expect(result.current.data).toEqual(liveNow);
+  });
+
+  it('returns an empty array when liveNow is absent from the response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    }) as unknown as typeof fetch;
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLiveNow(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('returns an empty array when the response is not ok', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ liveNow: [{ did: 'x', domains: [] }] }),
+    }) as unknown as typeof fetch;
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLiveNow(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('swallows fetch errors and returns an empty array', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('network down')) as unknown as typeof fetch;
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useLiveNow(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual([]);
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useModerationLists.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useModerationLists.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useModerationLists } from '@/hooks/queries/useModerationLists';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useAppViewEnabled } from '@/hooks/useAppViewEnabled';
+import { readAppViewEnabled } from '@/hooks/useAppViewSettings';
+
+const mockGetListMutes = jest.fn();
+const mockGetListBlocks = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewEnabled', () => ({
+  useAppViewEnabled: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewEnabled: jest.fn(() => true),
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getListMutes: mockGetListMutes,
+    getListBlocks: mockGetListBlocks,
+  })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+  (useCurrentAccount as jest.Mock).mockReturnValue({
+    data: { pdsUrl: 'https://pds', did: 'did:me' },
+  });
+  (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+  (readAppViewEnabled as jest.Mock).mockReturnValue(true);
+});
+
+describe('useModerationLists query hook', () => {
+  it('merges muted and blocked lists, deduped by URI', async () => {
+    mockGetListMutes.mockResolvedValueOnce({
+      lists: [{ uri: 'at://list/muted' }, { uri: 'at://list/both' }],
+    });
+    mockGetListBlocks.mockResolvedValueOnce({
+      lists: [
+        { uri: 'at://list/both', viewer: { blocked: 'at://block/both' } },
+        { uri: 'at://list/blocked', viewer: { blocked: 'at://block/blocked' } },
+      ],
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useModerationLists(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetListMutes).toHaveBeenCalledWith('token', 50);
+    expect(mockGetListBlocks).toHaveBeenCalledWith('token', 50);
+    expect(result.current.data).toEqual([
+      { list: { uri: 'at://list/muted' }, muted: true },
+      {
+        // Muted entry wins the dedupe; the listblock URI is layered on.
+        list: { uri: 'at://list/both' },
+        muted: true,
+        blockedUri: 'at://block/both',
+      },
+      {
+        list: { uri: 'at://list/blocked', viewer: { blocked: 'at://block/blocked' } },
+        muted: false,
+        blockedUri: 'at://block/blocked',
+      },
+    ]);
+  });
+
+  it('is disabled when token or pdsUrl is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useModerationLists(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetListMutes).not.toHaveBeenCalled();
+  });
+
+  it('throws when the AppView is disabled', async () => {
+    (readAppViewEnabled as jest.Mock).mockReturnValue(false);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useModerationLists(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetListMutes).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useMutedWords.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useMutedWords.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-native';
+
+import { useMutedWords } from '@/hooks/queries/useMutedWords';
+import { usePreferences } from '@/hooks/queries/usePreferences';
+
+jest.mock('@/hooks/queries/usePreferences', () => ({
+  usePreferences: jest.fn(),
+}));
+
+const MUTED_WORDS_PREF_TYPE = 'app.bsky.actor.defs#mutedWordsPref';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useMutedWords hook', () => {
+  it('extracts muted words from the mutedWordsPref', () => {
+    const items = [{ value: 'spoiler', targets: ['content'] }];
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: {
+        preferences: [
+          { $type: 'app.bsky.actor.defs#adultContentPref' },
+          { $type: MUTED_WORDS_PREF_TYPE, items },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+    });
+
+    const { result } = renderHook(() => useMutedWords());
+
+    expect(result.current.data).toEqual(items);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('returns an empty array when there is no mutedWordsPref', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: 'app.bsky.actor.defs#adultContentPref' }] },
+      isLoading: false,
+      isError: false,
+    });
+
+    const { result } = renderHook(() => useMutedWords());
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('returns an empty array when preferences are not yet loaded', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+
+    const { result } = renderHook(() => useMutedWords());
+
+    expect(result.current.data).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('survives usePreferences returning undefined (auto-mock guard)', () => {
+    (usePreferences as jest.Mock).mockReturnValue(undefined);
+
+    const { result } = renderHook(() => useMutedWords());
+
+    expect(result.current.data).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('propagates the error flag', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    const { result } = renderHook(() => useMutedWords());
+
+    expect(result.current.isError).toBe(true);
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useMutes.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useMutes.test.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useMutes } from '@/hooks/queries/useMutes';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useAppViewEnabled } from '@/hooks/useAppViewEnabled';
+import { readAppViewEnabled } from '@/hooks/useAppViewSettings';
+
+const mockGetMutes = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewEnabled', () => ({
+  useAppViewEnabled: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewEnabled: jest.fn(() => true),
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({ getMutes: mockGetMutes })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+  (useCurrentAccount as jest.Mock).mockReturnValue({
+    data: { pdsUrl: 'https://pds', did: 'did:me' },
+  });
+  (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+  (readAppViewEnabled as jest.Mock).mockReturnValue(true);
+});
+
+describe('useMutes query hook', () => {
+  it('fetches muted accounts and paginates', async () => {
+    mockGetMutes
+      .mockResolvedValueOnce({ mutes: [{ did: 'did:a' }], cursor: 'next' })
+      .mockResolvedValueOnce({ mutes: [{ did: 'did:b' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useMutes(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetMutes).toHaveBeenCalledWith('token', 50, undefined);
+    expect(result.current.data?.pages[0]).toEqual({ mutes: [{ did: 'did:a' }], cursor: 'next' });
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data?.pages).toHaveLength(2);
+    });
+    expect(mockGetMutes).toHaveBeenLastCalledWith('token', 50, 'next');
+  });
+
+  it('is disabled when token is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useMutes(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetMutes).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when pdsUrl is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:me' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useMutes(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetMutes).not.toHaveBeenCalled();
+  });
+
+  it('throws when the AppView is disabled', async () => {
+    (readAppViewEnabled as jest.Mock).mockReturnValue(false);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useMutes(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(mockGetMutes).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useNotificationPreferences.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useNotificationPreferences.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useNotificationPreferences } from '@/hooks/queries/useNotificationPreferences';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useAppViewEnabled } from '@/hooks/useAppViewEnabled';
+import { readAppViewEnabled } from '@/hooks/useAppViewSettings';
+
+const mockGetNotificationPreferences = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewEnabled', () => ({
+  useAppViewEnabled: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewEnabled: jest.fn(),
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getNotificationPreferences: mockGetNotificationPreferences,
+  })),
+}));
+
+describe('useNotificationPreferences query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+    (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+    (readAppViewEnabled as jest.Mock).mockReturnValue(true);
+  });
+
+  it('fetches notification preferences', async () => {
+    const prefs = { chat: { include: 'all' } };
+    mockGetNotificationPreferences.mockResolvedValueOnce(prefs);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useNotificationPreferences(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetNotificationPreferences).toHaveBeenCalledWith('token');
+    expect(result.current.data).toEqual(prefs);
+  });
+
+  it('throws AppViewRequiredError when the AppView is disabled', async () => {
+    (readAppViewEnabled as jest.Mock).mockReturnValue(false);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useNotificationPreferences(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect((result.current.error as Error).message).toContain('notifications');
+    expect(mockGetNotificationPreferences).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when token is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useNotificationPreferences(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetNotificationPreferences).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when pdsUrl is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:me' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useNotificationPreferences(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetNotificationPreferences).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useOzoneAdminQueries.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useOzoneAdminQueries.test.tsx
@@ -1,0 +1,181 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  useSafelinkRules,
+  useAddSafelinkRule,
+  useRemoveSafelinkRule,
+  useOzoneSets,
+  useOzoneVerifications,
+  useFindRelatedAccounts,
+} from '@/hooks/queries/useOzoneAdminQueries';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+
+const mockQuerySafelinkRules = jest.fn();
+const mockAddSafelinkRule = jest.fn();
+const mockRemoveSafelinkRule = jest.fn();
+const mockListSets = jest.fn();
+const mockListVerifications = jest.fn();
+const mockFindRelatedAccounts = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/useOzoneSettings', () => ({
+  useOzoneDid: jest.fn(),
+}));
+
+jest.mock('@/utils/blueskyOzone', () => ({
+  ozoneForAccount: jest.fn(),
+}));
+
+describe('useOzoneAdminQueries', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper, invalidateSpy };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({
+      querySafelinkRules: mockQuerySafelinkRules,
+      addSafelinkRule: mockAddSafelinkRule,
+      removeSafelinkRule: mockRemoveSafelinkRule,
+      listSets: mockListSets,
+      listVerifications: mockListVerifications,
+      findRelatedAccounts: mockFindRelatedAccounts,
+    });
+  });
+
+  it('useSafelinkRules fetches rules', async () => {
+    mockQuerySafelinkRules.mockResolvedValue({ rules: [{ id: 'r1' }] });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSafelinkRules(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockQuerySafelinkRules).toHaveBeenCalledWith('token', 'did:ozone', { limit: 100 });
+    expect(result.current.data).toEqual([{ id: 'r1' }]);
+  });
+
+  it('useSafelinkRules is disabled without token', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSafelinkRules(), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockQuerySafelinkRules).not.toHaveBeenCalled();
+  });
+
+  it('useOzoneSets fetches sets', async () => {
+    mockListSets.mockResolvedValue({ sets: [{ name: 's1' }] });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneSets(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockListSets).toHaveBeenCalledWith('token', 'did:ozone', { limit: 100 });
+    expect(result.current.data).toEqual([{ name: 's1' }]);
+  });
+
+  it('useOzoneVerifications fetches verifications', async () => {
+    mockListVerifications.mockResolvedValue({ verifications: [{ id: 'v1' }] });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneVerifications(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockListVerifications).toHaveBeenCalledWith('token', 'did:ozone', { limit: 100 });
+    expect(result.current.data).toEqual([{ id: 'v1' }]);
+  });
+
+  it('useFindRelatedAccounts fetches related accounts', async () => {
+    mockFindRelatedAccounts.mockResolvedValue({ accounts: [{ did: 'did:x' }] });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFindRelatedAccounts('did:target'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockFindRelatedAccounts).toHaveBeenCalledWith('token', 'did:ozone', 'did:target');
+    expect(result.current.data).toEqual([{ did: 'did:x' }]);
+  });
+
+  it('useFindRelatedAccounts is disabled without a did', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFindRelatedAccounts(undefined), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockFindRelatedAccounts).not.toHaveBeenCalled();
+  });
+
+  it('useAddSafelinkRule calls the API with createdBy and invalidates', async () => {
+    mockAddSafelinkRule.mockResolvedValue({});
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useAddSafelinkRule(), { wrapper });
+
+    result.current.mutate({
+      url: 'https://bad',
+      pattern: 'domain',
+      action: 'block',
+      reason: 'spam',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockAddSafelinkRule).toHaveBeenCalledWith('token', 'did:ozone', {
+      url: 'https://bad',
+      pattern: 'domain',
+      action: 'block',
+      reason: 'spam',
+      createdBy: 'did:current',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['ozone', 'safelink', 'rules'] });
+  });
+
+  it('useAddSafelinkRule throws when session missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAddSafelinkRule(), { wrapper });
+
+    result.current.mutate({ url: 'u', pattern: 'url', action: 'warn', reason: 'r' });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('useRemoveSafelinkRule calls the API and invalidates', async () => {
+    mockRemoveSafelinkRule.mockResolvedValue({});
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useRemoveSafelinkRule(), { wrapper });
+
+    result.current.mutate({ url: 'https://bad', pattern: 'domain' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockRemoveSafelinkRule).toHaveBeenCalledWith('token', 'did:ozone', {
+      url: 'https://bad',
+      pattern: 'domain',
+      createdBy: 'did:current',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['ozone', 'safelink', 'rules'] });
+  });
+
+  it('useRemoveSafelinkRule throws when PDS missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: undefined } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRemoveSafelinkRule(), { wrapper });
+
+    result.current.mutate({ url: 'u', pattern: 'url' });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useOzoneCommTemplates.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useOzoneCommTemplates.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useOzoneCommTemplates } from '@/hooks/queries/useOzoneCommTemplates';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+
+const mockListCommTemplates = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyOzone', () => ({ ozoneForAccount: jest.fn() }));
+
+describe('useOzoneCommTemplates hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({
+      listCommTemplates: mockListCommTemplates,
+    });
+  });
+
+  it('lists communication templates', async () => {
+    mockListCommTemplates.mockResolvedValue({
+      communicationTemplates: [{ id: 't1', name: 'Welcome' }],
+    });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneCommTemplates(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockListCommTemplates).toHaveBeenCalledWith('token', 'did:ozone');
+    expect(result.current.data).toEqual([{ id: 't1', name: 'Welcome' }]);
+  });
+
+  it('is disabled when ozoneDid missing', () => {
+    (useOzoneDid as jest.Mock).mockReturnValue('');
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneCommTemplates(), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockListCommTemplates).not.toHaveBeenCalled();
+  });
+
+  it('is disabled without a token', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneCommTemplates(), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useOzoneEvents.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useOzoneEvents.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useOzoneEvents } from '@/hooks/queries/useOzoneEvents';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+import { apiForAccount } from '@/utils/blueskyApi';
+import { fetchAvatarsByDid, subjectDid } from '@/utils/ozoneAvatars';
+
+const mockQueryEvents = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyOzone', () => ({ ozoneForAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+jest.mock('@/utils/ozoneAvatars', () => ({
+  fetchAvatarsByDid: jest.fn(),
+  subjectDid: jest.fn(),
+}));
+
+describe('useOzoneEvents hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({ queryEvents: mockQueryEvents });
+    (apiForAccount as jest.Mock).mockReturnValue({});
+    (fetchAvatarsByDid as jest.Mock).mockResolvedValue(new Map());
+    (subjectDid as jest.Mock).mockReturnValue(undefined);
+  });
+
+  it('queries events with filters and enriches avatars', async () => {
+    mockQueryEvents.mockResolvedValue({
+      events: [{ createdBy: 'did:c', subject: { did: 'did:s' } }],
+      cursor: 'next',
+    });
+    (subjectDid as jest.Mock).mockReturnValue('did:s');
+    (fetchAvatarsByDid as jest.Mock).mockResolvedValue(
+      new Map([
+        ['did:c', 'cav'],
+        ['did:s', 'sav'],
+      ]),
+    );
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneEvents({ types: ['x'] } as never, 20), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockQueryEvents).toHaveBeenCalledWith('token', 'did:ozone', {
+      types: ['x'],
+      limit: 20,
+      cursor: undefined,
+    });
+    expect(result.current.data?.pages[0].events[0]).toMatchObject({
+      creatorAvatar: 'cav',
+      subjectAvatar: 'sav',
+    });
+    expect(result.current.hasNextPage).toBe(true);
+  });
+
+  it('paginates using the cursor', async () => {
+    mockQueryEvents
+      .mockResolvedValueOnce({ events: [{ createdBy: 'a', subject: {} }], cursor: 'c1' })
+      .mockResolvedValueOnce({ events: [{ createdBy: 'b', subject: {} }], cursor: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneEvents({}, 10), { wrapper });
+
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => expect(result.current.data?.pages.length).toBe(2));
+    expect(mockQueryEvents).toHaveBeenLastCalledWith('token', 'did:ozone', {
+      limit: 10,
+      cursor: 'c1',
+    });
+  });
+
+  it('falls back to raw response when enrichment throws', async () => {
+    mockQueryEvents.mockResolvedValue({ events: [{ createdBy: 'a', subject: {} }], cursor: undefined });
+    (fetchAvatarsByDid as jest.Mock).mockRejectedValue(new Error('boom'));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneEvents(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.pages[0]).toEqual({
+      events: [{ createdBy: 'a', subject: {} }],
+      cursor: undefined,
+    });
+  });
+
+  it('is disabled when ozoneDid missing', () => {
+    (useOzoneDid as jest.Mock).mockReturnValue('');
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneEvents(), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockQueryEvents).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useOzoneLabelOptions.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useOzoneLabelOptions.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useOzoneLabelOptions } from '@/hooks/queries/useOzoneLabelOptions';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { apiForAccount } from '@/utils/blueskyApi';
+
+const mockGetLabelerServices = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+
+const FALLBACK_TAGS = ['auto-flagged', 'repeat-offender', 'reviewed', 'needs-translation'];
+
+describe('useOzoneLabelOptions hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (apiForAccount as jest.Mock).mockReturnValue({
+      getLabelerServices: mockGetLabelerServices,
+    });
+  });
+
+  it('returns labeler-provided label values plus fallback tags', async () => {
+    mockGetLabelerServices.mockResolvedValue({
+      views: [{ policies: { labelValues: ['spam', 'porn'] } }],
+    });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneLabelOptions(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGetLabelerServices).toHaveBeenCalledWith('token', ['did:ozone'], true);
+    expect(result.current.data).toEqual({ labels: ['spam', 'porn'], tags: FALLBACK_TAGS });
+  });
+
+  it('falls back to default labels when the labeler returns none', async () => {
+    mockGetLabelerServices.mockResolvedValue({ views: [{ policies: { labelValues: [] } }] });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneLabelOptions(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.labels).toContain('spam');
+    expect(result.current.data?.labels.length).toBeGreaterThan(0);
+    expect(result.current.data?.tags).toEqual(FALLBACK_TAGS);
+  });
+
+  it('falls back to defaults when the API call throws', async () => {
+    mockGetLabelerServices.mockRejectedValue(new Error('network'));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneLabelOptions(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.labels).toContain('impersonation');
+    expect(result.current.data?.tags).toEqual(FALLBACK_TAGS);
+  });
+
+  it('is disabled when ozoneDid missing', () => {
+    (useOzoneDid as jest.Mock).mockReturnValue('');
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneLabelOptions(), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetLabelerServices).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useOzoneMembership.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useOzoneMembership.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useOzoneMembership } from '@/hooks/queries/useOzoneMembership';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+
+const mockListTeamMembers = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyOzone', () => ({ ozoneForAccount: jest.fn() }));
+jest.mock('bluesky-ozone', () => ({
+  OZONE_MOD_ROLES: ['tools.ozone.team.defs#roleModerator', 'tools.ozone.team.defs#roleAdmin'],
+}));
+
+describe('useOzoneMembership query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did:me', pdsUrl: 'https://pds' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({ listTeamMembers: mockListTeamMembers });
+  });
+
+  it('resolves membership as a moderator when the viewer holds a mod role', async () => {
+    const self = {
+      did: 'did:me',
+      role: 'tools.ozone.team.defs#roleModerator',
+      disabled: false,
+    };
+    mockListTeamMembers.mockResolvedValue({ members: [self, { did: 'did:other' }] });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useOzoneMembership(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockListTeamMembers).toHaveBeenCalledWith('token', 'did:ozone', {
+      q: 'did:me',
+      limit: 25,
+    });
+    expect(result.current.data).toEqual({
+      isMod: true,
+      role: 'tools.ozone.team.defs#roleModerator',
+      self,
+    });
+  });
+
+  it('is not a mod when the matching member has a disabled flag', async () => {
+    const self = {
+      did: 'did:me',
+      role: 'tools.ozone.team.defs#roleModerator',
+      disabled: true,
+    };
+    mockListTeamMembers.mockResolvedValue({ members: [self] });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useOzoneMembership(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data?.isMod).toBe(false);
+  });
+
+  it('is not a mod when the role is not a moderation role', async () => {
+    const self = { did: 'did:me', role: 'tools.ozone.team.defs#roleVerifier' };
+    mockListTeamMembers.mockResolvedValue({ members: [self] });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useOzoneMembership(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual({
+      isMod: false,
+      role: 'tools.ozone.team.defs#roleVerifier',
+      self,
+    });
+  });
+
+  it('honors an ozoneDidOverride', async () => {
+    mockListTeamMembers.mockResolvedValue({ members: [] });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useOzoneMembership({ ozoneDidOverride: 'did:override' }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockListTeamMembers).toHaveBeenCalledWith('token', 'did:override', {
+      q: 'did:me',
+      limit: 25,
+    });
+  });
+
+  it('is disabled when enabled is false', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useOzoneMembership({ enabled: false }), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockListTeamMembers).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when the token is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useOzoneMembership(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockListTeamMembers).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useOzoneQueue.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useOzoneQueue.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useOzoneQueue } from '@/hooks/queries/useOzoneQueue';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+import { apiForAccount } from '@/utils/blueskyApi';
+import { fetchAvatarsByDid, subjectDid } from '@/utils/ozoneAvatars';
+
+const mockQueryStatuses = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyOzone', () => ({ ozoneForAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+jest.mock('@/utils/ozoneAvatars', () => ({
+  fetchAvatarsByDid: jest.fn(),
+  subjectDid: jest.fn(),
+}));
+
+describe('useOzoneQueue hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({ queryStatuses: mockQueryStatuses });
+    (apiForAccount as jest.Mock).mockReturnValue({});
+    (fetchAvatarsByDid as jest.Mock).mockResolvedValue(new Map());
+    (subjectDid as jest.Mock).mockReturnValue(undefined);
+  });
+
+  it('queries statuses with filters and splices avatars into accountStats', async () => {
+    mockQueryStatuses.mockResolvedValue({
+      subjectStatuses: [{ subject: { did: 'did:s' }, accountStats: { reportCount: 3 } }],
+      cursor: 'next',
+    });
+    (subjectDid as jest.Mock).mockReturnValue('did:s');
+    (fetchAvatarsByDid as jest.Mock).mockResolvedValue(new Map([['did:s', 'av']]));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneQueue({ reviewState: 'open' } as never, 50), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockQueryStatuses).toHaveBeenCalledWith('token', 'did:ozone', {
+      reviewState: 'open',
+      limit: 50,
+      cursor: undefined,
+    });
+    expect(result.current.data?.pages[0].subjectStatuses[0]).toEqual({
+      subject: { did: 'did:s' },
+      accountStats: { reportCount: 3, avatar: 'av' },
+    });
+    expect(result.current.hasNextPage).toBe(true);
+  });
+
+  it('leaves rows untouched when no avatar is found', async () => {
+    mockQueryStatuses.mockResolvedValue({
+      subjectStatuses: [{ subject: { did: 'did:s' } }],
+      cursor: undefined,
+    });
+    (subjectDid as jest.Mock).mockReturnValue('did:s');
+    (fetchAvatarsByDid as jest.Mock).mockResolvedValue(new Map());
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneQueue(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.pages[0].subjectStatuses[0]).toEqual({ subject: { did: 'did:s' } });
+  });
+
+  it('paginates using the cursor', async () => {
+    mockQueryStatuses
+      .mockResolvedValueOnce({ subjectStatuses: [{ subject: {} }], cursor: 'c1' })
+      .mockResolvedValueOnce({ subjectStatuses: [{ subject: {} }], cursor: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneQueue({}, 25), { wrapper });
+
+    await waitFor(() => expect(result.current.hasNextPage).toBe(true));
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+    await waitFor(() => expect(result.current.data?.pages.length).toBe(2));
+    expect(mockQueryStatuses).toHaveBeenLastCalledWith('token', 'did:ozone', {
+      limit: 25,
+      cursor: 'c1',
+    });
+  });
+
+  it('falls back to raw response when enrichment throws', async () => {
+    mockQueryStatuses.mockResolvedValue({ subjectStatuses: [{ subject: {} }], cursor: undefined });
+    (fetchAvatarsByDid as jest.Mock).mockRejectedValue(new Error('boom'));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneQueue(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.pages[0]).toEqual({
+      subjectStatuses: [{ subject: {} }],
+      cursor: undefined,
+    });
+  });
+
+  it('is disabled when ozoneDid missing', () => {
+    (useOzoneDid as jest.Mock).mockReturnValue('');
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneQueue(), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockQueryStatuses).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useOzoneScheduledActions.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useOzoneScheduledActions.test.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  useOzoneScheduledActions,
+  useCancelOzoneScheduledActions,
+} from '@/hooks/queries/useOzoneScheduledActions';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+
+const mockListScheduledActions = jest.fn();
+const mockCancelScheduledActions = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyOzone', () => ({ ozoneForAccount: jest.fn() }));
+
+describe('useOzoneScheduledActions hooks', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper, invalidateSpy };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({
+      listScheduledActions: mockListScheduledActions,
+      cancelScheduledActions: mockCancelScheduledActions,
+    });
+  });
+
+  it('lists scheduled actions with the default pending status', async () => {
+    mockListScheduledActions.mockResolvedValue({ actions: [{ id: 'a1' }] });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneScheduledActions(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockListScheduledActions).toHaveBeenCalledWith('token', 'did:ozone', {
+      statuses: ['pending'],
+    });
+    expect(result.current.data).toEqual([{ id: 'a1' }]);
+  });
+
+  it('passes custom statuses through', async () => {
+    mockListScheduledActions.mockResolvedValue({ actions: [] });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useOzoneScheduledActions(['executed', 'failed']),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockListScheduledActions).toHaveBeenCalledWith('token', 'did:ozone', {
+      statuses: ['executed', 'failed'],
+    });
+  });
+
+  it('is disabled when ozoneDid missing', () => {
+    (useOzoneDid as jest.Mock).mockReturnValue('');
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneScheduledActions(), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockListScheduledActions).not.toHaveBeenCalled();
+  });
+
+  it('useCancelOzoneScheduledActions cancels and invalidates all ozone queries', async () => {
+    mockCancelScheduledActions.mockResolvedValue({});
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useCancelOzoneScheduledActions(), { wrapper });
+
+    result.current.mutate({ subjects: ['did:a', 'did:b'], comment: 'stop' });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockCancelScheduledActions).toHaveBeenCalledWith(
+      'token',
+      'did:ozone',
+      ['did:a', 'did:b'],
+      'stop',
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['ozone'] });
+  });
+
+  it('useCancelOzoneScheduledActions throws when session missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCancelOzoneScheduledActions(), { wrapper });
+
+    result.current.mutate({ subjects: ['did:a'] });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useOzoneSubject.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useOzoneSubject.test.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useOzoneSubjectStatus, useOzoneSubjectEvents } from '@/hooks/queries/useOzoneSubject';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+import { apiForAccount } from '@/utils/blueskyApi';
+import { fetchAvatarsByDid, subjectDid } from '@/utils/ozoneAvatars';
+
+const mockQueryStatuses = jest.fn();
+const mockQueryEvents = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyOzone', () => ({ ozoneForAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+jest.mock('@/utils/ozoneAvatars', () => ({
+  fetchAvatarsByDid: jest.fn(),
+  subjectDid: jest.fn(),
+}));
+
+describe('useOzoneSubject hooks', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({
+      queryStatuses: mockQueryStatuses,
+      queryEvents: mockQueryEvents,
+    });
+    (apiForAccount as jest.Mock).mockReturnValue({});
+    (fetchAvatarsByDid as jest.Mock).mockResolvedValue(new Map());
+    (subjectDid as jest.Mock).mockReturnValue(undefined);
+  });
+
+  it('useOzoneSubjectStatus returns the first status', async () => {
+    mockQueryStatuses.mockResolvedValue({ subjectStatuses: [{ id: 1 }, { id: 2 }] });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneSubjectStatus('did:subject'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockQueryStatuses).toHaveBeenCalledWith('token', 'did:ozone', {
+      subject: 'did:subject',
+      limit: 1,
+    });
+    expect(result.current.data).toEqual({ id: 1 });
+  });
+
+  it('useOzoneSubjectStatus is disabled without subject', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneSubjectStatus(undefined), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockQueryStatuses).not.toHaveBeenCalled();
+  });
+
+  it('useOzoneSubjectEvents queries events and enriches with avatars', async () => {
+    mockQueryEvents.mockResolvedValue({
+      events: [
+        { createdBy: 'did:creator', subject: { did: 'did:sub' } },
+      ],
+    });
+    (subjectDid as jest.Mock).mockReturnValue('did:sub');
+    (fetchAvatarsByDid as jest.Mock).mockResolvedValue(
+      new Map([
+        ['did:creator', 'creator-av'],
+        ['did:sub', 'sub-av'],
+      ]),
+    );
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneSubjectEvents('did:sub', 10), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockQueryEvents).toHaveBeenCalledWith('token', 'did:ozone', {
+      subject: 'did:sub',
+      limit: 10,
+      includeAllUserRecords: true,
+      sortDirection: 'desc',
+    });
+    expect(result.current.data?.[0]).toMatchObject({
+      creatorAvatar: 'creator-av',
+      subjectAvatar: 'sub-av',
+    });
+  });
+
+  it('useOzoneSubjectEvents uses includeAllUserRecords=false for non-did subjects', async () => {
+    mockQueryEvents.mockResolvedValue({ events: [] });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useOzoneSubjectEvents('at://did:plc:x/app.bsky.feed.post/abc'),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockQueryEvents).toHaveBeenCalledWith(
+      'token',
+      'did:ozone',
+      expect.objectContaining({ includeAllUserRecords: false, limit: 50 }),
+    );
+  });
+
+  it('useOzoneSubjectEvents falls back to raw events when enrichment throws', async () => {
+    mockQueryEvents.mockResolvedValue({ events: [{ createdBy: 'did:c', subject: {} }] });
+    (fetchAvatarsByDid as jest.Mock).mockRejectedValue(new Error('boom'));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneSubjectEvents('did:sub'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ createdBy: 'did:c', subject: {} }]);
+  });
+
+  it('useOzoneSubjectEvents is disabled without subject', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneSubjectEvents(undefined), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockQueryEvents).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useOzoneTeam.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useOzoneTeam.test.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  useOzoneTeam,
+  useAddOzoneTeamMember,
+  useUpdateOzoneTeamMember,
+  useDeleteOzoneTeamMember,
+} from '@/hooks/queries/useOzoneTeam';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useOzoneDid } from '@/hooks/useOzoneSettings';
+import { ozoneForAccount } from '@/utils/blueskyOzone';
+import { apiForAccount } from '@/utils/blueskyApi';
+import { fetchProfilesByDid } from '@/utils/ozoneAvatars';
+
+const mockListTeamMembers = jest.fn();
+const mockAddTeamMember = jest.fn();
+const mockUpdateTeamMember = jest.fn();
+const mockDeleteTeamMember = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useOzoneSettings', () => ({ useOzoneDid: jest.fn() }));
+jest.mock('@/utils/blueskyOzone', () => ({ ozoneForAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+jest.mock('@/utils/ozoneAvatars', () => ({ fetchProfilesByDid: jest.fn() }));
+
+describe('useOzoneTeam hooks', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper, invalidateSpy };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:current' },
+    });
+    (useOzoneDid as jest.Mock).mockReturnValue('did:ozone');
+    (ozoneForAccount as jest.Mock).mockReturnValue({
+      listTeamMembers: mockListTeamMembers,
+      addTeamMember: mockAddTeamMember,
+      updateTeamMember: mockUpdateTeamMember,
+      deleteTeamMember: mockDeleteTeamMember,
+    });
+    (apiForAccount as jest.Mock).mockReturnValue({});
+    (fetchProfilesByDid as jest.Mock).mockResolvedValue(new Map());
+  });
+
+  it('lists team members and merges fetched profiles', async () => {
+    mockListTeamMembers.mockResolvedValue({
+      members: [
+        { did: 'did:a', profile: { handle: 'old' } },
+        { did: 'did:b', profile: {} },
+      ],
+    });
+    (fetchProfilesByDid as jest.Mock).mockResolvedValue(
+      new Map([['did:a', { handle: 'new', avatar: 'av' }]]),
+    );
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneTeam(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockListTeamMembers).toHaveBeenCalledWith('token', 'did:ozone', { limit: 100 });
+    expect(fetchProfilesByDid).toHaveBeenCalledWith(expect.anything(), 'token', ['did:a', 'did:b']);
+    expect(result.current.data).toEqual([
+      { did: 'did:a', profile: { handle: 'new', avatar: 'av' } },
+      { did: 'did:b', profile: {} },
+    ]);
+  });
+
+  it('falls back to raw members when profile enrichment throws', async () => {
+    mockListTeamMembers.mockResolvedValue({ members: [{ did: 'did:a' }] });
+    (fetchProfilesByDid as jest.Mock).mockRejectedValue(new Error('boom'));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneTeam(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([{ did: 'did:a' }]);
+  });
+
+  it('is disabled when ozoneDid missing', () => {
+    (useOzoneDid as jest.Mock).mockReturnValue('');
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOzoneTeam(), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('useAddOzoneTeamMember calls API and invalidates', async () => {
+    mockAddTeamMember.mockResolvedValue({});
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useAddOzoneTeamMember(), { wrapper });
+
+    result.current.mutate({ did: 'did:new', role: 'moderator' });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockAddTeamMember).toHaveBeenCalledWith('token', 'did:ozone', {
+      did: 'did:new',
+      role: 'moderator',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['ozone', 'teamMembers', 'did:ozone'],
+    });
+  });
+
+  it('useAddOzoneTeamMember throws when session missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAddOzoneTeamMember(), { wrapper });
+    result.current.mutate({ did: 'did:new', role: 'moderator' });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('useUpdateOzoneTeamMember calls API and invalidates', async () => {
+    mockUpdateTeamMember.mockResolvedValue({});
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useUpdateOzoneTeamMember(), { wrapper });
+
+    result.current.mutate({ did: 'did:x', role: 'admin', disabled: true });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockUpdateTeamMember).toHaveBeenCalledWith('token', 'did:ozone', {
+      did: 'did:x',
+      role: 'admin',
+      disabled: true,
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['ozone', 'teamMembers', 'did:ozone'],
+    });
+  });
+
+  it('useUpdateOzoneTeamMember throws when PDS missing', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: undefined } });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateOzoneTeamMember(), { wrapper });
+    result.current.mutate({ did: 'did:x' });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('useDeleteOzoneTeamMember calls API, returns did, and invalidates', async () => {
+    mockDeleteTeamMember.mockResolvedValue(undefined);
+    const { wrapper, invalidateSpy } = createWrapper();
+    const { result } = renderHook(() => useDeleteOzoneTeamMember(), { wrapper });
+
+    result.current.mutate('did:gone');
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockDeleteTeamMember).toHaveBeenCalledWith('token', 'did:ozone', 'did:gone');
+    expect(result.current.data).toBe('did:gone');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['ozone', 'teamMembers', 'did:ozone'],
+    });
+  });
+
+  it('useDeleteOzoneTeamMember throws when session missing', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeleteOzoneTeamMember(), { wrapper });
+    result.current.mutate('did:gone');
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/usePdsUrl.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/usePdsUrl.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { usePdsUrl, usePdsUrlFromDid } from '@/hooks/queries/usePdsUrl';
+import { getPdsUrlFromDid, getPdsUrlFromHandle } from '@/bluesky-api';
+
+// NOTE: jest.setup.js globally mocks getPdsUrlFromDid / getPdsUrlFromHandle to
+// resolve to 'https://pds.test'. We rely on that global mock here and assert
+// the resolved value accordingly.
+
+describe('usePdsUrl query hooks', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    (getPdsUrlFromDid as jest.Mock).mockClear();
+    (getPdsUrlFromHandle as jest.Mock).mockClear();
+  });
+
+  it('usePdsUrlFromDid resolves the PDS URL for a DID', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePdsUrlFromDid('did:plc:abc'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(getPdsUrlFromDid).toHaveBeenCalledWith('did:plc:abc');
+    expect(result.current.data).toBe('https://pds.test');
+  });
+
+  it('usePdsUrlFromDid is disabled when no DID is provided', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePdsUrlFromDid(undefined), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getPdsUrlFromDid).not.toHaveBeenCalled();
+  });
+
+  it('usePdsUrl routes a did: identifier through the DID resolver', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePdsUrl('did:plc:xyz'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.data).toBe('https://pds.test');
+    });
+    expect(getPdsUrlFromDid).toHaveBeenCalledWith('did:plc:xyz');
+    expect(getPdsUrlFromHandle).not.toHaveBeenCalled();
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('usePdsUrl routes a handle identifier through the handle resolver', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePdsUrl('alice.bsky.social'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.data).toBe('https://pds.test');
+    });
+    expect(getPdsUrlFromHandle).toHaveBeenCalledWith('alice.bsky.social');
+    expect(getPdsUrlFromDid).not.toHaveBeenCalled();
+  });
+
+  it('usePdsUrl is idle for an undefined identifier', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePdsUrl(undefined), { wrapper });
+
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.isLoading).toBe(false);
+    expect(getPdsUrlFromDid).not.toHaveBeenCalled();
+    expect(getPdsUrlFromHandle).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/usePersonalDetails.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/usePersonalDetails.test.tsx
@@ -1,0 +1,47 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { usePersonalDetails } from '@/hooks/queries/usePersonalDetails';
+import { usePreferences } from '@/hooks/queries/usePreferences';
+
+jest.mock('@/hooks/queries/usePreferences', () => ({
+  usePreferences: jest.fn(),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#personalDetailsPref';
+
+describe('usePersonalDetails query hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns undefined birthDate when there is no data', () => {
+    (usePreferences as jest.Mock).mockReturnValue({ data: undefined, isLoading: true });
+
+    const { result } = renderHook(() => usePersonalDetails());
+
+    expect(result.current.birthDate).toBeUndefined();
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns undefined when the pref is absent', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: 'other' }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => usePersonalDetails());
+
+    expect(result.current.birthDate).toBeUndefined();
+  });
+
+  it('returns the birthDate from the pref', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: PREF_TYPE, birthDate: '1990-01-01' }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => usePersonalDetails());
+
+    expect(result.current.birthDate).toBe('1990-01-01');
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/usePinnedPost.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/usePinnedPost.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { usePinnedPost } from '@/hooks/queries/usePinnedPost';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useAppViewEnabled } from '@/hooks/useAppViewEnabled';
+import { useAcceptLabelerDids } from '@/hooks/queries/useAcceptLabelerDids';
+import { getPostView } from '@/hooks/queries/microcosm';
+
+const mockGetPost = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewEnabled', () => ({
+  useAppViewEnabled: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useAcceptLabelerDids', () => ({
+  useAcceptLabelerDids: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/microcosm', () => ({
+  getPostView: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({ getPost: mockGetPost })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+  (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+  (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+  (useAcceptLabelerDids as jest.Mock).mockReturnValue(['did:labeler']);
+});
+
+describe('usePinnedPost query hook', () => {
+  it('resolves the pinned post via the AppView', async () => {
+    mockGetPost.mockResolvedValueOnce({ uri: 'at://pinned' });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePinnedPost('at://pinned'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetPost).toHaveBeenCalledWith('token', 'at://pinned', ['did:labeler']);
+    expect(result.current.data).toEqual({ uri: 'at://pinned' });
+  });
+
+  it('resolves via microcosm getPostView when the AppView is disabled', async () => {
+    (useAppViewEnabled as jest.Mock).mockReturnValue(false);
+    (getPostView as jest.Mock).mockResolvedValueOnce({ uri: 'at://pinned-mc' });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePinnedPost('at://pinned'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(getPostView).toHaveBeenCalledWith('at://pinned');
+    expect(mockGetPost).not.toHaveBeenCalled();
+    expect(result.current.data).toEqual({ uri: 'at://pinned-mc' });
+  });
+
+  it('is disabled when no URI is provided', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePinnedPost(undefined), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetPost).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when AppView enabled but token missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePinnedPost('at://pinned'), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/usePoll.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/usePoll.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  usePoll,
+  usePollVotes,
+  useIsPollClosed,
+  recordLocalVote,
+  clearLocalVote,
+} from '@/hooks/queries/usePoll';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { getPollRecord, getPollVotes } from '@/hooks/queries/microcosm';
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/microcosm', () => ({
+  getPollRecord: jest.fn(),
+  getPollVotes: jest.fn(),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:me' } });
+});
+
+describe('usePoll query hook', () => {
+  it('fetches the poll record by URI', async () => {
+    (getPollRecord as jest.Mock).mockResolvedValueOnce({ uri: 'at://poll', value: {} });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePoll('at://poll'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(getPollRecord).toHaveBeenCalledWith('at://poll');
+    expect(result.current.data).toEqual({ uri: 'at://poll', value: {} });
+  });
+
+  it('is disabled when no poll URI is provided', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePoll(undefined), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getPollRecord).not.toHaveBeenCalled();
+  });
+});
+
+describe('usePollVotes query hook', () => {
+  it('tallies network votes (last seen wins) and reports the viewer choice', async () => {
+    (getPollVotes as jest.Mock).mockResolvedValueOnce({
+      voters: [
+        { did: 'did:a', optionIndex: 0 },
+        { did: 'did:b', optionIndex: 1 },
+        { did: 'did:a', optionIndex: 1 }, // re-vote, last wins
+        { did: 'did:me', optionIndex: 0 },
+      ],
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePollVotes('at://poll'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual({
+      counts: [1, 2],
+      total: 3,
+      sampled: 3,
+      myOptionIndex: 0,
+    });
+  });
+
+  it('overlays a locally-recorded vote that the network has not indexed yet', async () => {
+    (getPollVotes as jest.Mock).mockResolvedValueOnce({
+      voters: [{ did: 'did:a', optionIndex: 0 }],
+    });
+    recordLocalVote('at://poll2', 'did:me', 1);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePollVotes('at://poll2'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data?.myOptionIndex).toBe(1);
+    expect(result.current.data?.total).toBe(2);
+    clearLocalVote('at://poll2', 'did:me');
+  });
+
+  it('respects the enabled flag', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => usePollVotes('at://poll', false), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getPollVotes).not.toHaveBeenCalled();
+  });
+});
+
+describe('useIsPollClosed', () => {
+  it('returns false when no endsAt is given', () => {
+    const { result } = renderHook(() => useIsPollClosed(undefined));
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true when endsAt is in the past', () => {
+    const { result } = renderHook(() => useIsPollClosed('2000-01-01T00:00:00Z'));
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when endsAt is in the future', () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const { result } = renderHook(() => useIsPollClosed(future));
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false for an unparseable date', () => {
+    const { result } = renderHook(() => useIsPollClosed('not-a-date'));
+    expect(result.current).toBe(false);
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/usePostControls.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/usePostControls.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useExistingPostControls } from '@/hooks/queries/usePostControls';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+}));
+
+// The hook constructs its BlueskyApi to read `.baseUrl`, then fetches the
+// repo records directly via global fetch.
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({ baseUrl: 'https://pds' })),
+}));
+
+const POST_URI = 'at://did:me/app.bsky.feed.post/abc';
+const originalFetch = global.fetch;
+let fetchMock: jest.Mock;
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+  (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+  fetchMock = jest.fn();
+  (global as unknown as { fetch: jest.Mock }).fetch = fetchMock;
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+describe('useExistingPostControls query hook', () => {
+  it('returns defaults when both records are missing (404)', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404 });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useExistingPostControls(POST_URI), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual({ replyAllow: { type: 'everyone' }, allowQuote: true });
+  });
+
+  it('decodes a limited threadgate and a disabled-quote postgate', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes('app.bsky.feed.threadgate')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            value: {
+              allow: [
+                { $type: 'app.bsky.feed.threadgate#followingRule' },
+                { $type: 'app.bsky.feed.threadgate#listRule', list: 'at://list/1' },
+              ],
+            },
+          }),
+        });
+      }
+      // postgate disables embedding
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          value: { embeddingRules: [{ $type: 'app.bsky.feed.postgate#disableRule' }] },
+        }),
+      });
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useExistingPostControls(POST_URI), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual({
+      replyAllow: { type: 'limited', following: true, listUris: ['at://list/1'] },
+      allowQuote: false,
+    });
+  });
+
+  it('decodes an empty allow array as nobody', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url.includes('threadgate')) {
+        return Promise.resolve({ ok: true, json: async () => ({ value: { allow: [] } }) });
+      }
+      return Promise.resolve({ ok: false, status: 404 });
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useExistingPostControls(POST_URI), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data?.replyAllow).toEqual({ type: 'nobody' });
+    expect(result.current.data?.allowQuote).toBe(true);
+  });
+
+  it('is disabled when the post URI is missing', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useExistingPostControls(undefined), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/usePostInteractionSettings.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/usePostInteractionSettings.test.tsx
@@ -1,0 +1,88 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { usePostInteractionSettings } from '@/hooks/queries/usePostInteractionSettings';
+import { usePreferences } from '@/hooks/queries/usePreferences';
+
+jest.mock('@/hooks/queries/usePreferences', () => ({
+  usePreferences: jest.fn(),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#postInteractionSettingsPref';
+
+describe('usePostInteractionSettings query hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns defaults when there is no preferences data', () => {
+    (usePreferences as jest.Mock).mockReturnValue({ data: undefined, isLoading: true });
+
+    const { result } = renderHook(() => usePostInteractionSettings());
+
+    expect(result.current.data).toEqual({
+      mode: 'anyone',
+      followers: false,
+      following: false,
+      mentioned: false,
+      allowQuotes: true,
+      allowedLists: [],
+    });
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns defaults when the pref is absent', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: 'other' }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => usePostInteractionSettings());
+
+    expect(result.current.data.mode).toBe('anyone');
+    expect(result.current.data.allowQuotes).toBe(true);
+  });
+
+  it('decodes an empty allow-rules array as "nobody"', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: PREF_TYPE, threadgateAllowRules: [] }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => usePostInteractionSettings());
+
+    expect(result.current.data.mode).toBe('nobody');
+  });
+
+  it('decodes follower/following/mention/list rules and disabled quotes', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: {
+        preferences: [
+          {
+            $type: PREF_TYPE,
+            threadgateAllowRules: [
+              { $type: 'app.bsky.feed.threadgate#followerRule' },
+              { $type: 'app.bsky.feed.threadgate#followingRule' },
+              { $type: 'app.bsky.feed.threadgate#mentionRule' },
+              { $type: 'app.bsky.feed.threadgate#listRule', list: 'at://list/1' },
+              null,
+              { foo: 'no-type' },
+            ],
+            postgateEmbeddingRules: [{ $type: 'app.bsky.feed.postgate#disableRule' }],
+          },
+        ],
+      },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => usePostInteractionSettings());
+
+    expect(result.current.data).toEqual({
+      mode: 'anyone',
+      followers: true,
+      following: true,
+      mentioned: true,
+      allowQuotes: false,
+      allowedLists: ['at://list/1'],
+    });
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useProfileRecord.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useProfileRecord.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import {
+  useProfileRecord,
+  isLoggedOutVisibilityDiscouraged,
+  isAccountAutomated,
+} from '@/hooks/queries/useProfileRecord';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+
+const mockGetProfileRecord = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getProfileRecord: mockGetProfileRecord,
+  })),
+}));
+
+describe('useProfileRecord query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { pdsUrl: 'https://pds', did: 'did:me' },
+    });
+  });
+
+  it('fetches the profile record for the current user', async () => {
+    const record = { uri: 'at://record', value: { labels: undefined } };
+    mockGetProfileRecord.mockResolvedValueOnce(record);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useProfileRecord(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetProfileRecord).toHaveBeenCalledWith('token', 'did:me');
+    expect(result.current.data).toEqual(record);
+  });
+
+  it('is disabled when token is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useProfileRecord(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetProfileRecord).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when pdsUrl is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:me' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useProfileRecord(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetProfileRecord).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when did is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { pdsUrl: 'https://pds' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useProfileRecord(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetProfileRecord).not.toHaveBeenCalled();
+  });
+});
+
+describe('isLoggedOutVisibilityDiscouraged', () => {
+  it('returns true when the !no-unauthenticated self-label is present', () => {
+    const record = {
+      value: { labels: { values: [{ val: '!no-unauthenticated' }] } },
+    };
+    expect(isLoggedOutVisibilityDiscouraged(record)).toBe(true);
+  });
+
+  it('returns false when the label is absent', () => {
+    expect(isLoggedOutVisibilityDiscouraged({ value: { labels: { values: [{ val: 'other' }] } } })).toBe(false);
+  });
+
+  it('returns false for null, missing labels, or missing values', () => {
+    expect(isLoggedOutVisibilityDiscouraged(null)).toBe(false);
+    expect(isLoggedOutVisibilityDiscouraged(undefined)).toBe(false);
+    expect(isLoggedOutVisibilityDiscouraged({ value: {} })).toBe(false);
+    expect(isLoggedOutVisibilityDiscouraged({ value: { labels: {} } })).toBe(false);
+  });
+});
+
+describe('isAccountAutomated', () => {
+  it('returns true when the automated self-label is present', () => {
+    const record = { value: { labels: { values: [{ val: 'automated' }] } } };
+    expect(isAccountAutomated(record)).toBe(true);
+  });
+
+  it('returns false when the label is absent', () => {
+    expect(isAccountAutomated({ value: { labels: { values: [{ val: 'other' }] } } })).toBe(false);
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useRpgInventory.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useRpgInventory.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useRpgInventory } from '@/hooks/queries/useRpgInventory';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { usePdsUrl } from '@/hooks/queries/usePdsUrl';
+
+const mockGetActorRpgInventory = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/usePdsUrl', () => ({
+  usePdsUrl: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getActorRpgInventory: mockGetActorRpgInventory,
+  })),
+}));
+
+describe('useRpgInventory query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { queryClient, wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (usePdsUrl as jest.Mock).mockReturnValue({ data: 'https://pds', isLoading: false });
+  });
+
+  it('fetches inventory items and flattens pages across fetchNextPage', async () => {
+    mockGetActorRpgInventory
+      .mockResolvedValueOnce({ records: [{ uri: 'i1' }], cursor: 'next' })
+      .mockResolvedValueOnce({ records: [{ uri: 'i2' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useRpgInventory('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorRpgInventory).toHaveBeenCalledWith('token', 'alice', 5, undefined);
+    expect(result.current.data).toEqual([{ uri: 'i1' }]);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ uri: 'i1' }, { uri: 'i2' }]);
+    });
+    expect(mockGetActorRpgInventory).toHaveBeenLastCalledWith('token', 'alice', 5, 'next');
+  });
+
+  it('defaults the limit to 50', async () => {
+    mockGetActorRpgInventory.mockResolvedValueOnce({ records: [], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useRpgInventory('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorRpgInventory).toHaveBeenCalledWith('token', 'alice', 50, undefined);
+  });
+
+  it('is disabled when there is no token', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useRpgInventory('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorRpgInventory).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when there is no identifier', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useRpgInventory(undefined, 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorRpgInventory).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when the PDS URL is missing', async () => {
+    (usePdsUrl as jest.Mock).mockReturnValue({ data: undefined, isLoading: false });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useRpgInventory('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorRpgInventory).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useSession.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useSession.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useSession } from '@/hooks/queries/useSession';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { apiForAccount } from '@/utils/blueskyApi';
+
+const mockGetSession = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+
+describe('useSession query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did:me', pdsUrl: 'https://pds' },
+    });
+    (apiForAccount as jest.Mock).mockReturnValue({ getSession: mockGetSession });
+  });
+
+  it('fetches the session for the current account', async () => {
+    const session = { handle: 'me.bsky.social', did: 'did:me', email: 'me@example.com' };
+    mockGetSession.mockResolvedValue(session);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSession(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(apiForAccount).toHaveBeenCalledWith({ did: 'did:me', pdsUrl: 'https://pds' });
+    expect(mockGetSession).toHaveBeenCalledWith('token');
+    expect(result.current.data).toEqual(session);
+  });
+
+  it('is disabled when token is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSession(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetSession).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when pdsUrl is missing', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'did:me' } });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSession(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetSession).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useSifaProfile.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useSifaProfile.test.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import {
+  useSifaSelf,
+  useSifaPositions,
+  useSifaEducation,
+  sortSifaPositions,
+  sortSifaEducation,
+} from '@/hooks/queries/useSifaProfile';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { usePdsUrl } from '@/hooks/queries/usePdsUrl';
+
+const mockGetSifaProfileSelf = jest.fn();
+const mockGetActorSifaPositions = jest.fn();
+const mockGetActorSifaEducation = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/usePdsUrl', () => ({
+  usePdsUrl: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getSifaProfileSelf: mockGetSifaProfileSelf,
+    getActorSifaPositions: mockGetActorSifaPositions,
+    getActorSifaEducation: mockGetActorSifaEducation,
+  })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+  (usePdsUrl as jest.Mock).mockReturnValue({ data: 'https://pds', isLoading: false });
+});
+
+describe('useSifaSelf query hook', () => {
+  it('reads the sifa self record', async () => {
+    mockGetSifaProfileSelf.mockResolvedValueOnce({ uri: 'self' });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSifaSelf('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetSifaProfileSelf).toHaveBeenCalledWith('token', 'alice');
+    expect(result.current.data).toEqual({ uri: 'self' });
+  });
+
+  it('returns null when the actor has no record', async () => {
+    mockGetSifaProfileSelf.mockResolvedValueOnce(null);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSifaSelf('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toBeNull();
+  });
+
+  it('is disabled when there is no token', async () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSifaSelf('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetSifaProfileSelf).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when the PDS URL is missing', async () => {
+    (usePdsUrl as jest.Mock).mockReturnValue({ data: undefined, isLoading: false });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSifaSelf('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetSifaProfileSelf).not.toHaveBeenCalled();
+  });
+});
+
+describe('useSifaPositions query hook', () => {
+  it('fetches positions and flattens pages across fetchNextPage', async () => {
+    mockGetActorSifaPositions
+      .mockResolvedValueOnce({ records: [{ uri: 'p1' }], cursor: 'next' })
+      .mockResolvedValueOnce({ records: [{ uri: 'p2' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSifaPositions('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorSifaPositions).toHaveBeenCalledWith('token', 'alice', 5, undefined);
+    expect(result.current.data).toEqual([{ uri: 'p1' }]);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ uri: 'p1' }, { uri: 'p2' }]);
+    });
+    expect(mockGetActorSifaPositions).toHaveBeenLastCalledWith('token', 'alice', 5, 'next');
+  });
+
+  it('defaults the limit to 50', async () => {
+    mockGetActorSifaPositions.mockResolvedValueOnce({ records: [], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSifaPositions('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorSifaPositions).toHaveBeenCalledWith('token', 'alice', 50, undefined);
+  });
+
+  it('is disabled when there is no identifier', async () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSifaPositions(undefined, 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorSifaPositions).not.toHaveBeenCalled();
+  });
+});
+
+describe('useSifaEducation query hook', () => {
+  it('fetches education and flattens pages across fetchNextPage', async () => {
+    mockGetActorSifaEducation
+      .mockResolvedValueOnce({ records: [{ uri: 'e1' }], cursor: 'next' })
+      .mockResolvedValueOnce({ records: [{ uri: 'e2' }], cursor: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSifaEducation('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetActorSifaEducation).toHaveBeenCalledWith('token', 'alice', 5, undefined);
+    expect(result.current.data).toEqual([{ uri: 'e1' }]);
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([{ uri: 'e1' }, { uri: 'e2' }]);
+    });
+    expect(mockGetActorSifaEducation).toHaveBeenLastCalledWith('token', 'alice', 5, 'next');
+  });
+
+  it('is disabled when the PDS URL is still loading', async () => {
+    (usePdsUrl as jest.Mock).mockReturnValue({ data: 'https://pds', isLoading: true });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSifaEducation('alice', 5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+    expect(mockGetActorSifaEducation).not.toHaveBeenCalled();
+  });
+});
+
+describe('sortSifaPositions helper', () => {
+  it('returns an empty array for undefined input', () => {
+    expect(sortSifaPositions(undefined)).toEqual([]);
+  });
+
+  it('floats primary positions to the top, then sorts by startedAt descending', () => {
+    const sorted = sortSifaPositions([
+      { uri: 'a', value: { startedAt: '2020-01-01' } },
+      { uri: 'b', value: { startedAt: '2022-01-01' } },
+      { uri: 'c', value: { isPrimary: true, startedAt: '2018-01-01' } },
+    ] as never);
+    expect(sorted.map((p) => p.uri)).toEqual(['c', 'b', 'a']);
+  });
+});
+
+describe('sortSifaEducation helper', () => {
+  it('returns an empty array for undefined input', () => {
+    expect(sortSifaEducation(undefined)).toEqual([]);
+  });
+
+  it('sorts by endedAt (falling back to startedAt) descending', () => {
+    const sorted = sortSifaEducation([
+      { uri: 'a', value: { endedAt: '2015-01-01' } },
+      { uri: 'b', value: { startedAt: '2021-01-01' } }, // still enrolled, uses startedAt
+      { uri: 'c', value: { endedAt: '2018-01-01' } },
+    ] as never);
+    expect(sorted.map((e) => e.uri)).toEqual(['b', 'c', 'a']);
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useSkyblurPost.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useSkyblurPost.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useSkyblurPost } from '@/hooks/queries/useSkyblurPost';
+import { resolveDidToPds } from '@/utils/oauth/discovery';
+
+jest.mock('@/utils/oauth/discovery', () => ({
+  resolveDidToPds: jest.fn(),
+}));
+
+const SKYBLUR_URL = 'https://skyblur.uk/post/did:plc:abc/rk1';
+const originalFetch = global.fetch;
+let fetchMock: jest.Mock;
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (resolveDidToPds as jest.Mock).mockResolvedValue('https://sky.pds');
+  fetchMock = jest.fn();
+  (global as unknown as { fetch: jest.Mock }).fetch = fetchMock;
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+describe('useSkyblurPost query hook', () => {
+  it('resolves the PDS and returns the decoded record', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        uri: 'at://did:plc:abc/uk.skyblur.post/rk1',
+        cid: 'cid1',
+        value: { text: 'my secret', additional: 'more', visibility: 'public' },
+      }),
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSkyblurPost(SKYBLUR_URL), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(resolveDidToPds).toHaveBeenCalledWith('did:plc:abc');
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('https://sky.pds/xrpc/com.atproto.repo.getRecord');
+    expect(calledUrl).toContain('collection=uk.skyblur.post');
+    expect(result.current.data).toEqual({
+      uri: 'at://did:plc:abc/uk.skyblur.post/rk1',
+      cid: 'cid1',
+      text: 'my secret',
+      additional: 'more',
+      visibility: 'public',
+    });
+  });
+
+  it('throws when the fetch fails', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 404 });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSkyblurPost(SKYBLUR_URL), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect((result.current.error as Error).message).toBe('Skyblur fetch failed: 404');
+  });
+
+  it('is disabled when the URL is not a Skyblur post', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSkyblurPost('https://example.com/foo'), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when the URL is null', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSkyblurPost(null), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useStandardDocument.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useStandardDocument.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useStandardDocument } from '@/hooks/queries/useStandardDocument';
+import { resolveDidToPds } from '@/utils/oauth/discovery';
+
+jest.mock('@/utils/oauth/discovery', () => ({
+  resolveDidToPds: jest.fn(),
+}));
+
+const originalFetch = global.fetch;
+let fetchMock: jest.Mock;
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (resolveDidToPds as jest.Mock).mockResolvedValue('https://doc.pds');
+  fetchMock = jest.fn();
+  (global as unknown as { fetch: jest.Mock }).fetch = fetchMock;
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+describe('useStandardDocument query hook', () => {
+  it('resolves the PDS and returns the record value', async () => {
+    const value = { title: 'Hello', publishedAt: '2024-01-01T00:00:00Z' };
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ uri: 'at://doc', cid: 'cid', value }),
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useStandardDocument({ did: 'did:author', rkey: 'rk1' }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(resolveDidToPds).toHaveBeenCalledWith('did:author');
+    const calledUrl = fetchMock.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('https://doc.pds/xrpc/com.atproto.repo.getRecord');
+    expect(calledUrl).toContain('repo=did%3Aauthor');
+    expect(calledUrl).toContain('collection=site.standard.document');
+    expect(calledUrl).toContain('rkey=rk1');
+    expect(result.current.data).toEqual(value);
+  });
+
+  it('throws when the getRecord request fails', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useStandardDocument({ did: 'did:author', rkey: 'rk1' }),
+      { wrapper },
+    );
+
+    // The hook sets `retry: 1`, so it retries once (with backoff) before
+    // surfacing the error — give waitFor extra headroom past the retry delay.
+    await waitFor(
+      () => {
+        expect(result.current.isError).toBe(true);
+      },
+      { timeout: 5000 },
+    );
+    expect((result.current.error as Error).message).toBe('getRecord failed: 500');
+  });
+
+  it('is disabled when the ref is null', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useStandardDocument(null), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when the rkey is missing', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(
+      () => useStandardDocument({ did: 'did:author', rkey: '' }),
+      { wrapper },
+    );
+
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useSuggestedFollows.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useSuggestedFollows.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useSuggestedFollows } from '@/hooks/queries/useSuggestedFollows';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useAcceptLabelerDids } from '@/hooks/queries/useAcceptLabelerDids';
+
+const mockGetSuggestions = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useAcceptLabelerDids', () => ({
+  useAcceptLabelerDids: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({ getSuggestions: mockGetSuggestions })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+  (useCurrentAccount as jest.Mock).mockReturnValue({
+    data: { pdsUrl: 'https://pds', did: 'did:me' },
+  });
+  (useAcceptLabelerDids as jest.Mock).mockReturnValue(['did:labeler']);
+});
+
+describe('useSuggestedFollows query hook', () => {
+  it('fetches suggestions and dedupes actors by DID', async () => {
+    mockGetSuggestions.mockResolvedValueOnce({
+      actors: [
+        { did: 'did:a' },
+        { did: 'did:a' },
+        { did: 'did:b' },
+        { did: undefined },
+      ],
+    });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSuggestedFollows(7), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetSuggestions).toHaveBeenCalledWith('token', {
+      limit: 7,
+      acceptLabelers: ['did:labeler'],
+    });
+    expect(result.current.data).toEqual([{ did: 'did:a' }, { did: 'did:b' }]);
+  });
+
+  it('respects the enabled flag', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSuggestedFollows(5, false), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetSuggestions).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when token is missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSuggestedFollows(), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetSuggestions).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useThreadPreferences.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useThreadPreferences.test.tsx
@@ -1,0 +1,60 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { useThreadPreferences } from '@/hooks/queries/useThreadPreferences';
+import { usePreferences } from '@/hooks/queries/usePreferences';
+
+jest.mock('@/hooks/queries/usePreferences', () => ({
+  usePreferences: jest.fn(),
+}));
+
+const PREF_TYPE = 'app.bsky.actor.defs#threadViewPref';
+
+describe('useThreadPreferences query hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns defaults when there is no data', () => {
+    (usePreferences as jest.Mock).mockReturnValue({ data: undefined, isLoading: true });
+
+    const { result } = renderHook(() => useThreadPreferences());
+
+    expect(result.current.data).toEqual({ sort: 'hotness', prioritizeFollowedUsers: false });
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns defaults when the pref is absent', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: 'other' }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useThreadPreferences());
+
+    expect(result.current.data).toEqual({ sort: 'hotness', prioritizeFollowedUsers: false });
+  });
+
+  it('decodes the pref values', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: {
+        preferences: [{ $type: PREF_TYPE, sort: 'newest', prioritizeFollowedUsers: true }],
+      },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useThreadPreferences());
+
+    expect(result.current.data).toEqual({ sort: 'newest', prioritizeFollowedUsers: true });
+  });
+
+  it('falls back to defaults for individual missing fields', () => {
+    (usePreferences as jest.Mock).mockReturnValue({
+      data: { preferences: [{ $type: PREF_TYPE }] },
+      isLoading: false,
+    });
+
+    const { result } = renderHook(() => useThreadPreferences());
+
+    expect(result.current.data).toEqual({ sort: 'hotness', prioritizeFollowedUsers: false });
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useTrendingTopics.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useTrendingTopics.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useTrendingTopics } from '@/hooks/queries/useTrendingTopics';
+import { useAppViewEnabled } from '@/hooks/useAppViewEnabled';
+import { readAppViewEnabled, useAppViewSettings } from '@/hooks/useAppViewSettings';
+
+const mockGetTrendingTopics = jest.fn();
+
+jest.mock('@/hooks/useAppViewEnabled', () => ({
+  useAppViewEnabled: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewEnabled: jest.fn(),
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+  useAppViewSettings: jest.fn(),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getTrendingTopics: mockGetTrendingTopics,
+  })),
+}));
+
+describe('useTrendingTopics query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useAppViewEnabled as jest.Mock).mockReturnValue(true);
+    (readAppViewEnabled as jest.Mock).mockReturnValue(true);
+    (useAppViewSettings as jest.Mock).mockReturnValue({
+      config: { preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true },
+    });
+  });
+
+  it('fetches trending topics and unwraps the topics array', async () => {
+    const topics = [{ topic: 'news', link: '/search?q=news' }];
+    mockGetTrendingTopics.mockResolvedValueOnce({ topics });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useTrendingTopics(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetTrendingTopics).toHaveBeenCalledWith(12);
+    expect(result.current.data).toEqual(topics);
+  });
+
+  it('passes a custom limit to the API', async () => {
+    mockGetTrendingTopics.mockResolvedValueOnce({ topics: [] });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useTrendingTopics(5), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockGetTrendingTopics).toHaveBeenCalledWith(5);
+  });
+
+  it('throws AppViewRequiredError when the AppView is disabled', async () => {
+    (readAppViewEnabled as jest.Mock).mockReturnValue(false);
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useTrendingTopics(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect((result.current.error as Error).message).toContain('trendingTopics');
+    expect(mockGetTrendingTopics).not.toHaveBeenCalled();
+  });
+
+  it('is disabled when the enabled flag is false', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useTrendingTopics(12, false), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetTrendingTopics).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useTypeaheadActors.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useTypeaheadActors.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useTypeaheadActors } from '@/hooks/queries/useTypeaheadActors';
+import { useAppViewSettings } from '@/hooks/useAppViewSettings';
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  useAppViewSettings: jest.fn(),
+}));
+
+describe('useTypeaheadActors query hook', () => {
+  const createWrapper = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return { wrapper };
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    (useAppViewSettings as jest.Mock).mockReturnValue({
+      config: { preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true },
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('does not query for below-threshold input and returns empty data', () => {
+    const { wrapper } = createWrapper();
+    global.fetch = jest.fn() as unknown as typeof fetch;
+
+    const { result } = renderHook(() => useTypeaheadActors('a'), { wrapper });
+
+    expect(result.current.data).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('debounces then fetches typeahead actors and strips the leading @', async () => {
+    const actors = [{ did: 'did:plc:1', handle: 'alice.bsky.social' }];
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ actors }),
+    }) as unknown as typeof fetch;
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useTypeaheadActors('@alice'), { wrapper });
+
+    // Debounce timer (250ms) must fire before the query commits.
+    await waitFor(() => {
+      jest.advanceTimersByTime(250);
+      expect(result.current.data).toEqual(actors);
+    });
+
+    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as URL;
+    expect(calledUrl.toString()).toBe(
+      'https://public.api.bsky.app/xrpc/app.bsky.actor.searchActorsTypeahead?q=alice&limit=8',
+    );
+  });
+
+  it('returns an empty array when the request is not ok', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ actors: [{ did: 'x', handle: 'x' }] }),
+    }) as unknown as typeof fetch;
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useTypeaheadActors('alice'), { wrapper });
+
+    await waitFor(() => {
+      jest.advanceTimersByTime(250);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(result.current.data).toEqual([]);
+    });
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useUserStories.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useUserStories.test.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useUserStories } from '@/hooks/queries/useUserStories';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { usePdsUrl } from '@/hooks/queries/usePdsUrl';
+import { buildStoryBlobUrl, findStoryImageBlob } from '@/utils/storyMedia';
+
+const mockGetActorFlashesStories = jest.fn();
+const mockGetActorSparkStories = jest.fn();
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({
+  useJwtToken: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/usePdsUrl', () => ({
+  usePdsUrl: jest.fn(),
+}));
+
+jest.mock('@/utils/storyMedia', () => ({
+  buildStoryBlobUrl: jest.fn(),
+  findStoryImageBlob: jest.fn(),
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewSettings: jest.fn(() => ({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true })),
+}));
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: jest.fn(() => ({
+    getActorFlashesStories: mockGetActorFlashesStories,
+    getActorSparkStories: mockGetActorSparkStories,
+  })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper };
+};
+
+const futureCreatedAt = new Date(Date.now() - 60_000).toISOString(); // recent, well within 24h
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+  (usePdsUrl as jest.Mock).mockReturnValue({ data: 'https://pds', isLoading: false });
+  (findStoryImageBlob as jest.Mock).mockReturnValue({ cid: 'blobcid', mimeType: 'image/jpeg', size: 123 });
+  (buildStoryBlobUrl as jest.Mock).mockReturnValue('https://pds/blob/url');
+});
+
+describe('useUserStories hook', () => {
+  it('returns active story images from flashes and spark records', async () => {
+    mockGetActorFlashesStories.mockResolvedValueOnce({
+      records: [
+        {
+          uri: 'at://did:author/blue.flashes.story.post/1',
+          value: { createdAt: futureCreatedAt, expiresInMinutes: 1440 },
+        },
+      ],
+    });
+    mockGetActorSparkStories.mockResolvedValueOnce({ records: [] });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useUserStories('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.hasActiveStory).toBe(true);
+    });
+    expect(mockGetActorFlashesStories).toHaveBeenCalledWith('token', 'alice', 50);
+    expect(mockGetActorSparkStories).toHaveBeenCalledWith('token', 'alice', 50);
+    expect(result.current.images).toEqual([
+      { url: 'https://pds/blob/url', mimeType: 'image/jpeg', sizeBytes: 123 },
+    ]);
+  });
+
+  it('filters out expired stories', async () => {
+    mockGetActorFlashesStories.mockResolvedValueOnce({
+      records: [
+        {
+          uri: 'at://did:author/blue.flashes.story.post/old',
+          value: { createdAt: '2000-01-01T00:00:00Z', expiresInMinutes: 1440 },
+        },
+      ],
+    });
+    mockGetActorSparkStories.mockResolvedValueOnce({ records: [] });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useUserStories('alice'), { wrapper });
+
+    await waitFor(() => {
+      expect(mockGetActorFlashesStories).toHaveBeenCalled();
+    });
+    expect(result.current.hasActiveStory).toBe(false);
+    expect(result.current.images).toEqual([]);
+  });
+
+  it('returns no stories and skips fetching when there is no identifier', () => {
+    (usePdsUrl as jest.Mock).mockReturnValue({ data: undefined, isLoading: false });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useUserStories(undefined), { wrapper });
+
+    expect(result.current.images).toEqual([]);
+    expect(result.current.hasActiveStory).toBe(false);
+    expect(mockGetActorFlashesStories).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch while the PDS URL is still loading', () => {
+    (usePdsUrl as jest.Mock).mockReturnValue({ data: 'https://pds', isLoading: true });
+    const { wrapper } = createWrapper();
+
+    renderHook(() => useUserStories('alice'), { wrapper });
+
+    expect(mockGetActorFlashesStories).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/queries/useVerifiersForDid.test.tsx
+++ b/apps/akari/__tests__/hooks/queries/useVerifiersForDid.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useVerifiersForDid } from '@/hooks/queries/useVerifiersForDid';
+import { createConstellationApi } from '@/constellation-api';
+
+const mockGetDistinctDids = jest.fn();
+
+jest.mock('@/constellation-api', () => ({
+  createConstellationApi: jest.fn(() => ({ getDistinctDids: mockGetDistinctDids })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('useVerifiersForDid query hook', () => {
+  it('queries Constellation for distinct verifier DIDs', async () => {
+    mockGetDistinctDids.mockResolvedValueOnce({ linking_dids: ['did:v1', 'did:v2'] });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useVerifiersForDid('did:subject'), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(createConstellationApi).toHaveBeenCalled();
+    expect(mockGetDistinctDids).toHaveBeenCalledWith({
+      target: 'did:subject',
+      collection: 'app.bsky.graph.verification',
+      path: '.subject',
+    });
+    expect(result.current.data).toEqual(['did:v1', 'did:v2']);
+  });
+
+  it('is disabled when no subject DID is provided', () => {
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useVerifiersForDid(undefined), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockGetDistinctDids).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/useCreateAccount.test.tsx
+++ b/apps/akari/__tests__/hooks/useCreateAccount.test.tsx
@@ -1,0 +1,297 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useAddAccount } from '@/hooks/mutations/useAddAccount';
+import { useCreateAccount as useCreateAccountMutation } from '@/hooks/mutations/useCreateAccount';
+import { useSwitchAccount } from '@/hooks/mutations/useSwitchAccount';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useConfirm } from '@/hooks/useConfirm';
+import { useCreateAccount, type CreateAccountInput } from '@/hooks/useCreateAccount';
+
+jest.mock('@/hooks/mutations/useAddAccount', () => ({ useAddAccount: jest.fn() }));
+jest.mock('@/hooks/mutations/useCreateAccount', () => ({ useCreateAccount: jest.fn() }));
+jest.mock('@/hooks/mutations/useSwitchAccount', () => ({ useSwitchAccount: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/useConfirm', () => ({ useConfirm: jest.fn() }));
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockConfirm = jest.fn();
+const mockCreateMutateAsync = jest.fn();
+const mockAddMutateAsync = jest.fn();
+const mockSwitchMutateAsync = jest.fn();
+
+const validBskyInput: CreateAccountInput = {
+  provider: 'bsky',
+  email: 'alice@example.com',
+  password: 'supersecret',
+  handle: 'alice',
+  handleSuffix: '.bsky.social',
+};
+
+const session = {
+  did: 'did:plc:alice',
+  handle: 'alice.bsky.social',
+  accessJwt: 'access',
+  refreshJwt: 'refresh',
+  profile: { displayName: 'Alice', avatar: 'https://avatar' },
+};
+
+function setup() {
+  return renderHook(() => useCreateAccount());
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useConfirm as jest.Mock).mockReturnValue(mockConfirm);
+  (useCurrentAccount as jest.Mock).mockReturnValue({ data: undefined });
+  (useCreateAccountMutation as jest.Mock).mockReturnValue({
+    mutateAsync: mockCreateMutateAsync,
+    isPending: false,
+  });
+  (useAddAccount as jest.Mock).mockReturnValue({ mutateAsync: mockAddMutateAsync });
+  (useSwitchAccount as jest.Mock).mockReturnValue({ mutateAsync: mockSwitchMutateAsync });
+
+  mockCreateMutateAsync.mockResolvedValue(session);
+  mockAddMutateAsync.mockResolvedValue({ did: 'did:plc:alice' });
+  mockSwitchMutateAsync.mockResolvedValue(undefined);
+});
+
+describe('useCreateAccount', () => {
+  it('exposes the loading flag from the create mutation', () => {
+    (useCreateAccountMutation as jest.Mock).mockReturnValue({
+      mutateAsync: mockCreateMutateAsync,
+      isPending: true,
+    });
+    const { result } = setup();
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('reports whether there is already a current account', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'x' } });
+    const { result } = setup();
+    expect(result.current.hasCurrentAccount).toBe(true);
+  });
+
+  it('runs the full create -> add -> switch flow and redirects home', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount(validBskyInput);
+    });
+
+    expect(mockCreateMutateAsync).toHaveBeenCalledWith({
+      email: 'alice@example.com',
+      handle: 'alice.bsky.social',
+      password: 'supersecret',
+      inviteCode: undefined,
+      pdsUrl: 'https://bsky.social',
+    });
+    expect(mockAddMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        did: 'did:plc:alice',
+        handle: 'alice.bsky.social',
+        displayName: 'Alice',
+        avatar: 'https://avatar',
+        jwtToken: 'access',
+        refreshToken: 'refresh',
+        pdsUrl: 'https://bsky.social',
+      }),
+    );
+    expect(mockSwitchMutateAsync).toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(result.current.redirectAfterAuth).toBe('/');
+    });
+  });
+
+  it('redirects to settings when adding a second account', async () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: { did: 'existing' } });
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount(validBskyInput);
+    });
+
+    await waitFor(() => {
+      expect(result.current.redirectAfterAuth).toBe('/(tabs)/settings');
+    });
+  });
+
+  it('passes a trimmed invite code through to the mutation', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount({ ...validBskyInput, inviteCode: '  abc-123  ' });
+    });
+
+    expect(mockCreateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ inviteCode: 'abc-123' }),
+    );
+  });
+
+  it('falls back to the handle for displayName when the profile is missing', async () => {
+    mockCreateMutateAsync.mockResolvedValueOnce({ ...session, profile: undefined });
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount(validBskyInput);
+    });
+
+    expect(mockAddMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ displayName: 'alice.bsky.social', avatar: undefined }),
+    );
+  });
+
+  it('validates required fields before hitting the network', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount({ ...validBskyInput, email: '   ' });
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'auth.fillAllFields' }),
+    );
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed email', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount({ ...validBskyInput, email: 'not-an-email' });
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'auth.signupInvalidEmail' }),
+    );
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('rejects a too-short password', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount({ ...validBskyInput, password: 'short' });
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'auth.signupPasswordTooShort' }),
+    );
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('rejects a too-short handle for a preset provider', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount({ ...validBskyInput, handle: 'ab' });
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'auth.signupHandleTooShort' }),
+    );
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid handle local part for a preset provider', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount({ ...validBskyInput, handle: 'bad_handle!' });
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'auth.signupHandleInvalid' }),
+    );
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('creates an account on a custom PDS with a full handle', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount({
+        provider: 'custom',
+        email: 'alice@example.com',
+        password: 'supersecret',
+        handle: 'me.example.com',
+        pdsUrl: 'https://pds.example.com/',
+      });
+    });
+
+    expect(mockCreateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        handle: 'me.example.com',
+        // trailing slash trimmed
+        pdsUrl: 'https://pds.example.com',
+      }),
+    );
+  });
+
+  it('rejects an invalid custom PDS url', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount({
+        provider: 'custom',
+        email: 'alice@example.com',
+        password: 'supersecret',
+        handle: 'me.example.com',
+        pdsUrl: 'ftp://not-https',
+      });
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'auth.signupCustomInvalidPdsUrl' }),
+    );
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid custom full handle', async () => {
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount({
+        provider: 'custom',
+        email: 'alice@example.com',
+        password: 'supersecret',
+        handle: 'nodot',
+        pdsUrl: 'https://pds.example.com',
+      });
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'auth.signupCustomInvalidHandle' }),
+    );
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the error message when account creation throws', async () => {
+    mockCreateMutateAsync.mockRejectedValueOnce(new Error('PDS rejected handle'));
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount(validBskyInput);
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'PDS rejected handle' }),
+    );
+    expect(result.current.redirectAfterAuth).toBeNull();
+  });
+
+  it('falls back to a generic message for non-Error throws', async () => {
+    mockCreateMutateAsync.mockRejectedValueOnce('weird');
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.createAccount(validBskyInput);
+    });
+
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'auth.signupFailedGeneric' }),
+    );
+  });
+});

--- a/apps/akari/__tests__/hooks/useExternalMediaSettings.test.tsx
+++ b/apps/akari/__tests__/hooks/useExternalMediaSettings.test.tsx
@@ -1,0 +1,49 @@
+import { renderHook, act } from '@testing-library/react-native';
+
+import { useExternalMediaSettings } from '@/hooks/useExternalMediaSettings';
+
+describe('useExternalMediaSettings', () => {
+  it('defaults both providers to enabled', () => {
+    const { result } = renderHook(() => useExternalMediaSettings());
+    expect(result.current.youtubeEnabled).toBe(true);
+    expect(result.current.gifEnabled).toBe(true);
+  });
+
+  it('toggles the youtube provider', () => {
+    const { result } = renderHook(() => useExternalMediaSettings());
+
+    act(() => {
+      result.current.setYoutubeEnabled(false);
+    });
+    expect(result.current.youtubeEnabled).toBe(false);
+    // gif is untouched
+    expect(result.current.gifEnabled).toBe(true);
+
+    act(() => {
+      result.current.setYoutubeEnabled(true);
+    });
+    expect(result.current.youtubeEnabled).toBe(true);
+  });
+
+  it('toggles the gif provider independently', () => {
+    const { result } = renderHook(() => useExternalMediaSettings());
+
+    act(() => {
+      result.current.setGifEnabled(false);
+    });
+    expect(result.current.gifEnabled).toBe(false);
+    expect(result.current.youtubeEnabled).toBe(true);
+  });
+
+  it('propagates changes to other mounted consumers', () => {
+    const a = renderHook(() => useExternalMediaSettings());
+    const b = renderHook(() => useExternalMediaSettings());
+
+    act(() => {
+      a.result.current.setGifEnabled(false);
+    });
+
+    expect(a.result.current.gifEnabled).toBe(false);
+    expect(b.result.current.gifEnabled).toBe(false);
+  });
+});

--- a/apps/akari/__tests__/hooks/useFavicon.test.tsx
+++ b/apps/akari/__tests__/hooks/useFavicon.test.tsx
@@ -1,0 +1,96 @@
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+import { useFavicon } from '@/hooks/useFavicon';
+import { fetchFavicon, getDomainFromUrl } from '@/utils/faviconUtils';
+
+jest.mock('@/utils/faviconUtils', () => ({
+  fetchFavicon: jest.fn(),
+  getDomainFromUrl: jest.fn(),
+}));
+
+describe('useFavicon', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getDomainFromUrl as jest.Mock).mockImplementation((url: string) => `domain(${url})`);
+  });
+
+  it('fetches and exposes the favicon url for a plain url', async () => {
+    (fetchFavicon as jest.Mock).mockResolvedValueOnce('https://favicon.test/icon.png');
+
+    const { result } = renderHook(() => useFavicon('https://example.com'));
+
+    // starts loading immediately
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.domain).toBe('domain(https://example.com)');
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.faviconUrl).toBe('https://favicon.test/icon.png');
+    expect(fetchFavicon).toHaveBeenCalledWith('https://example.com');
+  });
+
+  it('does not fetch when an emoji is provided', () => {
+    const { result } = renderHook(() => useFavicon('https://example.com', '🔥'));
+
+    expect(fetchFavicon).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.faviconUrl).toBeNull();
+  });
+
+  it('treats a whitespace-only emoji as absent and still fetches', async () => {
+    (fetchFavicon as jest.Mock).mockResolvedValueOnce('https://favicon.test/icon.png');
+
+    const { result } = renderHook(() => useFavicon('https://example.com', '   '));
+
+    await waitFor(() => {
+      expect(result.current.faviconUrl).toBe('https://favicon.test/icon.png');
+    });
+    expect(fetchFavicon).toHaveBeenCalled();
+  });
+
+  it('does not fetch when the url is empty', () => {
+    const { result } = renderHook(() => useFavicon(''));
+
+    expect(fetchFavicon).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.faviconUrl).toBeNull();
+  });
+
+  it('clears the favicon when the fetch rejects', async () => {
+    (fetchFavicon as jest.Mock).mockRejectedValueOnce(new Error('boom'));
+
+    const { result } = renderHook(() => useFavicon('https://example.com'));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.faviconUrl).toBeNull();
+  });
+
+  it('ignores a resolved fetch after the url changes (cancellation)', async () => {
+    let resolveFirst: (value: string | null) => void = () => {};
+    (fetchFavicon as jest.Mock)
+      .mockImplementationOnce(
+        () =>
+          new Promise<string | null>((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce('https://favicon.test/second.png');
+
+    const { result, rerender } = renderHook(({ url }: { url: string }) => useFavicon(url), {
+      initialProps: { url: 'https://first.com' },
+    });
+
+    // swap url before the first promise resolves
+    rerender({ url: 'https://second.com' });
+
+    // resolve the now-cancelled first fetch
+    resolveFirst('https://favicon.test/first.png');
+
+    await waitFor(() => {
+      expect(result.current.faviconUrl).toBe('https://favicon.test/second.png');
+    });
+  });
+});

--- a/apps/akari/__tests__/hooks/useFollowingCleanupController.test.tsx
+++ b/apps/akari/__tests__/hooks/useFollowingCleanupController.test.tsx
@@ -1,0 +1,248 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import { useFollowingCleanupController } from '@/hooks/useFollowingCleanupController';
+import { useJwtToken } from '@/hooks/queries/useJwtToken';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useFollowUser } from '@/hooks/mutations/useFollowUser';
+import { useToast } from '@/contexts/ToastContext';
+import { apiForAccount } from '@/utils/blueskyApi';
+import {
+  getFollowingCleanupController,
+  initialFollowingCleanupState,
+} from '@/utils/followingCleanupController';
+
+jest.mock('@/hooks/queries/useJwtToken', () => ({ useJwtToken: jest.fn() }));
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({ useCurrentAccount: jest.fn() }));
+jest.mock('@/hooks/mutations/useFollowUser', () => ({ useFollowUser: jest.fn() }));
+jest.mock('@/utils/blueskyApi', () => ({ apiForAccount: jest.fn() }));
+jest.mock('@/utils/followingCleanupController', () => ({
+  getFollowingCleanupController: jest.fn(),
+  followingCleanupQueryKey: (did: string | undefined) => ['followingCleanup', did],
+  initialFollowingCleanupState: jest.fn(() => ({
+    entries: {},
+    totalDiscovered: 0,
+    totalScanned: 0,
+    paginationDone: false,
+    runState: 'idle',
+  })),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+};
+
+type Ctrl = {
+  getState: jest.Mock;
+  start: jest.Mock;
+  pause: jest.Mock;
+  clear: jest.Mock;
+  removeProfile: jest.Mock;
+  restoreEntry: jest.Mock;
+};
+
+function makeController(): Ctrl {
+  return {
+    getState: jest.fn(() => initialFollowingCleanupState()),
+    start: jest.fn(() => Promise.resolve()),
+    pause: jest.fn(),
+    clear: jest.fn(),
+    removeProfile: jest.fn(),
+    restoreEntry: jest.fn(),
+  };
+}
+
+describe('useFollowingCleanupController', () => {
+  const mutate = jest.fn();
+  let controller: Ctrl;
+  let showToast: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    controller = makeController();
+    (getFollowingCleanupController as jest.Mock).mockReturnValue(controller);
+    (useJwtToken as jest.Mock).mockReturnValue({ data: 'token' });
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did:plc:me', pdsUrl: 'https://pds' },
+    });
+    (useFollowUser as jest.Mock).mockReturnValue({ mutate, isPending: false });
+    (apiForAccount as jest.Mock).mockReturnValue({ id: 'api' });
+    showToast = jest.fn();
+    (useToast as jest.Mock).mockReturnValue({ showToast, hideToast: jest.fn() });
+  });
+
+  it('exposes account context, initial state and pending flag', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    expect(result.current.accountDid).toBe('did:plc:me');
+    expect(result.current.token).toBe('token');
+    expect(result.current.state.runState).toBe('idle');
+    expect(result.current.unfollowPending).toBe(false);
+  });
+
+  it('start() invokes the controller with the api and token', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    act(() => {
+      result.current.start();
+    });
+
+    expect(apiForAccount).toHaveBeenCalledWith({ did: 'did:plc:me', pdsUrl: 'https://pds' });
+    expect(controller.start).toHaveBeenCalledWith({ api: { id: 'api' }, token: 'token' });
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it('start() shows an error toast and bails when credentials are missing', () => {
+    (useJwtToken as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    act(() => {
+      result.current.start();
+    });
+
+    expect(controller.start).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith({ type: 'error', message: 'common.somethingWentWrong' });
+  });
+
+  it('start() surfaces a toast and logs if the controller scan rejects', async () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    controller.start.mockReturnValue(Promise.reject(new Error('boom')));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    await act(async () => {
+      result.current.start();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(showToast).toHaveBeenCalledWith({ type: 'error', message: 'common.somethingWentWrong' });
+    });
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it('pause() and clear() delegate to the controller', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    act(() => {
+      result.current.pause();
+      result.current.clear();
+    });
+
+    expect(controller.pause).toHaveBeenCalledTimes(1);
+    expect(controller.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('pause() and clear() no-op when there is no account did', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: undefined });
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    act(() => {
+      result.current.pause();
+      result.current.clear();
+    });
+
+    expect(controller.pause).not.toHaveBeenCalled();
+    expect(controller.clear).not.toHaveBeenCalled();
+  });
+
+  it('unfollow() optimistically removes the profile and fires the mutation', () => {
+    const profile = {
+      did: 'did:plc:target',
+      viewer: { following: 'at://follow/uri' },
+    } as never;
+    controller.getState.mockReturnValue({
+      ...initialFollowingCleanupState(),
+      entries: { 'did:plc:target': { profile, status: 'done', lastActivityAt: null, followedAt: null } },
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    act(() => {
+      result.current.unfollow(profile);
+    });
+
+    expect(controller.removeProfile).toHaveBeenCalledWith('did:plc:target');
+    expect(mutate).toHaveBeenCalledWith(
+      { did: 'did:plc:target', followUri: 'at://follow/uri', action: 'unfollow' },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
+  });
+
+  it('unfollow() restores the entry and toasts on mutation error', () => {
+    const previousEntry = {
+      profile: { did: 'did:plc:target' },
+      status: 'done',
+      lastActivityAt: null,
+      followedAt: null,
+    };
+    const profile = {
+      did: 'did:plc:target',
+      viewer: { following: 'at://follow/uri' },
+    } as never;
+    controller.getState.mockReturnValue({
+      ...initialFollowingCleanupState(),
+      entries: { 'did:plc:target': previousEntry },
+    });
+    mutate.mockImplementation((_vars, opts) => opts.onError());
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    act(() => {
+      result.current.unfollow(profile);
+    });
+
+    expect(controller.restoreEntry).toHaveBeenCalledWith(previousEntry);
+    expect(showToast).toHaveBeenCalledWith({
+      type: 'error',
+      message: 'settings.followingCleanup.unfollowFailed',
+    });
+  });
+
+  it('unfollow() shows an error and bails when there is no follow uri', () => {
+    const profile = { did: 'did:plc:target', viewer: {} } as never;
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    act(() => {
+      result.current.unfollow(profile);
+    });
+
+    expect(mutate).not.toHaveBeenCalled();
+    expect(controller.removeProfile).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith({
+      type: 'error',
+      message: 'settings.followingCleanup.unfollowFailed',
+    });
+  });
+
+  it('reconciles cached state with the live controller on mount', async () => {
+    const liveState = {
+      ...initialFollowingCleanupState(),
+      runState: 'paused' as const,
+      entries: { 'did:plc:x': { profile: { did: 'did:plc:x' }, status: 'done', lastActivityAt: null, followedAt: null } },
+    };
+    controller.getState.mockReturnValue(liveState);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useFollowingCleanupController(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.state.runState).toBe('paused');
+    });
+    expect(result.current.state.entries['did:plc:x']).toBeDefined();
+  });
+});

--- a/apps/akari/__tests__/hooks/useFollowingCleanupFilters.test.tsx
+++ b/apps/akari/__tests__/hooks/useFollowingCleanupFilters.test.tsx
@@ -1,0 +1,184 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { useFollowingCleanupFilters } from '@/hooks/useFollowingCleanupFilters';
+import type { FollowingCleanupEntry, FollowingCleanupState } from '@/utils/followingCleanupController';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = new Date('2026-05-29T00:00:00.000Z').getTime();
+
+function makeEntry(overrides: Partial<FollowingCleanupEntry> & { did: string }): FollowingCleanupEntry {
+  const { did, profile, ...rest } = overrides;
+  return {
+    status: 'done',
+    lastActivityAt: null,
+    followedAt: null,
+    ...rest,
+    profile: {
+      did,
+      handle: `${did}.test`,
+      ...profile,
+    } as FollowingCleanupEntry['profile'],
+  };
+}
+
+function makeState(entries: FollowingCleanupEntry[]): FollowingCleanupState {
+  const map: FollowingCleanupState['entries'] = {};
+  for (const e of entries) map[e.profile.did] = e;
+  return {
+    entries: map,
+    totalDiscovered: entries.length,
+    totalScanned: entries.length,
+    paginationDone: true,
+    runState: 'completed',
+  };
+}
+
+describe('useFollowingCleanupFilters', () => {
+  it('excludes entries that are not done', () => {
+    const state = makeState([
+      makeEntry({ did: 'pending', status: 'pending', lastActivityAt: null }),
+      makeEntry({ did: 'done', status: 'done', lastActivityAt: null }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(), 'never', 'lastActivity', NOW),
+    );
+    expect(result.current.filteredFollows.map((e) => e.profile.did)).toEqual(['done']);
+  });
+
+  it('excludes skipped dids from filteredFollows', () => {
+    const state = makeState([
+      makeEntry({ did: 'a', lastActivityAt: null }),
+      makeEntry({ did: 'b', lastActivityAt: null }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(['a']), 'never', 'lastActivity', NOW),
+    );
+    expect(result.current.filteredFollows.map((e) => e.profile.did)).toEqual(['b']);
+  });
+
+  it("threshold 'never' only keeps entries with null lastActivity", () => {
+    const state = makeState([
+      makeEntry({ did: 'silent', lastActivityAt: null }),
+      makeEntry({ did: 'active', lastActivityAt: new Date(NOW).toISOString() }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(), 'never', 'lastActivity', NOW),
+    );
+    expect(result.current.filteredFollows.map((e) => e.profile.did)).toEqual(['silent']);
+  });
+
+  it('numeric threshold keeps null-activity entries and entries older than the cutoff', () => {
+    const state = makeState([
+      makeEntry({ did: 'null', lastActivityAt: null }),
+      makeEntry({ did: 'old', lastActivityAt: new Date(NOW - 40 * DAY_MS).toISOString() }),
+      makeEntry({ did: 'recent', lastActivityAt: new Date(NOW - 10 * DAY_MS).toISOString() }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(), 30, 'lastActivity', NOW),
+    );
+    const dids = result.current.filteredFollows.map((e) => e.profile.did);
+    expect(dids).toContain('null');
+    expect(dids).toContain('old');
+    expect(dids).not.toContain('recent');
+  });
+
+  it('sorts by lastActivity ascending (oldest first, null treated as 0)', () => {
+    const state = makeState([
+      makeEntry({ did: 'newer', lastActivityAt: new Date(NOW - 40 * DAY_MS).toISOString() }),
+      makeEntry({ did: 'older', lastActivityAt: new Date(NOW - 100 * DAY_MS).toISOString() }),
+      makeEntry({ did: 'null', lastActivityAt: null }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(), 30, 'lastActivity', NOW),
+    );
+    expect(result.current.filteredFollows.map((e) => e.profile.did)).toEqual([
+      'null',
+      'older',
+      'newer',
+    ]);
+  });
+
+  it('sorts by followedAt with null sorting to the bottom', () => {
+    const state = makeState([
+      makeEntry({ did: 'recentFollow', lastActivityAt: null, followedAt: new Date(NOW - 5 * DAY_MS).toISOString() }),
+      makeEntry({ did: 'oldFollow', lastActivityAt: null, followedAt: new Date(NOW - 500 * DAY_MS).toISOString() }),
+      makeEntry({ did: 'noFollow', lastActivityAt: null, followedAt: null }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(), 'never', 'followedAt', NOW),
+    );
+    expect(result.current.filteredFollows.map((e) => e.profile.did)).toEqual([
+      'oldFollow',
+      'recentFollow',
+      'noFollow',
+    ]);
+  });
+
+  it('sorts by fewestPosts ascending (missing count treated as 0)', () => {
+    const state = makeState([
+      makeEntry({ did: 'many', lastActivityAt: null, profile: { postsCount: 100 } as never }),
+      makeEntry({ did: 'few', lastActivityAt: null, profile: { postsCount: 2 } as never }),
+      makeEntry({ did: 'none', lastActivityAt: null }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(), 'never', 'fewestPosts', NOW),
+    );
+    expect(result.current.filteredFollows.map((e) => e.profile.did)).toEqual([
+      'none',
+      'few',
+      'many',
+    ]);
+  });
+
+  it('sorts by mostFollowers descending (missing count treated as 0)', () => {
+    const state = makeState([
+      makeEntry({ did: 'small', lastActivityAt: null, profile: { followersCount: 5 } as never }),
+      makeEntry({ did: 'big', lastActivityAt: null, profile: { followersCount: 9000 } as never }),
+      makeEntry({ did: 'none', lastActivityAt: null }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(), 'never', 'mostFollowers', NOW),
+    );
+    expect(result.current.filteredFollows.map((e) => e.profile.did)).toEqual([
+      'big',
+      'small',
+      'none',
+    ]);
+  });
+
+  it('followedAt sort handles both present and missing followedAt on either side', () => {
+    const state = makeState([
+      makeEntry({ did: 'hasFollow', lastActivityAt: null, followedAt: new Date(NOW - 3 * DAY_MS).toISOString() }),
+      makeEntry({ did: 'noFollowA', lastActivityAt: null, followedAt: null }),
+      makeEntry({ did: 'noFollowB', lastActivityAt: null, followedAt: null }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(), 'never', 'followedAt', NOW),
+    );
+    expect(result.current.filteredFollows[0].profile.did).toBe('hasFollow');
+  });
+
+  it('lastActivity sort places null-activity entries first', () => {
+    const state = makeState([
+      makeEntry({ did: 'hasActivity', lastActivityAt: new Date(NOW - 200 * DAY_MS).toISOString() }),
+      makeEntry({ did: 'nullActivity', lastActivityAt: null }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(), 30, 'lastActivity', NOW),
+    );
+    expect(result.current.filteredFollows.map((e) => e.profile.did)).toEqual([
+      'nullActivity',
+      'hasActivity',
+    ]);
+  });
+
+  it('skippedEntries only includes skipped dids that have a scanned entry', () => {
+    const state = makeState([
+      makeEntry({ did: 'scanned', lastActivityAt: null }),
+    ]);
+    const { result } = renderHook(() =>
+      useFollowingCleanupFilters(state, new Set(['scanned', 'unscanned']), 'never', 'lastActivity', NOW),
+    );
+    expect(result.current.skippedEntries.map((e) => e.profile.did)).toEqual(['scanned']);
+  });
+});

--- a/apps/akari/__tests__/hooks/useFollowingCleanupLabels.test.tsx
+++ b/apps/akari/__tests__/hooks/useFollowingCleanupLabels.test.tsx
@@ -1,0 +1,135 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { useFollowingCleanupLabels } from '@/hooks/useFollowingCleanupLabels';
+import type { FollowingCleanupEntry } from '@/utils/followingCleanupController';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = new Date('2026-05-29T00:00:00.000Z').getTime();
+
+function makeEntry(overrides: Omit<Partial<FollowingCleanupEntry>, 'profile'> & { profile?: Record<string, unknown> }): FollowingCleanupEntry {
+  const { profile, ...rest } = overrides;
+  return {
+    status: 'done',
+    lastActivityAt: null,
+    followedAt: null,
+    ...rest,
+    profile: {
+      did: 'did:plc:test',
+      handle: 'test.test',
+      ...profile,
+    } as FollowingCleanupEntry['profile'],
+  };
+}
+
+describe('useFollowingCleanupLabels', () => {
+  describe('getLastActivityLabel', () => {
+    it('returns activityUnknown when lastActivity is null and postsCount is undefined', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      const label = result.current.getLastActivityLabel(makeEntry({ lastActivityAt: null }));
+      expect(label).toBe('settings.followingCleanup.activityUnknown');
+    });
+
+    it('returns activityUnknown when null activity but postsCount > 0 (AppView gap)', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      const label = result.current.getLastActivityLabel(
+        makeEntry({ lastActivityAt: null, profile: { postsCount: 12 } }),
+      );
+      expect(label).toBe('settings.followingCleanup.activityUnknown');
+    });
+
+    it('returns neverPosted when null activity and postsCount is 0', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      const label = result.current.getLastActivityLabel(
+        makeEntry({ lastActivityAt: null, profile: { postsCount: 0 } }),
+      );
+      expect(label).toBe('settings.followingCleanup.neverPosted');
+    });
+
+    it('returns lastSeenToday for activity less than a day ago', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      const label = result.current.getLastActivityLabel(
+        makeEntry({ lastActivityAt: new Date(NOW - 1000).toISOString() }),
+      );
+      expect(label).toBe('settings.followingCleanup.lastSeenToday');
+    });
+
+    it('returns lastSeenOneDay for exactly one day ago', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      const label = result.current.getLastActivityLabel(
+        makeEntry({ lastActivityAt: new Date(NOW - DAY_MS).toISOString() }),
+      );
+      expect(label).toBe('settings.followingCleanup.lastSeenOneDay');
+    });
+
+    it('returns lastSeenDays for multiple days ago', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      const label = result.current.getLastActivityLabel(
+        makeEntry({ lastActivityAt: new Date(NOW - 5 * DAY_MS).toISOString() }),
+      );
+      expect(label).toBe('settings.followingCleanup.lastSeenDays');
+    });
+  });
+
+  describe('getFollowedAtLabel', () => {
+    it('returns null when followedAt is missing', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      expect(result.current.getFollowedAtLabel(makeEntry({ followedAt: null }))).toBeNull();
+    });
+
+    it('returns followedToday for less than a day', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      expect(
+        result.current.getFollowedAtLabel(makeEntry({ followedAt: new Date(NOW - 1000).toISOString() })),
+      ).toBe('settings.followingCleanup.followedToday');
+    });
+
+    it('returns followedOneDay for exactly one day', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      expect(
+        result.current.getFollowedAtLabel(makeEntry({ followedAt: new Date(NOW - DAY_MS).toISOString() })),
+      ).toBe('settings.followingCleanup.followedOneDay');
+    });
+
+    it('returns followedDays for under 30 days', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      expect(
+        result.current.getFollowedAtLabel(makeEntry({ followedAt: new Date(NOW - 10 * DAY_MS).toISOString() })),
+      ).toBe('settings.followingCleanup.followedDays');
+    });
+
+    it('returns followedMonths between 30 days and a year', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      expect(
+        result.current.getFollowedAtLabel(makeEntry({ followedAt: new Date(NOW - 90 * DAY_MS).toISOString() })),
+      ).toBe('settings.followingCleanup.followedMonths');
+    });
+
+    it('returns followedYears beyond a year', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      expect(
+        result.current.getFollowedAtLabel(makeEntry({ followedAt: new Date(NOW - 800 * DAY_MS).toISOString() })),
+      ).toBe('settings.followingCleanup.followedYears');
+    });
+  });
+
+  describe('getStatsLabel', () => {
+    it('returns null when no counts are present', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      expect(result.current.getStatsLabel(makeEntry({ profile: {} }))).toBeNull();
+    });
+
+    it('returns the stats key when at least one count is present', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      const label = result.current.getStatsLabel(
+        makeEntry({ profile: { followersCount: 1200, followsCount: 50, postsCount: 3400 } }),
+      );
+      expect(label).toBe('settings.followingCleanup.stats');
+    });
+
+    it('renders the line even when only one count is defined', () => {
+      const { result } = renderHook(() => useFollowingCleanupLabels(NOW));
+      const label = result.current.getStatsLabel(makeEntry({ profile: { postsCount: 0 } }));
+      expect(label).toBe('settings.followingCleanup.stats');
+    });
+  });
+});

--- a/apps/akari/__tests__/hooks/useFollowingCleanupSkips.test.tsx
+++ b/apps/akari/__tests__/hooks/useFollowingCleanupSkips.test.tsx
@@ -1,0 +1,115 @@
+import { act, renderHook } from '@testing-library/react-native';
+import { MMKV } from 'react-native-mmkv';
+
+import { useFollowingCleanupSkips } from '@/hooks/useFollowingCleanupSkips';
+
+describe('useFollowingCleanupSkips', () => {
+  it('falls back to an empty set when stored value is not valid JSON', () => {
+    const storage = new MMKV({ id: 'following-cleanup-skips' });
+    storage.set('skips:did:plc:badjson', 'not-json{');
+    const { result } = renderHook(() => useFollowingCleanupSkips('did:plc:badjson'));
+    expect(result.current.skipped.size).toBe(0);
+  });
+
+  it('falls back to an empty set when stored value is not an array', () => {
+    const storage = new MMKV({ id: 'following-cleanup-skips' });
+    storage.set('skips:did:plc:notarray', JSON.stringify({ foo: 'bar' }));
+    const { result } = renderHook(() => useFollowingCleanupSkips('did:plc:notarray'));
+    expect(result.current.skipped.size).toBe(0);
+  });
+
+  it('reads a previously-persisted array and filters non-strings', () => {
+    const storage = new MMKV({ id: 'following-cleanup-skips' });
+    storage.set('skips:did:plc:persisted', JSON.stringify(['did:plc:keep', 42, null]));
+    const { result } = renderHook(() => useFollowingCleanupSkips('did:plc:persisted'));
+    expect(result.current.skipped.has('did:plc:keep')).toBe(true);
+    expect(result.current.skipped.size).toBe(1);
+  });
+
+  it('returns an empty set and no-ops when accountDid is undefined', () => {
+    const { result } = renderHook(() => useFollowingCleanupSkips(undefined));
+    expect(result.current.skipped.size).toBe(0);
+
+    act(() => {
+      result.current.skip('did:plc:x');
+      result.current.unskip('did:plc:x');
+      result.current.clearAll();
+    });
+    expect(result.current.skipped.size).toBe(0);
+  });
+
+  it('adds a did via skip and reflects it reactively', () => {
+    const { result } = renderHook(() => useFollowingCleanupSkips('did:plc:alpha'));
+    expect(result.current.skipped.has('did:plc:1')).toBe(false);
+
+    act(() => {
+      result.current.skip('did:plc:1');
+    });
+    expect(result.current.skipped.has('did:plc:1')).toBe(true);
+  });
+
+  it('does not duplicate or re-notify when skipping an already-skipped did', () => {
+    const { result } = renderHook(() => useFollowingCleanupSkips('did:plc:beta'));
+    act(() => {
+      result.current.skip('did:plc:dup');
+    });
+    const first = result.current.skipped;
+    act(() => {
+      result.current.skip('did:plc:dup');
+    });
+    expect(result.current.skipped).toBe(first);
+    expect(result.current.skipped.size).toBe(1);
+  });
+
+  it('removes a did via unskip', () => {
+    const { result } = renderHook(() => useFollowingCleanupSkips('did:plc:gamma'));
+    act(() => {
+      result.current.skip('did:plc:a');
+      result.current.skip('did:plc:b');
+    });
+    expect(result.current.skipped.size).toBe(2);
+
+    act(() => {
+      result.current.unskip('did:plc:a');
+    });
+    expect(result.current.skipped.has('did:plc:a')).toBe(false);
+    expect(result.current.skipped.has('did:plc:b')).toBe(true);
+  });
+
+  it('unskip of an absent did does not notify or change state', () => {
+    const { result } = renderHook(() => useFollowingCleanupSkips('did:plc:delta'));
+    act(() => {
+      result.current.skip('did:plc:present');
+    });
+    const snapshot = result.current.skipped;
+    act(() => {
+      result.current.unskip('did:plc:absent');
+    });
+    expect(result.current.skipped).toBe(snapshot);
+  });
+
+  it('clearAll empties the skip set', () => {
+    const { result } = renderHook(() => useFollowingCleanupSkips('did:plc:epsilon'));
+    act(() => {
+      result.current.skip('did:plc:a');
+      result.current.skip('did:plc:b');
+    });
+    expect(result.current.skipped.size).toBe(2);
+
+    act(() => {
+      result.current.clearAll();
+    });
+    expect(result.current.skipped.size).toBe(0);
+  });
+
+  it('keeps skip lists isolated per account', () => {
+    const a = renderHook(() => useFollowingCleanupSkips('did:plc:acctA'));
+    const b = renderHook(() => useFollowingCleanupSkips('did:plc:acctB'));
+
+    act(() => {
+      a.result.current.skip('did:plc:shared');
+    });
+    expect(a.result.current.skipped.has('did:plc:shared')).toBe(true);
+    expect(b.result.current.skipped.has('did:plc:shared')).toBe(false);
+  });
+});

--- a/apps/akari/__tests__/hooks/useNotifyAudience.test.tsx
+++ b/apps/akari/__tests__/hooks/useNotifyAudience.test.tsx
@@ -1,0 +1,36 @@
+import { renderHook, act } from '@testing-library/react-native';
+
+import { useNotifyAudience } from '@/hooks/useNotifyAudience';
+
+describe('useNotifyAudience', () => {
+  it('defaults to "followers" when nothing is stored', () => {
+    const { result } = renderHook(() => useNotifyAudience());
+    expect(result.current.audience).toBe('followers');
+  });
+
+  it('updates the audience and reflects it on subsequent reads', () => {
+    const { result } = renderHook(() => useNotifyAudience());
+
+    act(() => {
+      result.current.setAudience('mutuals');
+    });
+    expect(result.current.audience).toBe('mutuals');
+
+    act(() => {
+      result.current.setAudience('no-one');
+    });
+    expect(result.current.audience).toBe('no-one');
+  });
+
+  it('notifies every mounted subscriber of a change', () => {
+    const a = renderHook(() => useNotifyAudience());
+    const b = renderHook(() => useNotifyAudience());
+
+    act(() => {
+      a.result.current.setAudience('anyone');
+    });
+
+    expect(a.result.current.audience).toBe('anyone');
+    expect(b.result.current.audience).toBe('anyone');
+  });
+});

--- a/apps/akari/__tests__/hooks/useProfileMenuItems.test.tsx
+++ b/apps/akari/__tests__/hooks/useProfileMenuItems.test.tsx
@@ -1,0 +1,390 @@
+import { renderHook, act } from '@testing-library/react-native';
+
+import { searchProfilePosts } from '@/components/profile/profileActions';
+import { useToast } from '@/contexts/ToastContext';
+import { useBlockUser } from '@/hooks/mutations/useBlockUser';
+import { useMuteUser } from '@/hooks/mutations/useMuteUser';
+import { useConfirm } from '@/hooks/useConfirm';
+import { useProfileMenuItems } from '@/hooks/useProfileMenuItems';
+import { useRequireAuth } from '@/hooks/useRequireAuth';
+
+import * as Clipboard from 'expo-clipboard';
+import * as Haptics from 'expo-haptics';
+
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: jest.fn(),
+}));
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  ImpactFeedbackStyle: { Light: 'light', Medium: 'medium' },
+}));
+
+jest.mock('@/components/profile/profileActions', () => ({
+  searchProfilePosts: jest.fn(),
+}));
+
+jest.mock('@/contexts/ToastContext', () => ({
+  useToast: jest.fn(),
+}));
+
+jest.mock('@/hooks/mutations/useBlockUser', () => ({
+  useBlockUser: jest.fn(),
+}));
+
+jest.mock('@/hooks/mutations/useMuteUser', () => ({
+  useMuteUser: jest.fn(),
+}));
+
+jest.mock('@/hooks/useConfirm', () => ({
+  useConfirm: jest.fn(),
+}));
+
+jest.mock('@/hooks/useRequireAuth', () => ({
+  useRequireAuth: jest.fn(),
+}));
+
+jest.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const mockShowToast = jest.fn();
+const mockConfirm = jest.fn();
+const mockPromptSignIn = jest.fn();
+const mockBlockMutateAsync = jest.fn();
+const mockMuteMutate = jest.fn();
+
+function setup(args: Parameters<typeof useProfileMenuItems>[0]) {
+  return renderHook(() => useProfileMenuItems(args));
+}
+
+const baseProfile = {
+  did: 'did:plc:alice',
+  handle: 'alice.test',
+  viewer: {},
+} as unknown as NonNullable<Parameters<typeof useProfileMenuItems>[0]['profile']>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (useToast as jest.Mock).mockReturnValue({ showToast: mockShowToast });
+  (useConfirm as jest.Mock).mockReturnValue(mockConfirm);
+  (useRequireAuth as jest.Mock).mockReturnValue({
+    isGuest: false,
+    promptSignIn: mockPromptSignIn,
+  });
+  (useBlockUser as jest.Mock).mockReturnValue({ mutateAsync: mockBlockMutateAsync });
+  (useMuteUser as jest.Mock).mockReturnValue({ mutate: mockMuteMutate });
+  mockBlockMutateAsync.mockResolvedValue(undefined);
+});
+
+describe('useProfileMenuItems', () => {
+  it('returns only search + copy link for the user\'s own profile', () => {
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: true,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    expect(result.current.map((i) => i.key)).toEqual(['search', 'copyLink']);
+  });
+
+  it('returns the full menu for another profile', () => {
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    expect(result.current.map((i) => i.key)).toEqual([
+      'copyLink',
+      'search',
+      'addToLists',
+      'mute',
+      'block',
+      'report',
+    ]);
+  });
+
+  it('appends a "message on Germ" row when the callback is provided', () => {
+    const onMessageOnGerm = jest.fn();
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+      onMessageOnGerm,
+    });
+
+    const germItem = result.current.find((i) => i.key === 'messageOnGerm');
+    expect(germItem).toBeDefined();
+
+    act(() => {
+      germItem?.onPress?.();
+    });
+    expect(onMessageOnGerm).toHaveBeenCalled();
+    expect(Haptics.impactAsync).toHaveBeenCalledWith('light');
+  });
+
+  it('shows "unmute"/"unblock" labels when already muted/blocked', () => {
+    const blockedMuted = {
+      ...baseProfile,
+      viewer: { blocking: 'at://block', muted: true },
+    } as typeof baseProfile;
+
+    const { result } = setup({
+      profile: blockedMuted,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    expect(result.current.find((i) => i.key === 'mute')?.label).toBe('common.unmute');
+    expect(result.current.find((i) => i.key === 'block')?.label).toBe('common.unblock');
+  });
+
+  it('copies the profile link and toasts success', async () => {
+    (Clipboard.setStringAsync as jest.Mock).mockResolvedValueOnce(undefined);
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    const copy = result.current.find((i) => i.key === 'copyLink');
+    await act(async () => {
+      await copy?.onPress?.();
+    });
+
+    expect(Clipboard.setStringAsync).toHaveBeenCalledWith(
+      'https://bsky.app/profile/alice.test',
+    );
+    expect(mockShowToast).toHaveBeenCalledWith({
+      message: 'profile.linkCopied',
+      type: 'success',
+    });
+  });
+
+  it('confirms an error when the clipboard write throws', async () => {
+    (Clipboard.setStringAsync as jest.Mock).mockRejectedValueOnce(new Error('clipboard'));
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    const copy = result.current.find((i) => i.key === 'copyLink');
+    await act(async () => {
+      await copy?.onPress?.();
+    });
+
+    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'profile.linkCopyError' }),
+    );
+  });
+
+  it('confirms before copying when there is no handle', async () => {
+    const noHandle = { ...baseProfile, handle: undefined } as unknown as typeof baseProfile;
+    const { result } = setup({
+      profile: noHandle,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    const copy = result.current.find((i) => i.key === 'copyLink');
+    await act(async () => {
+      await copy?.onPress?.();
+    });
+
+    expect(Clipboard.setStringAsync).not.toHaveBeenCalled();
+    expect(mockConfirm).toHaveBeenCalled();
+  });
+
+  it('triggers profile post search', () => {
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    act(() => {
+      result.current.find((i) => i.key === 'search')?.onPress?.();
+    });
+    expect(searchProfilePosts).toHaveBeenCalledWith({ handle: 'alice.test' });
+  });
+
+  it('opens the list picker from "add to lists"', () => {
+    const onOpenListPicker = jest.fn();
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker,
+    });
+
+    act(() => {
+      result.current.find((i) => i.key === 'addToLists')?.onPress?.();
+    });
+    expect(onOpenListPicker).toHaveBeenCalled();
+  });
+
+  it('opens the report sheet for an authenticated user', () => {
+    const onOpenReportSheet = jest.fn();
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet,
+      onOpenListPicker: jest.fn(),
+    });
+
+    act(() => {
+      result.current.find((i) => i.key === 'report')?.onPress?.();
+    });
+    expect(onOpenReportSheet).toHaveBeenCalled();
+    expect(Haptics.impactAsync).toHaveBeenCalledWith('medium');
+  });
+
+  it('prompts sign-in instead of mutating for a guest', () => {
+    (useRequireAuth as jest.Mock).mockReturnValue({
+      isGuest: true,
+      promptSignIn: mockPromptSignIn,
+    });
+    const onOpenReportSheet = jest.fn();
+
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet,
+      onOpenListPicker: jest.fn(),
+    });
+
+    act(() => {
+      result.current.find((i) => i.key === 'block')?.onPress?.();
+    });
+    act(() => {
+      result.current.find((i) => i.key === 'mute')?.onPress?.();
+    });
+    act(() => {
+      result.current.find((i) => i.key === 'report')?.onPress?.();
+    });
+
+    expect(mockPromptSignIn).toHaveBeenCalledTimes(3);
+    expect(mockConfirm).not.toHaveBeenCalled();
+    expect(onOpenReportSheet).not.toHaveBeenCalled();
+  });
+
+  it('confirms then blocks when the destructive button is pressed', async () => {
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    act(() => {
+      result.current.find((i) => i.key === 'block')?.onPress?.();
+    });
+
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+    const confirmArgs = mockConfirm.mock.calls[0][0];
+    const destructiveButton = confirmArgs.buttons.find(
+      (b: { style?: string }) => b.style === 'destructive',
+    );
+
+    await act(async () => {
+      await destructiveButton.onPress();
+    });
+
+    expect(mockBlockMutateAsync).toHaveBeenCalledWith({
+      did: 'did:plc:alice',
+      action: 'block',
+    });
+  });
+
+  it('unblocks (passing the existing block uri) when already blocking', async () => {
+    const blocked = {
+      ...baseProfile,
+      viewer: { blocking: 'at://existing-block' },
+    } as typeof baseProfile;
+
+    const { result } = setup({
+      profile: blocked,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    act(() => {
+      result.current.find((i) => i.key === 'block')?.onPress?.();
+    });
+    const destructiveButton = mockConfirm.mock.calls[0][0].buttons.find(
+      (b: { style?: string }) => b.style === 'destructive',
+    );
+
+    await act(async () => {
+      await destructiveButton.onPress();
+    });
+
+    expect(mockBlockMutateAsync).toHaveBeenCalledWith({
+      did: 'did:plc:alice',
+      blockUri: 'at://existing-block',
+      action: 'unblock',
+    });
+  });
+
+  it('toasts an error when the block mutation throws', async () => {
+    mockBlockMutateAsync.mockRejectedValueOnce(new Error('nope'));
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    act(() => {
+      result.current.find((i) => i.key === 'block')?.onPress?.();
+    });
+    const destructiveButton = mockConfirm.mock.calls[0][0].buttons.find(
+      (b: { style?: string }) => b.style === 'destructive',
+    );
+
+    await act(async () => {
+      await destructiveButton.onPress();
+    });
+
+    expect(mockShowToast).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error' }),
+    );
+  });
+
+  it('confirms then mutes when the destructive button is pressed', () => {
+    const { result } = setup({
+      profile: baseProfile,
+      isOwnProfile: false,
+      onOpenReportSheet: jest.fn(),
+      onOpenListPicker: jest.fn(),
+    });
+
+    act(() => {
+      result.current.find((i) => i.key === 'mute')?.onPress?.();
+    });
+    const destructiveButton = mockConfirm.mock.calls[0][0].buttons.find(
+      (b: { style?: string }) => b.style === 'destructive',
+    );
+
+    act(() => {
+      destructiveButton.onPress();
+    });
+
+    expect(mockMuteMutate).toHaveBeenCalledWith({
+      actor: 'did:plc:alice',
+      action: 'mute',
+    });
+  });
+});

--- a/apps/akari/__tests__/hooks/useRateLimitWait.test.tsx
+++ b/apps/akari/__tests__/hooks/useRateLimitWait.test.tsx
@@ -1,0 +1,71 @@
+import { renderHook, act } from '@testing-library/react-native';
+
+import { getRateLimitCooldownUntil } from '@/bluesky-api';
+import { useRateLimitWait } from '@/hooks/useRateLimitWait';
+
+jest.mock('@/bluesky-api', () => ({
+  getRateLimitCooldownUntil: jest.fn(),
+}));
+
+describe('useRateLimitWait', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns 0 when no pds url is supplied', () => {
+    const { result } = renderHook(() => useRateLimitWait(undefined));
+    expect(result.current).toBe(0);
+    expect(getRateLimitCooldownUntil).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 when the client is not rate-limited', () => {
+    (getRateLimitCooldownUntil as jest.Mock).mockReturnValue(undefined);
+    const { result } = renderHook(() => useRateLimitWait('https://pds.test'));
+    expect(result.current).toBe(0);
+  });
+
+  it('returns the remaining wait in milliseconds', () => {
+    // cooldown until t=5000, now is t=0 -> 5000ms remaining
+    (getRateLimitCooldownUntil as jest.Mock).mockReturnValue(5000);
+    const { result } = renderHook(() => useRateLimitWait('https://pds.test'));
+    expect(result.current).toBe(5000);
+  });
+
+  it('never returns a negative wait once the cooldown has passed', () => {
+    (getRateLimitCooldownUntil as jest.Mock).mockReturnValue(1000);
+    jest.setSystemTime(2000);
+    const { result } = renderHook(() => useRateLimitWait('https://pds.test'));
+    expect(result.current).toBe(0);
+  });
+
+  it('recomputes the remaining wait on each one-second tick', () => {
+    (getRateLimitCooldownUntil as jest.Mock).mockReturnValue(10_000);
+
+    const { result } = renderHook(() => useRateLimitWait('https://pds.test'));
+    expect(result.current).toBe(10_000);
+
+    // advance the clock 3s; the interval fires and the memo recomputes.
+    // advanceTimersByTime also moves the fake Date forward, so now=3000.
+    act(() => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    expect(result.current).toBe(7000);
+  });
+
+  it('clears its interval on unmount', () => {
+    (getRateLimitCooldownUntil as jest.Mock).mockReturnValue(10_000);
+    const clearSpy = jest.spyOn(global, 'clearInterval');
+
+    const { unmount } = renderHook(() => useRateLimitWait('https://pds.test'));
+    unmount();
+
+    expect(clearSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/hooks/useSavedFeedsList.test.tsx
+++ b/apps/akari/__tests__/hooks/useSavedFeedsList.test.tsx
@@ -1,0 +1,127 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { useSavedFeedsList } from '@/hooks/useSavedFeedsList';
+import { useCurrentAccount } from '@/hooks/queries/useCurrentAccount';
+import { useFeeds } from '@/hooks/queries/useFeeds';
+import { useSavedFeeds } from '@/hooks/queries/usePreferences';
+
+jest.mock('@/hooks/queries/useCurrentAccount', () => ({
+  useCurrentAccount: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/useFeeds', () => ({
+  useFeeds: jest.fn(),
+}));
+
+jest.mock('@/hooks/queries/usePreferences', () => ({
+  useSavedFeeds: jest.fn(),
+}));
+
+describe('useSavedFeedsList', () => {
+  const refetchFeeds = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useCurrentAccount as jest.Mock).mockReturnValue({
+      data: { did: 'did:plc:me', handle: 'me.test', pdsUrl: 'https://pds' },
+    });
+    (useSavedFeeds as jest.Mock).mockReturnValue({ data: [], isLoading: false });
+    (useFeeds as jest.Mock).mockReturnValue({
+      data: { feeds: [] },
+      isLoading: false,
+      refetch: refetchFeeds,
+    });
+  });
+
+  it('passes the current account did and limit 50 to useFeeds', () => {
+    renderHook(() => useSavedFeedsList());
+    expect(useFeeds as jest.Mock).toHaveBeenCalledWith('did:plc:me', 50);
+  });
+
+  it('expands the synthetic following timeline entry into a feed-shaped record', () => {
+    (useSavedFeeds as jest.Mock).mockReturnValue({
+      data: [{ type: 'timeline', value: 'following' }],
+      isLoading: false,
+    });
+    const { result } = renderHook(() => useSavedFeedsList());
+    expect(result.current.allFeedsWithCreated).toHaveLength(1);
+    const following = result.current.allFeedsWithCreated[0];
+    expect(following.uri).toBe('following');
+    expect(following.displayName).toBe('Following');
+    expect(following.creator.did).toBe('did:plc:me');
+    expect(following.creator.handle).toBe('me.test');
+  });
+
+  it('uses empty strings for the following creator when no account is present', () => {
+    (useCurrentAccount as jest.Mock).mockReturnValue({ data: undefined });
+    (useSavedFeeds as jest.Mock).mockReturnValue({
+      data: [{ type: 'timeline', value: 'following' }],
+      isLoading: false,
+    });
+    (useFeeds as jest.Mock).mockReturnValue({
+      data: { feeds: [] },
+      isLoading: false,
+      refetch: refetchFeeds,
+    });
+    const { result } = renderHook(() => useSavedFeedsList());
+    expect(result.current.allFeedsWithCreated[0].creator.did).toBe('');
+    expect(result.current.allFeedsWithCreated[0].creator.handle).toBe('');
+  });
+
+  it('passes through feed metadata for saved feed entries', () => {
+    const metadata = { uri: 'at://feed/abc', displayName: 'Cool Feed' };
+    (useSavedFeeds as jest.Mock).mockReturnValue({
+      data: [{ type: 'feed', metadata }],
+      isLoading: false,
+    });
+    const { result } = renderHook(() => useSavedFeedsList());
+    expect(result.current.allFeedsWithCreated).toEqual([metadata]);
+  });
+
+  it('drops feed entries lacking metadata and unknown timeline values', () => {
+    (useSavedFeeds as jest.Mock).mockReturnValue({
+      data: [
+        { type: 'feed', metadata: undefined },
+        { type: 'timeline', value: 'whats-hot' },
+      ],
+      isLoading: false,
+    });
+    const { result } = renderHook(() => useSavedFeedsList());
+    expect(result.current.allFeedsWithCreated).toHaveLength(0);
+  });
+
+  it('concatenates created feeds after the saved feeds', () => {
+    const metadata = { uri: 'at://feed/saved', displayName: 'Saved' };
+    const created = { uri: 'at://feed/created', displayName: 'Created' };
+    (useSavedFeeds as jest.Mock).mockReturnValue({
+      data: [{ type: 'feed', metadata }],
+      isLoading: false,
+    });
+    (useFeeds as jest.Mock).mockReturnValue({
+      data: { feeds: [created] },
+      isLoading: false,
+      refetch: refetchFeeds,
+    });
+    const { result } = renderHook(() => useSavedFeedsList());
+    expect(result.current.allFeedsWithCreated).toEqual([metadata, created]);
+  });
+
+  it('surfaces loading flags and the refetch function', () => {
+    (useSavedFeeds as jest.Mock).mockReturnValue({ data: [], isLoading: true });
+    (useFeeds as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      refetch: refetchFeeds,
+    });
+    const { result } = renderHook(() => useSavedFeedsList());
+    expect(result.current.savedFeedsLoading).toBe(true);
+    expect(result.current.feedsLoading).toBe(true);
+    expect(result.current.refetchFeeds).toBe(refetchFeeds);
+  });
+
+  it('handles undefined savedFeeds without throwing', () => {
+    (useSavedFeeds as jest.Mock).mockReturnValue({ data: undefined, isLoading: false });
+    const { result } = renderHook(() => useSavedFeedsList());
+    expect(result.current.allFeedsWithCreated).toEqual([]);
+  });
+});

--- a/apps/akari/__tests__/utils/appLogoIcon.test.ts
+++ b/apps/akari/__tests__/utils/appLogoIcon.test.ts
@@ -1,0 +1,111 @@
+type Bridge = {
+  setAlternateIconName: jest.Mock;
+  getCurrentAlternateIconName: jest.Mock;
+  supportsAlternateIcons: jest.Mock;
+};
+
+function loadModule(os: string, bridge: Bridge | null) {
+  jest.doMock('react-native', () => ({
+    Platform: { OS: os },
+    NativeModules: bridge ? { AppLogoIconBridge: bridge } : {},
+  }));
+  return require('@/utils/appLogoIcon');
+}
+
+function makeBridge(): Bridge {
+  return {
+    setAlternateIconName: jest.fn().mockResolvedValue(true),
+    getCurrentAlternateIconName: jest.fn().mockResolvedValue(null),
+    supportsAlternateIcons: jest.fn().mockResolvedValue(true),
+  };
+}
+
+describe('appLogoIcon', () => {
+  let warnSpy: jest.SpyInstance;
+  let logSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+    warnSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+
+  describe('applyHomescreenIcon', () => {
+    it('no-ops on web without touching native modules', async () => {
+      const { applyHomescreenIcon } = loadModule('web', null);
+      await expect(applyHomescreenIcon('default')).resolves.toBeUndefined();
+    });
+
+    it('soft no-ops on native when the bridge is unavailable and warns once', async () => {
+      const { applyHomescreenIcon } = loadModule('ios', null);
+      await expect(applyHomescreenIcon('default')).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('NativeModules.AppLogoIconBridge is undefined'),
+      );
+    });
+
+    it('passes null to the native bridge for the default variant', async () => {
+      const bridge = makeBridge();
+      const { applyHomescreenIcon } = loadModule('ios', bridge);
+      await applyHomescreenIcon('default');
+      expect(bridge.setAlternateIconName).toHaveBeenCalledWith(null);
+    });
+
+    it('passes the variant name to the native bridge for non-default variants', async () => {
+      const bridge = makeBridge();
+      const { applyHomescreenIcon } = loadModule('android', bridge);
+      await applyHomescreenIcon('pride' as never);
+      expect(bridge.setAlternateIconName).toHaveBeenCalledWith('pride');
+    });
+
+    it('swallows native bridge errors and warns', async () => {
+      const bridge = makeBridge();
+      bridge.setAlternateIconName.mockRejectedValue(new Error('backgrounded'));
+      const { applyHomescreenIcon } = loadModule('ios', bridge);
+      await expect(applyHomescreenIcon('dark' as never)).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[applyHomescreenIcon] failed',
+        expect.any(Error),
+      );
+    });
+  });
+
+  describe('supportsHomescreenIconSwap', () => {
+    it('returns false on web', async () => {
+      const { supportsHomescreenIconSwap } = loadModule('web', makeBridge());
+      await expect(supportsHomescreenIconSwap()).resolves.toBe(false);
+    });
+
+    it('returns false on native when the bridge is unavailable', async () => {
+      const { supportsHomescreenIconSwap } = loadModule('android', null);
+      await expect(supportsHomescreenIconSwap()).resolves.toBe(false);
+    });
+
+    it('delegates to the native bridge when available', async () => {
+      const bridge = makeBridge();
+      bridge.supportsAlternateIcons.mockResolvedValue(true);
+      const { supportsHomescreenIconSwap } = loadModule('ios', bridge);
+      await expect(supportsHomescreenIconSwap()).resolves.toBe(true);
+      expect(bridge.supportsAlternateIcons).toHaveBeenCalled();
+    });
+
+    it('returns the false value reported by the native bridge', async () => {
+      const bridge = makeBridge();
+      bridge.supportsAlternateIcons.mockResolvedValue(false);
+      const { supportsHomescreenIconSwap } = loadModule('android', bridge);
+      await expect(supportsHomescreenIconSwap()).resolves.toBe(false);
+    });
+
+    it('returns false when the native bridge throws', async () => {
+      const bridge = makeBridge();
+      bridge.supportsAlternateIcons.mockRejectedValue(new Error('nope'));
+      const { supportsHomescreenIconSwap } = loadModule('ios', bridge);
+      await expect(supportsHomescreenIconSwap()).resolves.toBe(false);
+    });
+  });
+});

--- a/apps/akari/__tests__/utils/appView.test.ts
+++ b/apps/akari/__tests__/utils/appView.test.ts
@@ -1,0 +1,228 @@
+import type { Account } from '@/types/account';
+import {
+  APP_VIEW_PRESETS,
+  AppViewRequiredError,
+  type AppViewConfig,
+  DEFAULT_APP_VIEW,
+  isAppViewEnabled,
+  isAppViewRequiredError,
+  resolveAccountAppView,
+  resolveAppView,
+  resolveCdnHost,
+} from '@/utils/appView';
+
+function makeConfig(overrides: Partial<AppViewConfig> = {}): AppViewConfig {
+  return { ...DEFAULT_APP_VIEW, ...overrides };
+}
+
+describe('DEFAULT_APP_VIEW', () => {
+  it('defaults to the bsky preset with the AppView enabled', () => {
+    expect(DEFAULT_APP_VIEW).toEqual({ preset: 'bsky', cdnPreset: 'bsky', appViewEnabled: true });
+  });
+});
+
+describe('isAppViewEnabled', () => {
+  it('returns true when explicitly enabled', () => {
+    expect(isAppViewEnabled(makeConfig({ appViewEnabled: true }))).toBe(true);
+  });
+
+  it('returns false only when explicitly disabled', () => {
+    expect(isAppViewEnabled(makeConfig({ appViewEnabled: false }))).toBe(false);
+  });
+
+  it('treats a legacy config without the flag as enabled', () => {
+    const legacy = { preset: 'bsky', cdnPreset: 'bsky' } as unknown as AppViewConfig;
+    expect(isAppViewEnabled(legacy)).toBe(true);
+  });
+});
+
+describe('AppViewRequiredError', () => {
+  it('carries the feature key, code, name, and message', () => {
+    const err = new AppViewRequiredError('timeline');
+    expect(err).toBeInstanceOf(Error);
+    expect(err.code).toBe('APP_VIEW_REQUIRED');
+    expect(err.featureKey).toBe('timeline');
+    expect(err.name).toBe('AppViewRequiredError');
+    expect(err.message).toBe('Feature requires an AppView: timeline');
+  });
+});
+
+describe('isAppViewRequiredError', () => {
+  it('detects AppViewRequiredError instances', () => {
+    expect(isAppViewRequiredError(new AppViewRequiredError('search'))).toBe(true);
+  });
+
+  it('detects any error carrying the APP_VIEW_REQUIRED code', () => {
+    const err = Object.assign(new Error('nope'), { code: 'APP_VIEW_REQUIRED' });
+    expect(isAppViewRequiredError(err)).toBe(true);
+  });
+
+  it('rejects plain errors and non-error values', () => {
+    expect(isAppViewRequiredError(new Error('boom'))).toBe(false);
+    expect(isAppViewRequiredError({ code: 'APP_VIEW_REQUIRED' })).toBe(false);
+    expect(isAppViewRequiredError(null)).toBe(false);
+    expect(isAppViewRequiredError(undefined)).toBe(false);
+    expect(isAppViewRequiredError('APP_VIEW_REQUIRED')).toBe(false);
+  });
+});
+
+describe('resolveCdnHost', () => {
+  it('returns undefined for the default bsky preset', () => {
+    expect(resolveCdnHost(makeConfig({ cdnPreset: 'bsky' }))).toBeUndefined();
+  });
+
+  it('returns the blueat mirror host', () => {
+    expect(resolveCdnHost(makeConfig({ cdnPreset: 'blueat' }))).toBe('https://cdn.blueat.net');
+  });
+
+  it('normalizes a custom CDN url (trims trailing slashes)', () => {
+    expect(resolveCdnHost(makeConfig({ cdnPreset: 'custom', customCdnUrl: 'https://cdn.example.com///' }))).toBe(
+      'https://cdn.example.com',
+    );
+  });
+
+  it('returns undefined for a missing custom CDN url', () => {
+    expect(resolveCdnHost(makeConfig({ cdnPreset: 'custom', customCdnUrl: undefined }))).toBeUndefined();
+  });
+
+  it('returns undefined for a blank custom CDN url', () => {
+    expect(resolveCdnHost(makeConfig({ cdnPreset: 'custom', customCdnUrl: '   ' }))).toBeUndefined();
+  });
+
+  it('returns undefined for a non-http custom CDN url', () => {
+    expect(resolveCdnHost(makeConfig({ cdnPreset: 'custom', customCdnUrl: 'ftp://cdn.example.com' }))).toBeUndefined();
+  });
+
+  it('trims surrounding whitespace from a custom CDN url', () => {
+    expect(resolveCdnHost(makeConfig({ cdnPreset: 'custom', customCdnUrl: '  https://cdn.example.com  ' }))).toBe(
+      'https://cdn.example.com',
+    );
+  });
+});
+
+describe('resolveAppView', () => {
+  it('resolves the bsky preset', () => {
+    expect(resolveAppView(makeConfig({ preset: 'bsky' }))).toEqual(APP_VIEW_PRESETS.bsky);
+  });
+
+  it('resolves the blacksky preset', () => {
+    expect(resolveAppView(makeConfig({ preset: 'blacksky' }))).toEqual(APP_VIEW_PRESETS.blacksky);
+  });
+
+  it('falls back to the bsky preset for an unknown preset id', () => {
+    const config = makeConfig({ preset: 'mystery' as AppViewConfig['preset'] });
+    expect(resolveAppView(config)).toEqual(APP_VIEW_PRESETS.bsky);
+  });
+
+  it('resolves a valid custom preset using a did:web', () => {
+    const config = makeConfig({
+      preset: 'custom',
+      customUrl: 'https://appview.example.com/',
+      customDid: 'did:web:appview.example.com',
+    });
+    expect(resolveAppView(config)).toEqual({
+      url: 'https://appview.example.com',
+      did: 'did:web:appview.example.com',
+    });
+  });
+
+  it('resolves a custom preset using a plain did:plc', () => {
+    const config = makeConfig({
+      preset: 'custom',
+      customUrl: 'https://appview.example.com',
+      customDid: 'did:plc:abc123',
+    });
+    expect(resolveAppView(config)).toEqual({
+      url: 'https://appview.example.com',
+      did: 'did:plc:abc123',
+    });
+  });
+
+  it('resolves a custom preset using a did:plc and strips a #bsky_appview fragment', () => {
+    const config = makeConfig({
+      preset: 'custom',
+      customUrl: 'https://appview.example.com',
+      customDid: 'did:plc:abc123#bsky_appview',
+    });
+    expect(resolveAppView(config)).toEqual({
+      url: 'https://appview.example.com',
+      did: 'did:plc:abc123',
+    });
+  });
+
+  it('falls back to bsky when the custom url is missing', () => {
+    const config = makeConfig({ preset: 'custom', customDid: 'did:web:appview.example.com' });
+    expect(resolveAppView(config)).toEqual(APP_VIEW_PRESETS.bsky);
+  });
+
+  it('falls back to bsky when the custom did is missing', () => {
+    const config = makeConfig({ preset: 'custom', customUrl: 'https://appview.example.com' });
+    expect(resolveAppView(config)).toEqual(APP_VIEW_PRESETS.bsky);
+  });
+
+  it('falls back to bsky when the custom url is not http(s)', () => {
+    const config = makeConfig({
+      preset: 'custom',
+      customUrl: 'appview.example.com',
+      customDid: 'did:web:appview.example.com',
+    });
+    expect(resolveAppView(config)).toEqual(APP_VIEW_PRESETS.bsky);
+  });
+
+  it('falls back to bsky when the custom did is not a recognised method', () => {
+    const config = makeConfig({
+      preset: 'custom',
+      customUrl: 'https://appview.example.com',
+      customDid: 'did:key:zabc',
+    });
+    expect(resolveAppView(config)).toEqual(APP_VIEW_PRESETS.bsky);
+  });
+});
+
+describe('resolveAccountAppView', () => {
+  const globalConfig = makeConfig({ preset: 'bsky' });
+
+  it('uses the global config when the account is null', () => {
+    expect(resolveAccountAppView(null, globalConfig)).toEqual(APP_VIEW_PRESETS.bsky);
+  });
+
+  it('uses the global config when the account is undefined', () => {
+    expect(resolveAccountAppView(undefined, globalConfig)).toEqual(APP_VIEW_PRESETS.bsky);
+  });
+
+  it('uses the global config when there is no override', () => {
+    const account: Pick<Account, 'appView'> = {};
+    expect(resolveAccountAppView(account, makeConfig({ preset: 'blacksky' }))).toEqual(APP_VIEW_PRESETS.blacksky);
+  });
+
+  it('uses the global config when the override preset is "default"', () => {
+    const account: Pick<Account, 'appView'> = { appView: { preset: 'default' } };
+    expect(resolveAccountAppView(account, makeConfig({ preset: 'blacksky' }))).toEqual(APP_VIEW_PRESETS.blacksky);
+  });
+
+  it('applies a per-account preset override', () => {
+    const account: Pick<Account, 'appView'> = { appView: { preset: 'blacksky' } };
+    expect(resolveAccountAppView(account, globalConfig)).toEqual(APP_VIEW_PRESETS.blacksky);
+  });
+
+  it('applies a per-account custom override', () => {
+    const account: Pick<Account, 'appView'> = {
+      appView: {
+        preset: 'custom',
+        customUrl: 'https://account.example.com',
+        customDid: 'did:web:account.example.com',
+      },
+    };
+    expect(resolveAccountAppView(account, globalConfig)).toEqual({
+      url: 'https://account.example.com',
+      did: 'did:web:account.example.com',
+    });
+  });
+
+  it('falls back to bsky when a custom override is invalid', () => {
+    const account: Pick<Account, 'appView'> = {
+      appView: { preset: 'custom', customUrl: 'not-a-url' },
+    };
+    expect(resolveAccountAppView(account, globalConfig)).toEqual(APP_VIEW_PRESETS.bsky);
+  });
+});

--- a/apps/akari/__tests__/utils/blueskyApi.test.ts
+++ b/apps/akari/__tests__/utils/blueskyApi.test.ts
@@ -1,0 +1,97 @@
+import type { Account } from '@/types/account';
+import type { AppViewConfig } from '@/utils/appView';
+import { DEFAULT_APP_VIEW } from '@/utils/appView';
+
+const mockBlueskyApi = jest.fn();
+const mockReadAppViewSettings = jest.fn<AppViewConfig, []>();
+
+jest.mock('@/bluesky-api', () => ({
+  BlueskyApi: function BlueskyApi(this: unknown, ...args: unknown[]) {
+    return mockBlueskyApi(...args);
+  },
+}));
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewSettings: () => mockReadAppViewSettings(),
+}));
+
+import { apiForAccount, apiForPdsUrl, apiForPublicAppView } from '@/utils/blueskyApi';
+
+function makeConfig(overrides: Partial<AppViewConfig> = {}): AppViewConfig {
+  return { ...DEFAULT_APP_VIEW, ...overrides };
+}
+
+describe('blueskyApi factory helpers', () => {
+  beforeEach(() => {
+    mockBlueskyApi.mockReset();
+    mockReadAppViewSettings.mockReset();
+    mockReadAppViewSettings.mockReturnValue(makeConfig());
+    // Return a sentinel so we can assert the helper returns the constructed instance.
+    mockBlueskyApi.mockImplementation((...args: unknown[]) => ({ args }) as never);
+  });
+
+  describe('apiForAccount', () => {
+    it('constructs a client at the account pdsUrl with the global default did', () => {
+      const account: Pick<Account, 'pdsUrl' | 'appView'> = { pdsUrl: 'https://pds.example.com' };
+      const result = apiForAccount(account);
+
+      expect(mockBlueskyApi).toHaveBeenCalledWith('https://pds.example.com', 'did:web:api.bsky.app');
+      expect(result).toEqual({ args: ['https://pds.example.com', 'did:web:api.bsky.app'] });
+    });
+
+    it('honours a per-account custom AppView override', () => {
+      const account: Pick<Account, 'pdsUrl' | 'appView'> = {
+        pdsUrl: 'https://pds.example.com',
+        appView: {
+          preset: 'custom',
+          customUrl: 'https://appview.example.com',
+          customDid: 'did:web:appview.example.com',
+        },
+      };
+      apiForAccount(account);
+
+      expect(mockBlueskyApi).toHaveBeenCalledWith('https://pds.example.com', 'did:web:appview.example.com');
+    });
+
+    it('throws when the account has no pdsUrl', () => {
+      const account: Pick<Account, 'pdsUrl' | 'appView'> = {};
+      expect(() => apiForAccount(account)).toThrow('apiForAccount: account is missing pdsUrl');
+      expect(mockBlueskyApi).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('apiForPdsUrl', () => {
+    it('constructs a client at the given pdsUrl using the global default did', () => {
+      const result = apiForPdsUrl('https://other-pds.example.com');
+
+      expect(mockBlueskyApi).toHaveBeenCalledWith('https://other-pds.example.com', 'did:web:api.bsky.app');
+      expect(result).toEqual({ args: ['https://other-pds.example.com', 'did:web:api.bsky.app'] });
+    });
+
+    it('uses the configured preset did when the global config selects blacksky', () => {
+      mockReadAppViewSettings.mockReturnValue(makeConfig({ preset: 'blacksky' }));
+      apiForPdsUrl('https://other-pds.example.com');
+
+      expect(mockBlueskyApi).toHaveBeenCalledWith(
+        'https://other-pds.example.com',
+        'did:web:api.blacksky.community',
+      );
+    });
+  });
+
+  describe('apiForPublicAppView', () => {
+    it('constructs a client at the AppView base url with no proxy did', () => {
+      const result = apiForPublicAppView();
+
+      expect(mockBlueskyApi).toHaveBeenCalledWith('https://public.api.bsky.app', null);
+      expect(result).toEqual({ args: ['https://public.api.bsky.app', null] });
+    });
+
+    it('uses the configured preset url when the global config selects blacksky', () => {
+      mockReadAppViewSettings.mockReturnValue(makeConfig({ preset: 'blacksky' }));
+      apiForPublicAppView();
+
+      expect(mockBlueskyApi).toHaveBeenCalledWith('https://api.blacksky.community', null);
+    });
+  });
+});

--- a/apps/akari/__tests__/utils/blueskyOzone.test.ts
+++ b/apps/akari/__tests__/utils/blueskyOzone.test.ts
@@ -1,0 +1,36 @@
+const mockBlueskyOzoneCtor = jest.fn();
+
+jest.mock('bluesky-ozone', () => ({
+  BlueskyOzone: jest.fn((...args: unknown[]) => {
+    mockBlueskyOzoneCtor(...args);
+    return { args };
+  }),
+}));
+
+import { DEFAULT_OZONE_DID, ozoneForAccount } from '@/utils/blueskyOzone';
+
+describe('ozoneForAccount', () => {
+  beforeEach(() => {
+    mockBlueskyOzoneCtor.mockClear();
+  });
+
+  it('constructs a client rooted at the account pdsUrl with a null appview did', () => {
+    const client = ozoneForAccount({ pdsUrl: 'https://pds.example.com' });
+    expect(mockBlueskyOzoneCtor).toHaveBeenCalledWith('https://pds.example.com', null);
+    expect(client).toBeDefined();
+  });
+
+  it('throws when the account has no pdsUrl', () => {
+    expect(() => ozoneForAccount({ pdsUrl: '' })).toThrow(/missing pdsUrl/);
+    expect(() =>
+      ozoneForAccount({ pdsUrl: undefined as unknown as string }),
+    ).toThrow(/missing pdsUrl/);
+    expect(mockBlueskyOzoneCtor).not.toHaveBeenCalled();
+  });
+});
+
+describe('DEFAULT_OZONE_DID', () => {
+  it('points at the official Bluesky moderation service', () => {
+    expect(DEFAULT_OZONE_DID).toBe('did:plc:ar7c4by46qjdydhdevvrndac');
+  });
+});

--- a/apps/akari/__tests__/utils/cdn.test.ts
+++ b/apps/akari/__tests__/utils/cdn.test.ts
@@ -1,0 +1,94 @@
+import { cdnImageUrl, rewriteCdnUrl } from '@/utils/cdn';
+
+const mockReadAppViewSettings = jest.fn();
+const mockResolveCdnHost = jest.fn();
+
+jest.mock('@/hooks/useAppViewSettings', () => ({
+  readAppViewSettings: () => mockReadAppViewSettings(),
+}));
+
+jest.mock('@/utils/appView', () => ({
+  resolveCdnHost: (config: unknown) => mockResolveCdnHost(config),
+}));
+
+describe('rewriteCdnUrl', () => {
+  beforeEach(() => {
+    mockReadAppViewSettings.mockReset();
+    mockResolveCdnHost.mockReset();
+    mockReadAppViewSettings.mockReturnValue({ cdnPreset: 'bsky' });
+  });
+
+  it('returns undefined for nullish input', () => {
+    expect(rewriteCdnUrl(null)).toBeUndefined();
+    expect(rewriteCdnUrl(undefined)).toBeUndefined();
+    // Host resolution should never be consulted for falsy input.
+    expect(mockResolveCdnHost).not.toHaveBeenCalled();
+  });
+
+  it('returns the empty string verbatim for empty input (not nullish)', () => {
+    expect(rewriteCdnUrl('')).toBe('');
+    expect(mockResolveCdnHost).not.toHaveBeenCalled();
+  });
+
+  it('returns the url unchanged when no CDN override is active', () => {
+    mockResolveCdnHost.mockReturnValue(undefined);
+    const url = 'https://cdn.bsky.app/img/avatar/plain/did/cid@jpeg';
+    expect(rewriteCdnUrl(url)).toBe(url);
+  });
+
+  it('rewrites the host for each known bsky CDN host', () => {
+    mockResolveCdnHost.mockReturnValue('https://cdn.blueat.net');
+    const path = '/img/feed_thumbnail/plain/did:plc:abc/bafy@jpeg';
+    expect(rewriteCdnUrl(`https://cdn.bsky.app${path}`)).toBe(
+      `https://cdn.blueat.net${path}`,
+    );
+    expect(rewriteCdnUrl(`https://cdn.bsky.social${path}`)).toBe(
+      `https://cdn.blueat.net${path}`,
+    );
+    expect(rewriteCdnUrl(`https://public.cdn.bsky.app${path}`)).toBe(
+      `https://cdn.blueat.net${path}`,
+    );
+  });
+
+  it('leaves non-matching hosts untouched even with an override active', () => {
+    mockResolveCdnHost.mockReturnValue('https://cdn.blueat.net');
+    const tenor = 'https://media.tenor.com/abc/def.gif';
+    expect(rewriteCdnUrl(tenor)).toBe(tenor);
+    const local = 'file:///var/tmp/photo.jpg';
+    expect(rewriteCdnUrl(local)).toBe(local);
+  });
+});
+
+describe('cdnImageUrl', () => {
+  beforeEach(() => {
+    mockReadAppViewSettings.mockReset();
+    mockResolveCdnHost.mockReset();
+    mockReadAppViewSettings.mockReturnValue({ cdnPreset: 'bsky' });
+  });
+
+  it('synthesises a cdn.bsky.app url with the default jpeg format', () => {
+    mockResolveCdnHost.mockReturnValue(undefined);
+    expect(
+      cdnImageUrl({ size: 'avatar', did: 'did:plc:abc', blobRef: 'bafy' }),
+    ).toBe('https://cdn.bsky.app/img/avatar/plain/did:plc:abc/bafy@jpeg');
+  });
+
+  it('honours an explicit png format', () => {
+    mockResolveCdnHost.mockReturnValue(undefined);
+    expect(
+      cdnImageUrl({
+        size: 'feed_fullsize',
+        did: 'did:plc:abc',
+        blobRef: 'bafy',
+        format: 'png',
+      }),
+    ).toBe('https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:abc/bafy@png');
+  });
+
+  it('routes the synthesised url through the rewrite when an override is active', () => {
+    mockResolveCdnHost.mockReturnValue('https://cdn.blueat.net');
+    expect(
+      cdnImageUrl({ size: 'banner', did: 'did:plc:abc', blobRef: 'bafy' }),
+    ).toBe('https://cdn.blueat.net/img/banner/plain/did:plc:abc/bafy@jpeg');
+  });
+});

--- a/apps/akari/__tests__/utils/draftMapper.test.ts
+++ b/apps/akari/__tests__/utils/draftMapper.test.ts
@@ -1,0 +1,273 @@
+import type { BlueskyDraftView } from '@/bluesky-api';
+import {
+  composerStateToDraft,
+  draftViewToComposerState,
+  type ComposerDraftState,
+  type DraftPostEntry,
+} from '@/utils/draftMapper';
+import type { PostControls } from '@/utils/postControls';
+
+const EVERYONE_ALLOW_QUOTE: PostControls = {
+  replyAllow: { type: 'everyone' },
+  allowQuote: true,
+};
+
+describe('composerStateToDraft', () => {
+  it('maps a single text-only post with no gating', () => {
+    const draft = composerStateToDraft({
+      posts: [{ text: 'hello world', images: [] }],
+      controls: EVERYONE_ALLOW_QUOTE,
+    });
+    expect(draft).toEqual({ posts: [{ text: 'hello world' }] });
+    // `everyone` reply + allowQuote omit gate fields entirely.
+    expect(draft.threadgateAllow).toBeUndefined();
+    expect(draft.postgateEmbeddingRules).toBeUndefined();
+    expect(draft.deviceId).toBeUndefined();
+    expect(draft.deviceName).toBeUndefined();
+  });
+
+  it('seeds a single blank post when posts is empty', () => {
+    const draft = composerStateToDraft({
+      posts: [],
+      controls: EVERYONE_ALLOW_QUOTE,
+    });
+    expect(draft.posts).toEqual([{ text: '' }]);
+  });
+
+  it('maps multiple thread entries preserving order', () => {
+    const posts: DraftPostEntry[] = [
+      { text: 'first', images: [] },
+      { text: 'second', images: [] },
+      { text: 'third', images: [] },
+    ];
+    const draft = composerStateToDraft({ posts, controls: EVERYONE_ALLOW_QUOTE });
+    expect(draft.posts).toEqual([{ text: 'first' }, { text: 'second' }, { text: 'third' }]);
+  });
+
+  it('maps attached images into embedImages with alt text', () => {
+    const draft = composerStateToDraft({
+      posts: [
+        {
+          text: 'with images',
+          images: [
+            { uri: 'file:///a.jpg', alt: 'an A', mimeType: 'image/jpeg' },
+            { uri: 'file:///b.png', alt: 'a B', mimeType: 'image/png' },
+          ],
+        },
+      ],
+      controls: EVERYONE_ALLOW_QUOTE,
+    });
+    expect(draft.posts[0].embedImages).toEqual([
+      { localRef: { path: 'file:///a.jpg' }, alt: 'an A' },
+      { localRef: { path: 'file:///b.png' }, alt: 'a B' },
+    ]);
+  });
+
+  it('omits alt when an image has empty alt text', () => {
+    const draft = composerStateToDraft({
+      posts: [{ text: 't', images: [{ uri: 'file:///c.jpg', alt: '', mimeType: 'image/jpeg' }] }],
+      controls: EVERYONE_ALLOW_QUOTE,
+    });
+    expect(draft.posts[0].embedImages).toEqual([{ localRef: { path: 'file:///c.jpg' }, alt: undefined }]);
+  });
+
+  it('does not set embedImages when there are no images', () => {
+    const draft = composerStateToDraft({
+      posts: [{ text: 't', images: [] }],
+      controls: EVERYONE_ALLOW_QUOTE,
+    });
+    expect('embedImages' in draft.posts[0]).toBe(false);
+  });
+
+  it('emits an empty threadgate allow array for `nobody`', () => {
+    const draft = composerStateToDraft({
+      posts: [{ text: 't', images: [] }],
+      controls: { replyAllow: { type: 'nobody' }, allowQuote: true },
+    });
+    expect(draft.threadgateAllow).toEqual([]);
+  });
+
+  it('maps limited reply rules (mention/following/follower/lists)', () => {
+    const draft = composerStateToDraft({
+      posts: [{ text: 't', images: [] }],
+      controls: {
+        replyAllow: {
+          type: 'limited',
+          mention: true,
+          following: true,
+          follower: true,
+          listUris: ['at://list/1', 'at://list/2'],
+        },
+        allowQuote: true,
+      },
+    });
+    expect(draft.threadgateAllow).toEqual([
+      { $type: 'app.bsky.feed.threadgate#mentionRule' },
+      { $type: 'app.bsky.feed.threadgate#followingRule' },
+      { $type: 'app.bsky.feed.threadgate#followerRule' },
+      { $type: 'app.bsky.feed.threadgate#listRule', list: 'at://list/1' },
+      { $type: 'app.bsky.feed.threadgate#listRule', list: 'at://list/2' },
+    ]);
+  });
+
+  it('emits an empty allow array for limited with no flags set', () => {
+    const draft = composerStateToDraft({
+      posts: [{ text: 't', images: [] }],
+      controls: { replyAllow: { type: 'limited' }, allowQuote: true },
+    });
+    expect(draft.threadgateAllow).toEqual([]);
+  });
+
+  it('only includes the rules that are enabled', () => {
+    const draft = composerStateToDraft({
+      posts: [{ text: 't', images: [] }],
+      controls: { replyAllow: { type: 'limited', following: true }, allowQuote: true },
+    });
+    expect(draft.threadgateAllow).toEqual([{ $type: 'app.bsky.feed.threadgate#followingRule' }]);
+  });
+
+  it('adds a postgate disable rule when quotes are not allowed', () => {
+    const draft = composerStateToDraft({
+      posts: [{ text: 't', images: [] }],
+      controls: { replyAllow: { type: 'everyone' }, allowQuote: false },
+    });
+    expect(draft.postgateEmbeddingRules).toEqual([{ $type: 'app.bsky.feed.postgate#disableRule' }]);
+  });
+
+  it('includes deviceId and deviceName when provided', () => {
+    const draft = composerStateToDraft({
+      posts: [{ text: 't', images: [] }],
+      controls: EVERYONE_ALLOW_QUOTE,
+      deviceId: 'device-123',
+      deviceName: 'My Phone',
+    });
+    expect(draft.deviceId).toBe('device-123');
+    expect(draft.deviceName).toBe('My Phone');
+  });
+});
+
+describe('draftViewToComposerState', () => {
+  const baseView = (overrides: Partial<BlueskyDraftView['draft']> = {}): BlueskyDraftView => ({
+    id: 'draft-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-02T00:00:00.000Z',
+    draft: {
+      posts: [{ text: 'hello' }],
+      ...overrides,
+    },
+  });
+
+  it('decodes id, timestamps, posts, and default controls', () => {
+    const state = draftViewToComposerState(baseView());
+    expect(state).toEqual<ComposerDraftState>({
+      id: 'draft-1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-02T00:00:00.000Z',
+      posts: [{ text: 'hello', images: [] }],
+      controls: { replyAllow: { type: 'everyone' }, allowQuote: true },
+    });
+  });
+
+  it('seeds a single blank post when the draft has no posts', () => {
+    const state = draftViewToComposerState(baseView({ posts: [] }));
+    expect(state.posts).toEqual([{ text: '', images: [] }]);
+  });
+
+  it('defaults missing post text to empty string', () => {
+    const state = draftViewToComposerState(
+      baseView({ posts: [{ text: undefined as unknown as string }] }),
+    );
+    expect(state.posts[0].text).toBe('');
+  });
+
+  it('decodes embedded images, defaulting missing alt to empty string', () => {
+    const state = draftViewToComposerState(
+      baseView({
+        posts: [
+          {
+            text: 'images',
+            embedImages: [
+              { localRef: { path: 'file:///a.jpg' }, alt: 'alt A' },
+              { localRef: { path: 'file:///b.jpg' } },
+            ],
+          },
+        ],
+      }),
+    );
+    expect(state.posts[0].images).toEqual([
+      { uri: 'file:///a.jpg', alt: 'alt A', mimeType: 'image/jpeg' },
+      { uri: 'file:///b.jpg', alt: '', mimeType: 'image/jpeg' },
+    ]);
+  });
+
+  it('maps an empty threadgate allow array to `nobody`', () => {
+    const state = draftViewToComposerState(baseView({ threadgateAllow: [] }));
+    expect(state.controls.replyAllow).toEqual({ type: 'nobody' });
+  });
+
+  it('maps threadgate rules to limited controls (all rule types)', () => {
+    const state = draftViewToComposerState(
+      baseView({
+        threadgateAllow: [
+          { $type: 'app.bsky.feed.threadgate#mentionRule' },
+          { $type: 'app.bsky.feed.threadgate#followingRule' },
+          { $type: 'app.bsky.feed.threadgate#followerRule' },
+          { $type: 'app.bsky.feed.threadgate#listRule', list: 'at://list/1' },
+          { $type: 'app.bsky.feed.threadgate#listRule', list: 'at://list/2' },
+        ],
+      }),
+    );
+    expect(state.controls.replyAllow).toEqual({
+      type: 'limited',
+      mention: true,
+      following: true,
+      follower: true,
+      listUris: ['at://list/1', 'at://list/2'],
+    });
+  });
+
+  it('omits listUris when no list rules are present', () => {
+    const state = draftViewToComposerState(
+      baseView({ threadgateAllow: [{ $type: 'app.bsky.feed.threadgate#mentionRule' }] }),
+    );
+    expect(state.controls.replyAllow).toEqual({ type: 'limited', mention: true });
+  });
+
+  it('reads allowQuote false when a postgate disable rule is present', () => {
+    const state = draftViewToComposerState(
+      baseView({ postgateEmbeddingRules: [{ $type: 'app.bsky.feed.postgate#disableRule' }] }),
+    );
+    expect(state.controls.allowQuote).toBe(false);
+  });
+
+  it('reads allowQuote true when postgate rules is an empty array', () => {
+    const state = draftViewToComposerState(baseView({ postgateEmbeddingRules: [] }));
+    expect(state.controls.allowQuote).toBe(true);
+  });
+});
+
+describe('round-trip', () => {
+  it('preserves text, images, and controls through encode then decode', () => {
+    const posts: DraftPostEntry[] = [
+      {
+        text: 'first',
+        images: [{ uri: 'file:///a.jpg', alt: 'A', mimeType: 'image/jpeg' }],
+      },
+      { text: 'second', images: [] },
+    ];
+    const controls: PostControls = {
+      replyAllow: { type: 'limited', following: true, listUris: ['at://list/x'] },
+      allowQuote: false,
+    };
+    const draft = composerStateToDraft({ posts, controls });
+    const view: BlueskyDraftView = {
+      id: 'rt-1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      draft,
+    };
+    const state = draftViewToComposerState(view);
+    expect(state.posts).toEqual(posts);
+    expect(state.controls).toEqual(controls);
+  });
+});

--- a/apps/akari/__tests__/utils/embedThumb.test.ts
+++ b/apps/akari/__tests__/utils/embedThumb.test.ts
@@ -1,0 +1,82 @@
+import {
+  matchYouTubeId,
+  resolveExternalThumb,
+  vimeoThumbnailFor,
+  youtubeThumbnailUrl,
+} from '@/utils/embedThumb';
+
+describe('resolveExternalThumb', () => {
+  it('returns undefined for nullish / falsy thumbs', () => {
+    expect(resolveExternalThumb(undefined)).toBeUndefined();
+    expect(resolveExternalThumb(null)).toBeUndefined();
+    expect(resolveExternalThumb('')).toBeUndefined();
+    expect(resolveExternalThumb(0)).toBeUndefined();
+  });
+
+  it('returns a string thumb (view shape) as-is', () => {
+    expect(resolveExternalThumb('https://example.com/thumb.jpg')).toBe(
+      'https://example.com/thumb.jpg',
+    );
+  });
+
+  it('extracts the $link from a blob ref (record shape)', () => {
+    expect(resolveExternalThumb({ ref: { $link: 'bafycid' } })).toBe('bafycid');
+  });
+
+  it('returns undefined when the object has no usable ref', () => {
+    expect(resolveExternalThumb({})).toBeUndefined();
+    expect(resolveExternalThumb({ ref: {} })).toBeUndefined();
+    expect(resolveExternalThumb({ ref: { $link: undefined } })).toBeUndefined();
+  });
+
+  it('returns undefined for other primitive types', () => {
+    expect(resolveExternalThumb(true)).toBeUndefined();
+    expect(resolveExternalThumb(42)).toBeUndefined();
+  });
+});
+
+describe('youtubeThumbnailUrl', () => {
+  it('builds the hqdefault url for a video id', () => {
+    expect(youtubeThumbnailUrl('dQw4w9WgXcQ')).toBe(
+      'https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg',
+    );
+  });
+});
+
+describe('matchYouTubeId', () => {
+  it('matches standard watch urls', () => {
+    expect(matchYouTubeId('https://www.youtube.com/watch?v=abc123')).toBe('abc123');
+  });
+
+  it('matches youtu.be short urls', () => {
+    expect(matchYouTubeId('https://youtu.be/abc123')).toBe('abc123');
+  });
+
+  it('matches music.youtube.com watch urls', () => {
+    expect(matchYouTubeId('https://music.youtube.com/watch?v=abc123')).toBe('abc123');
+  });
+
+  it('matches embed urls', () => {
+    expect(matchYouTubeId('https://www.youtube.com/embed/abc123')).toBe('abc123');
+  });
+
+  it('matches shorts urls', () => {
+    expect(matchYouTubeId('https://youtube.com/shorts/abc123')).toBe('abc123');
+  });
+
+  it('stops the id at query params and fragments', () => {
+    expect(matchYouTubeId('https://www.youtube.com/watch?v=abc123&t=10s')).toBe('abc123');
+  });
+
+  it('returns null for non-youtube urls', () => {
+    expect(matchYouTubeId('https://example.com/video')).toBeNull();
+    expect(matchYouTubeId('https://vimeo.com/12345')).toBeNull();
+  });
+});
+
+describe('vimeoThumbnailFor', () => {
+  it('always returns null (no public no-API pattern)', () => {
+    expect(vimeoThumbnailFor('https://vimeo.com/12345')).toBeNull();
+    expect(vimeoThumbnailFor('')).toBeNull();
+  });
+});

--- a/apps/akari/__tests__/utils/featureFlags.test.ts
+++ b/apps/akari/__tests__/utils/featureFlags.test.ts
@@ -1,0 +1,13 @@
+import { isFeatureEnabled } from '@/utils/featureFlags';
+
+describe('isFeatureEnabled', () => {
+  it('returns the current value for the groupChats flag', () => {
+    // groupChats is gated off until the chat service rolls out group convos
+    // for non-employee accounts.
+    expect(isFeatureEnabled('groupChats')).toBe(false);
+  });
+
+  it('returns a boolean for every defined flag', () => {
+    expect(typeof isFeatureEnabled('groupChats')).toBe('boolean');
+  });
+});

--- a/apps/akari/__tests__/utils/followingCleanupController.test.ts
+++ b/apps/akari/__tests__/utils/followingCleanupController.test.ts
@@ -1,0 +1,679 @@
+import { QueryClient } from '@tanstack/react-query';
+
+import type { BlueskyProfile } from '@/bluesky-api';
+
+const mockIsRateLimitError = jest.fn();
+
+jest.mock('@/bluesky-api', () => ({
+  isRateLimitError: (...args: unknown[]) => mockIsRateLimitError(...args),
+}));
+
+import {
+  followingCleanupQueryKey,
+  getFollowingCleanupController,
+  initialFollowingCleanupState,
+} from '@/utils/followingCleanupController';
+
+type AnyController = {
+  getState: () => ReturnType<typeof initialFollowingCleanupState>;
+  start: (creds: { api: unknown; token: string }) => Promise<void>;
+  pause: () => void;
+  clear: () => void;
+  removeProfile: (did: string) => void;
+  restoreEntry: (entry: unknown) => void;
+};
+
+const ACCOUNT_DID = 'did:plc:me';
+
+function makeProfile(overrides: Partial<BlueskyProfile> & { did: string }): BlueskyProfile {
+  return {
+    handle: `${overrides.did}.test`,
+    ...overrides,
+  } as unknown as BlueskyProfile;
+}
+
+function makeFeedItem(opts: { postIndexedAt?: string; reasonIndexedAt?: string } = {}) {
+  return {
+    post: opts.postIndexedAt ? { indexedAt: opts.postIndexedAt } : undefined,
+    reason: opts.reasonIndexedAt ? { indexedAt: opts.reasonIndexedAt } : undefined,
+  };
+}
+
+/**
+ * Build a mock BlueskyApi. By default everything paginates a single page and
+ * then reports done (no cursor), so a `start()` call completes promptly.
+ */
+function makeApi(over: Partial<Record<string, jest.Mock>> = {}) {
+  return {
+    getFollows: jest.fn().mockResolvedValue({ follows: [], cursor: undefined }),
+    listFollowRecords: jest.fn().mockResolvedValue({ records: [], cursor: undefined }),
+    getProfiles: jest.fn().mockResolvedValue({ profiles: [] }),
+    getAuthorFeed: jest.fn().mockResolvedValue({ feed: [] }),
+    ...over,
+  };
+}
+
+function makeController(api: ReturnType<typeof makeApi>, did = ACCOUNT_DID) {
+  // Use a unique account DID per controller so the module-level registry
+  // doesn't hand back a controller from a previous test with stale state.
+  const queryClient = new QueryClient();
+  const setSpy = jest.spyOn(queryClient, 'setQueryData');
+  const ctrl = getFollowingCleanupController(queryClient, did) as unknown as AnyController;
+  return { ctrl, queryClient, setSpy, creds: { api, token: 'tok' } };
+}
+
+let uniqueCounter = 0;
+function uniqueDid() {
+  uniqueCounter += 1;
+  return `did:plc:acct-${uniqueCounter}`;
+}
+
+let warnSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  // jest.setup.js enables fake timers globally, but this controller leans on
+  // real setTimeout/setInterval polling to interleave its concurrent
+  // producers and workers. Run these tests against real timers.
+  jest.useRealTimers();
+  jest.clearAllMocks();
+  mockIsRateLimitError.mockReturnValue(false);
+  warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+});
+
+describe('followingCleanupQueryKey', () => {
+  it('builds a stable key with the account did', () => {
+    expect(followingCleanupQueryKey('did:plc:x')).toEqual(['followingCleanup', 'did:plc:x']);
+  });
+
+  it('handles an undefined did', () => {
+    expect(followingCleanupQueryKey(undefined)).toEqual(['followingCleanup', undefined]);
+  });
+});
+
+describe('initialFollowingCleanupState', () => {
+  it('returns a fresh idle state', () => {
+    expect(initialFollowingCleanupState()).toEqual({
+      entries: {},
+      totalDiscovered: 0,
+      totalScanned: 0,
+      paginationDone: false,
+      runState: 'idle',
+    });
+  });
+
+  it('returns a new object each call', () => {
+    expect(initialFollowingCleanupState()).not.toBe(initialFollowingCleanupState());
+  });
+});
+
+describe('getFollowingCleanupController', () => {
+  it('returns the same instance for the same account did', () => {
+    const qc = new QueryClient();
+    const a = getFollowingCleanupController(qc, 'did:plc:reuse');
+    const b = getFollowingCleanupController(qc, 'did:plc:reuse');
+    expect(a).toBe(b);
+  });
+
+  it('returns different instances for different account dids', () => {
+    const qc = new QueryClient();
+    const a = getFollowingCleanupController(qc, 'did:plc:one');
+    const b = getFollowingCleanupController(qc, 'did:plc:two');
+    expect(a).not.toBe(b);
+  });
+
+  it('exposes an idle initial state', () => {
+    const qc = new QueryClient();
+    const ctrl = getFollowingCleanupController(qc, 'did:plc:fresh') as unknown as AnyController;
+    expect(ctrl.getState().runState).toBe('idle');
+  });
+});
+
+describe('FollowingCleanupController.start (happy path)', () => {
+  it('discovers, enriches and scans a single follow then completes', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:target';
+    const profile = makeProfile({ did: target });
+    const detailed = makeProfile({ did: target, followersCount: 10 });
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [profile], cursor: undefined }),
+      listFollowRecords: jest.fn().mockResolvedValueOnce({
+        records: [{ value: { subject: target, createdAt: '2024-01-01T00:00:00Z' } }],
+        cursor: undefined,
+      }),
+      getProfiles: jest.fn().mockResolvedValueOnce({ profiles: [detailed] }),
+      getAuthorFeed: jest.fn().mockResolvedValue({
+        feed: [makeFeedItem({ postIndexedAt: '2025-05-05T00:00:00Z' })],
+      }),
+    });
+    const { ctrl, setSpy } = makeController(api, did);
+
+    await ctrl.start({ api, token: 'tok' });
+
+    const state = ctrl.getState();
+    expect(state.runState).toBe('completed');
+    expect(state.paginationDone).toBe(true);
+    expect(state.totalDiscovered).toBe(1);
+    expect(state.totalScanned).toBe(1);
+    const entry = state.entries[target];
+    expect(entry.status).toBe('done');
+    expect(entry.lastActivityAt).toBe('2025-05-05T00:00:00Z');
+    expect(entry.followedAt).toBe('2024-01-01T00:00:00Z');
+    expect(entry.profile.followersCount).toBe(10);
+    // flush writes state to the query cache
+    expect(setSpy).toHaveBeenCalledWith(
+      followingCleanupQueryKey(did),
+      expect.objectContaining({ runState: expect.any(String) }),
+    );
+  });
+
+  it('prefers the reason.indexedAt (repost) over the post indexedAt', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:repost';
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+      getAuthorFeed: jest.fn().mockResolvedValue({
+        feed: [
+          makeFeedItem({
+            postIndexedAt: '2020-01-01T00:00:00Z',
+            reasonIndexedAt: '2025-09-09T00:00:00Z',
+          }),
+        ],
+      }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(ctrl.getState().entries[target].lastActivityAt).toBe('2025-09-09T00:00:00Z');
+  });
+
+  it('retries an empty author feed without the filter and records null activity', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:empty';
+    const getAuthorFeed = jest
+      .fn()
+      .mockResolvedValueOnce({ feed: [] })
+      .mockResolvedValueOnce({ feed: [] });
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+      getAuthorFeed,
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+
+    expect(getAuthorFeed).toHaveBeenCalledTimes(2);
+    // second call is the unfiltered retry (only 3 args)
+    expect(getAuthorFeed.mock.calls[1]).toEqual(['tok', target, 3]);
+    const entry = ctrl.getState().entries[target];
+    expect(entry.status).toBe('done');
+    expect(entry.lastActivityAt).toBeNull();
+  });
+
+  it('paginates multiple follows pages via the cursor', async () => {
+    const did = uniqueDid();
+    const p1 = makeProfile({ did: 'did:plc:p1' });
+    const p2 = makeProfile({ did: 'did:plc:p2' });
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [p1], cursor: 'next' })
+        .mockResolvedValueOnce({ follows: [p2], cursor: undefined }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+
+    const state = ctrl.getState();
+    expect(state.totalDiscovered).toBe(2);
+    expect(Object.keys(state.entries).toSorted()).toEqual(['did:plc:p1', 'did:plc:p2']);
+    // cursor was threaded into the second call
+    expect(api.getFollows.mock.calls[1][3]).toBe('next');
+  });
+
+  it('skips follows that were already discovered', async () => {
+    const did = uniqueDid();
+    const dup = makeProfile({ did: 'did:plc:dup' });
+    const api = makeApi({
+      getFollows: jest.fn().mockResolvedValueOnce({ follows: [dup, dup], cursor: undefined }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(ctrl.getState().totalDiscovered).toBe(1);
+  });
+
+  it('is a no-op when called while already running', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:slow';
+    let resolveFollows: (v: unknown) => void = () => {};
+    const api = makeApi({
+      getFollows: jest.fn().mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFollows = resolve;
+          }),
+      ),
+    });
+    const { ctrl } = makeController(api, did);
+    const first = ctrl.start({ api, token: 'tok' });
+    // second call should return immediately without launching new producers
+    await ctrl.start({ api, token: 'tok' });
+    expect(ctrl.getState().runState).toBe('running');
+    resolveFollows({ follows: [makeProfile({ did: target })], cursor: undefined });
+    await first;
+    expect(ctrl.getState().runState).toBe('completed');
+    expect(api.getFollows).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('FollowingCleanupController.start (follow records producer)', () => {
+  it('stashes orphan followedAt then attaches it when the profile is discovered', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:orphan';
+    // listFollowRecords resolves first (before getFollows) so the date is orphaned.
+    let releaseFollows: (v: unknown) => void = () => {};
+    const api = makeApi({
+      getFollows: jest.fn().mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseFollows = resolve;
+          }),
+      ),
+      listFollowRecords: jest.fn().mockResolvedValueOnce({
+        records: [{ value: { subject: target, createdAt: '2023-03-03T00:00:00Z' } }],
+        cursor: undefined,
+      }),
+    });
+    const { ctrl } = makeController(api, did);
+    const run = ctrl.start({ api, token: 'tok' });
+    // let the records producer run and stash the orphan date
+    await Promise.resolve();
+    await Promise.resolve();
+    releaseFollows({ follows: [makeProfile({ did: target })], cursor: undefined });
+    await run;
+    expect(ctrl.getState().entries[target].followedAt).toBe('2023-03-03T00:00:00Z');
+  });
+
+  it('ignores records missing a subject or createdAt', async () => {
+    const did = uniqueDid();
+    const api = makeApi({
+      listFollowRecords: jest.fn().mockResolvedValueOnce({
+        records: [
+          { value: { subject: undefined, createdAt: '2023-01-01T00:00:00Z' } },
+          { value: { subject: 'did:plc:nope', createdAt: undefined } },
+          { value: undefined },
+        ],
+        cursor: undefined,
+      }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(ctrl.getState().entries).toEqual({});
+  });
+
+  it('paginates follow records via cursor', async () => {
+    const did = uniqueDid();
+    const api = makeApi({
+      listFollowRecords: jest
+        .fn()
+        .mockResolvedValueOnce({ records: [], cursor: 'r2' })
+        .mockResolvedValueOnce({ records: [], cursor: undefined }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(api.listFollowRecords).toHaveBeenCalledTimes(2);
+    expect(api.listFollowRecords.mock.calls[1][3]).toBe('r2');
+  });
+});
+
+describe('FollowingCleanupController.start (profiles enrichment)', () => {
+  it('merges detailed profile data while preserving the viewer.following uri', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:merge';
+    const lightweight = makeProfile({
+      did: target,
+      viewer: { following: 'at://follow/1' },
+    } as Partial<BlueskyProfile> & { did: string });
+    const detailed = makeProfile({
+      did: target,
+      followersCount: 5,
+      viewer: { muted: false },
+    } as Partial<BlueskyProfile> & { did: string });
+    const api = makeApi({
+      getFollows: jest.fn().mockResolvedValueOnce({ follows: [lightweight], cursor: undefined }),
+      getProfiles: jest.fn().mockResolvedValueOnce({ profiles: [detailed] }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    const merged = ctrl.getState().entries[target].profile;
+    expect(merged.followersCount).toBe(5);
+    expect((merged.viewer as { following?: string }).following).toBe('at://follow/1');
+    expect((merged.viewer as { muted?: boolean }).muted).toBe(false);
+  });
+
+  it('ignores detailed entries without a did and unknown dids', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:known';
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+      getProfiles: jest.fn().mockResolvedValueOnce({
+        profiles: [
+          undefined,
+          { did: undefined },
+          makeProfile({ did: 'did:plc:stranger', followersCount: 99 }),
+        ],
+      }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    // stranger never discovered -> not in entries; known stays without counts
+    expect(ctrl.getState().entries['did:plc:stranger']).toBeUndefined();
+    expect(ctrl.getState().entries[target].profile.followersCount).toBeUndefined();
+  });
+});
+
+describe('FollowingCleanupController.start (error handling)', () => {
+  it('retries getFollows on a non-rate-limit error and logs a warning', async () => {
+    const did = uniqueDid();
+    mockIsRateLimitError.mockReturnValue(false);
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce({ follows: [], cursor: undefined }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(api.getFollows).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('does not warn for getFollows rate-limit errors', async () => {
+    const did = uniqueDid();
+    mockIsRateLimitError.mockReturnValue(true);
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('429'))
+        .mockResolvedValueOnce({ follows: [], cursor: undefined }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(api.getFollows).toHaveBeenCalledTimes(2);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('retries listFollowRecords on a non-rate-limit error', async () => {
+    const did = uniqueDid();
+    const api = makeApi({
+      listFollowRecords: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce({ records: [], cursor: undefined }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(api.listFollowRecords).toHaveBeenCalledTimes(2);
+  });
+
+  it('re-queues a getProfiles batch on error and retries', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:retryprofile';
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+      getProfiles: jest
+        .fn()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce({
+          profiles: [makeProfile({ did: target, followersCount: 7 })],
+        }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(api.getProfiles.mock.calls.length).toBeGreaterThanOrEqual(2);
+    expect(ctrl.getState().entries[target].profile.followersCount).toBe(7);
+  });
+
+  it('marks an entry as error on a non-rate-limit author feed failure', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:feederr';
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+      getAuthorFeed: jest.fn().mockRejectedValue(new Error('feed boom')),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    const entry = ctrl.getState().entries[target];
+    expect(entry.status).toBe('error');
+    expect(ctrl.getState().totalScanned).toBe(1);
+  });
+
+  it('requeues a rate-limited author feed scan without counting it', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:feedrl';
+    // first author feed call rate-limits, second succeeds
+    mockIsRateLimitError.mockImplementation((err: unknown) => (err as Error).message === 'rl');
+    const getAuthorFeed = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('rl'))
+      .mockResolvedValue({ feed: [makeFeedItem({ postIndexedAt: '2025-01-01T00:00:00Z' })] });
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+      getAuthorFeed,
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    const entry = ctrl.getState().entries[target];
+    expect(entry.status).toBe('done');
+    // scanned only once despite the rate-limit requeue
+    expect(ctrl.getState().totalScanned).toBe(1);
+    expect(getAuthorFeed.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe('FollowingCleanupController.start (credential guards)', () => {
+  it('completes immediately when start runs but producers find no creds set internally', async () => {
+    // Sanity: a normal empty run still completes.
+    const did = uniqueDid();
+    const api = makeApi();
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(ctrl.getState().runState).toBe('completed');
+  });
+});
+
+describe('FollowingCleanupController.start (resume after completion)', () => {
+  it('wipes state and rescans when start is called again after completion', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:rescan';
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValue({ follows: [makeProfile({ did: target })], cursor: undefined }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(ctrl.getState().runState).toBe('completed');
+    expect(ctrl.getState().totalDiscovered).toBe(1);
+
+    // Second run: completed state is wiped and rebuilt.
+    await ctrl.start({ api, token: 'tok' });
+    expect(ctrl.getState().runState).toBe('completed');
+    expect(ctrl.getState().totalDiscovered).toBe(1);
+    expect(ctrl.getState().totalScanned).toBe(1);
+  });
+});
+
+describe('FollowingCleanupController.pause', () => {
+  it('surfaces paused immediately when idle but data exists', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:pausable';
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+    });
+    const { ctrl, setSpy } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    setSpy.mockClear();
+    ctrl.pause();
+    expect(ctrl.getState().runState).toBe('paused');
+    expect(setSpy).toHaveBeenCalled();
+  });
+
+  it('does nothing when idle with no discovered data', () => {
+    const did = uniqueDid();
+    const { ctrl, setSpy } = makeController(makeApi(), did);
+    ctrl.pause();
+    expect(ctrl.getState().runState).toBe('idle');
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it('requests a graceful stop while running and ends in the paused state', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:running';
+    let releaseFollows: (v: unknown) => void = () => {};
+    const api = makeApi({
+      getFollows: jest.fn().mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            releaseFollows = resolve;
+          }),
+      ),
+    });
+    const { ctrl } = makeController(api, did);
+    const run = ctrl.start({ api, token: 'tok' });
+    await Promise.resolve();
+    ctrl.pause();
+    expect(ctrl.getState().runState).toBe('paused');
+    // unblock the in-flight getFollows so producers can observe pauseRequested
+    releaseFollows({ follows: [makeProfile({ did: target })], cursor: 'more' });
+    await run;
+    expect(ctrl.getState().runState).toBe('paused');
+  });
+
+  it('resumes a paused scan, re-enqueuing pending entries', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:resumeme';
+    let releaseFollows: (v: unknown) => void = () => {};
+    const api = makeApi({
+      getFollows: jest.fn().mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseFollows = resolve;
+          }),
+      ),
+      getAuthorFeed: jest
+        .fn()
+        .mockResolvedValue({ feed: [makeFeedItem({ postIndexedAt: '2025-02-02T00:00:00Z' })] }),
+    });
+    const { ctrl } = makeController(api, did);
+    const run = ctrl.start({ api, token: 'tok' });
+    await Promise.resolve();
+    ctrl.pause();
+    // page comes back with a cursor (pagination not done) but pauseRequested halts it
+    releaseFollows({ follows: [makeProfile({ did: target })], cursor: 'next' });
+    await run;
+    expect(ctrl.getState().runState).toBe('paused');
+
+    // Resume: producer now returns a final page and workers drain the queue.
+    api.getFollows.mockResolvedValue({ follows: [], cursor: undefined });
+    await ctrl.start({ api, token: 'tok' });
+    expect(ctrl.getState().runState).toBe('completed');
+    expect(ctrl.getState().entries[target].status).toBe('done');
+  });
+});
+
+describe('FollowingCleanupController.clear', () => {
+  it('resets all state to the initial idle state', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:clearme';
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+    });
+    const { ctrl, setSpy } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    expect(ctrl.getState().totalDiscovered).toBe(1);
+    setSpy.mockClear();
+    ctrl.clear();
+    expect(ctrl.getState()).toEqual(initialFollowingCleanupState());
+    expect(setSpy).toHaveBeenCalled();
+  });
+});
+
+describe('FollowingCleanupController.removeProfile', () => {
+  it('removes an existing entry and flushes', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:removeme';
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+    });
+    const { ctrl, setSpy } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    setSpy.mockClear();
+    ctrl.removeProfile(target);
+    expect(ctrl.getState().entries[target]).toBeUndefined();
+    expect(setSpy).toHaveBeenCalled();
+  });
+
+  it('is a no-op for an unknown did', () => {
+    const did = uniqueDid();
+    const { ctrl, setSpy } = makeController(makeApi(), did);
+    ctrl.removeProfile('did:plc:ghost');
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('FollowingCleanupController.restoreEntry', () => {
+  it('re-inserts a previously removed entry', () => {
+    const did = uniqueDid();
+    const { ctrl, setSpy } = makeController(makeApi(), did);
+    const entry = {
+      profile: makeProfile({ did: 'did:plc:restored' }),
+      status: 'done' as const,
+      lastActivityAt: '2025-01-01T00:00:00Z',
+      followedAt: null,
+    };
+    ctrl.restoreEntry(entry);
+    expect(ctrl.getState().entries['did:plc:restored']).toBe(entry);
+    expect(setSpy).toHaveBeenCalled();
+  });
+
+  it('does not overwrite an entry that already exists', async () => {
+    const did = uniqueDid();
+    const target = 'did:plc:exists';
+    const api = makeApi({
+      getFollows: jest
+        .fn()
+        .mockResolvedValueOnce({ follows: [makeProfile({ did: target })], cursor: undefined }),
+    });
+    const { ctrl } = makeController(api, did);
+    await ctrl.start({ api, token: 'tok' });
+    const original = ctrl.getState().entries[target];
+    ctrl.restoreEntry({
+      profile: makeProfile({ did: target }),
+      status: 'pending',
+      lastActivityAt: null,
+      followedAt: null,
+    });
+    expect(ctrl.getState().entries[target]).toBe(original);
+  });
+});

--- a/apps/akari/__tests__/utils/liveStatus.test.ts
+++ b/apps/akari/__tests__/utils/liveStatus.test.ts
@@ -1,0 +1,207 @@
+import type { BlueskyActorStatusView } from '@/bluesky-api';
+import type { LiveNowEntry } from '@/hooks/queries/useLiveNow';
+import {
+  DEFAULT_ALLOWED_LIVE_DOMAINS,
+  allowedLiveHostsForDid,
+  formatAllowedLiveServices,
+  getLiveHost,
+  isLiveHostAllowed,
+  isProfileLive,
+  liveServiceName,
+} from '@/utils/liveStatus';
+
+const LIVE_TOKEN = 'app.bsky.actor.status#live';
+
+function makeStatus(overrides: Partial<BlueskyActorStatusView> = {}): BlueskyActorStatusView {
+  return {
+    status: LIVE_TOKEN,
+    record: {},
+    embed: {
+      $type: 'app.bsky.embed.external#view',
+      external: { uri: 'https://www.youtube.com/watch?v=abc' },
+    },
+    ...overrides,
+  };
+}
+
+describe('getLiveHost', () => {
+  it('normalizes a hostname and strips a leading www.', () => {
+    expect(getLiveHost('https://www.youtube.com/watch?v=abc')).toBe('youtube.com');
+  });
+
+  it('lowercases the host', () => {
+    expect(getLiveHost('https://YouTube.COM/live')).toBe('youtube.com');
+  });
+
+  it('keeps provider subdomains intact', () => {
+    expect(getLiveHost('https://someone.substack.com/p/x')).toBe('someone.substack.com');
+  });
+
+  it('returns null for an unparseable url', () => {
+    expect(getLiveHost('not a url')).toBeNull();
+    expect(getLiveHost('')).toBeNull();
+  });
+});
+
+describe('isLiveHostAllowed', () => {
+  const allowed = new Set(['youtube.com', 'substack.com']);
+
+  it('matches an exact host', () => {
+    expect(isLiveHostAllowed('youtube.com', allowed)).toBe(true);
+  });
+
+  it('matches a subdomain of an allowed host', () => {
+    expect(isLiveHostAllowed('someone.substack.com', allowed)).toBe(true);
+  });
+
+  it('normalizes the allowed entries before comparing', () => {
+    expect(isLiveHostAllowed('youtube.com', new Set(['www.YouTube.com']))).toBe(true);
+  });
+
+  it('rejects an unrelated host', () => {
+    expect(isLiveHostAllowed('evil.com', allowed)).toBe(false);
+  });
+
+  it('rejects a host that merely contains an allowed domain as a substring', () => {
+    expect(isLiveHostAllowed('youtube.com.evil.com', allowed)).toBe(false);
+    expect(isLiveHostAllowed('notyoutube.com', allowed)).toBe(false);
+  });
+
+  it('returns false against an empty allow set', () => {
+    expect(isLiveHostAllowed('youtube.com', new Set())).toBe(false);
+  });
+});
+
+describe('allowedLiveHostsForDid', () => {
+  const entries: LiveNowEntry[] = [
+    { did: 'did:plc:alice', domains: ['example.com', 'foo.tv'] },
+    { did: 'did:plc:bob', domains: ['bob-only.com'] },
+  ];
+
+  it('always includes the default allowed domains', () => {
+    const hosts = allowedLiveHostsForDid(undefined, []);
+    for (const domain of DEFAULT_ALLOWED_LIVE_DOMAINS) {
+      expect(hosts.has(domain)).toBe(true);
+    }
+  });
+
+  it('folds in per-DID domains for a matching did', () => {
+    const hosts = allowedLiveHostsForDid('did:plc:alice', entries);
+    expect(hosts.has('example.com')).toBe(true);
+    expect(hosts.has('foo.tv')).toBe(true);
+    expect(hosts.has('bob-only.com')).toBe(false);
+  });
+
+  it('ignores per-DID config when did is undefined', () => {
+    const hosts = allowedLiveHostsForDid(undefined, entries);
+    expect(hosts.has('example.com')).toBe(false);
+  });
+
+  it('returns only defaults when the did has no entry', () => {
+    const hosts = allowedLiveHostsForDid('did:plc:nobody', entries);
+    expect(hosts.has('example.com')).toBe(false);
+    expect(hosts.has('youtube.com')).toBe(true);
+  });
+});
+
+describe('liveServiceName', () => {
+  it('returns the friendly name for a known host', () => {
+    expect(liveServiceName('twitch.tv')).toBe('Twitch');
+    expect(liveServiceName('youtube.com')).toBe('YouTube');
+    expect(liveServiceName('stream.place')).toBe('Streamplace');
+  });
+
+  it('falls back to the bare host for an unknown service', () => {
+    expect(liveServiceName('unknown.example')).toBe('unknown.example');
+  });
+});
+
+describe('formatAllowedLiveServices', () => {
+  it('joins friendly names with commas', () => {
+    const result = formatAllowedLiveServices(new Set(['twitch.tv', 'youtube.com']));
+    expect(result).toBe('Twitch, YouTube');
+  });
+
+  it('normalizes hosts and de-duplicates resulting names', () => {
+    const result = formatAllowedLiveServices(new Set(['www.youtube.com', 'youtube.com']));
+    expect(result).toBe('YouTube');
+  });
+
+  it('returns an empty string for an empty set', () => {
+    expect(formatAllowedLiveServices(new Set())).toBe('');
+  });
+});
+
+describe('isProfileLive', () => {
+  const NOW = Date.parse('2026-05-29T12:00:00.000Z');
+
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(NOW);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns false when there is no status', () => {
+    expect(isProfileLive(undefined, 'did:plc:alice', [])).toBe(false);
+  });
+
+  it('returns false when the status token is not the live token', () => {
+    const status = makeStatus({ status: 'app.bsky.actor.status#offline' });
+    expect(isProfileLive(status, 'did:plc:alice', [])).toBe(false);
+  });
+
+  it('returns false when the status is disabled by a moderator', () => {
+    expect(isProfileLive(makeStatus({ isDisabled: true }), 'did:plc:alice', [])).toBe(false);
+  });
+
+  it('returns false when isActive is explicitly false', () => {
+    expect(isProfileLive(makeStatus({ isActive: false }), 'did:plc:alice', [])).toBe(false);
+  });
+
+  it('returns false when the status has already expired', () => {
+    const status = makeStatus({ expiresAt: '2026-05-29T11:00:00.000Z' });
+    expect(isProfileLive(status, 'did:plc:alice', [])).toBe(false);
+  });
+
+  it('treats an expiry exactly equal to now as expired', () => {
+    const status = makeStatus({ expiresAt: new Date(NOW).toISOString() });
+    expect(isProfileLive(status, 'did:plc:alice', [])).toBe(false);
+  });
+
+  it('ignores a non-finite expiry timestamp', () => {
+    const status = makeStatus({ expiresAt: 'not-a-date' });
+    expect(isProfileLive(status, 'did:plc:alice', [])).toBe(true);
+  });
+
+  it('returns false when the embed has no host', () => {
+    const status = makeStatus({ embed: { external: { uri: 'not a url' } } });
+    expect(isProfileLive(status, 'did:plc:alice', [])).toBe(false);
+  });
+
+  it('returns false when there is no embed at all', () => {
+    const status = makeStatus({ embed: undefined });
+    expect(isProfileLive(status, 'did:plc:alice', [])).toBe(false);
+  });
+
+  it('returns false when the host is not allowed for this DID', () => {
+    const status = makeStatus({ embed: { external: { uri: 'https://evil.com/live' } } });
+    expect(isProfileLive(status, 'did:plc:alice', [])).toBe(false);
+  });
+
+  it('returns true for a valid, unexpired, allowed default host', () => {
+    expect(isProfileLive(makeStatus(), 'did:plc:alice', [])).toBe(true);
+  });
+
+  it('returns true when the future expiry is still ahead of now', () => {
+    const status = makeStatus({ expiresAt: '2026-05-29T13:00:00.000Z' });
+    expect(isProfileLive(status, 'did:plc:alice', [])).toBe(true);
+  });
+
+  it('returns true for a host granted only via per-DID config', () => {
+    const entries: LiveNowEntry[] = [{ did: 'did:plc:alice', domains: ['custom.example'] }];
+    const status = makeStatus({ embed: { external: { uri: 'https://custom.example/live' } } });
+    expect(isProfileLive(status, 'did:plc:alice', entries)).toBe(true);
+  });
+});

--- a/apps/akari/__tests__/utils/navigation.test.ts
+++ b/apps/akari/__tests__/utils/navigation.test.ts
@@ -1,0 +1,266 @@
+import { router, usePathname } from 'expo-router';
+import { Platform } from 'react-native';
+
+import {
+  useNavigateToFeed,
+  useNavigateToGallery,
+  useNavigateToPost,
+  useNavigateToProfile,
+  useProfileHref,
+} from '@/utils/navigation';
+
+// jest.setup.js installs a manual mock for @/utils/navigation (so component
+// tests get a stub). This suite exercises the real implementation, so opt out.
+jest.unmock('@/utils/navigation');
+
+jest.mock('expo-router', () => ({
+  router: { push: jest.fn() },
+  usePathname: jest.fn(),
+}));
+
+const originalPlatform = Platform.OS;
+
+/** Set the value usePathname() returns for the hook under test. */
+function mockPathname(pathname: string) {
+  (usePathname as jest.Mock).mockReturnValue(pathname);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Platform.OS = originalPlatform;
+});
+
+afterAll(() => {
+  Platform.OS = originalPlatform;
+});
+
+describe('useNavigateToPost', () => {
+  it('uses the top-level profile route on web', () => {
+    Platform.OS = 'web';
+    mockPathname('/anything');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).toHaveBeenCalledWith('/profile/alice.test/post/abc');
+  });
+
+  it('encodes actor and rKey', () => {
+    Platform.OS = 'web';
+    mockPathname('/anything');
+    useNavigateToPost()({ actor: 'did:plc:a/b', rKey: 'r k' });
+    expect(router.push).toHaveBeenCalledWith(
+      `/profile/${encodeURIComponent('did:plc:a/b')}/post/${encodeURIComponent('r k')}`,
+    );
+  });
+
+  it('uses the profile tab route on native when on the profile tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/profile/me.test');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).toHaveBeenCalledWith('/profile/alice.test/post/abc');
+  });
+
+  it('uses the collapsed user-profile route on native when on the index tab (root)', () => {
+    Platform.OS = 'ios';
+    mockPathname('/');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).toHaveBeenCalledWith('/user-profile/alice.test/post/abc');
+  });
+
+  it('treats /index paths as the index tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/index/something');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).toHaveBeenCalledWith('/user-profile/alice.test/post/abc');
+  });
+
+  it('treats collapsed /user-profile paths as the index tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/user-profile/bob.test');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).toHaveBeenCalledWith('/user-profile/alice.test/post/abc');
+  });
+
+  it('strips the (tabs) group prefix when detecting the tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/(tabs)/notifications');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).toHaveBeenCalledWith('/notifications/user-profile/alice.test/post/abc');
+  });
+
+  it('uses the per-tab variant for non-index, non-profile tabs', () => {
+    Platform.OS = 'ios';
+    mockPathname('/search/results');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).toHaveBeenCalledWith('/search/user-profile/alice.test/post/abc');
+  });
+
+  it('falls back to the index tab for unknown pathnames', () => {
+    Platform.OS = 'ios';
+    mockPathname('/totally-unknown');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).toHaveBeenCalledWith('/user-profile/alice.test/post/abc');
+  });
+
+  it('does not push when already on the same path (isSamePath guard)', () => {
+    Platform.OS = 'web';
+    mockPathname('/profile/alice.test/post/abc');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).not.toHaveBeenCalled();
+  });
+
+  it('ignores query strings and hashes when comparing paths', () => {
+    Platform.OS = 'web';
+    mockPathname('/profile/alice.test/post/abc?ref=x#top');
+    useNavigateToPost()({ actor: 'alice.test', rKey: 'abc' });
+    expect(router.push).not.toHaveBeenCalled();
+  });
+});
+
+describe('useNavigateToProfile', () => {
+  it('uses the top-level profile route on web', () => {
+    Platform.OS = 'web';
+    mockPathname('/anything');
+    useNavigateToProfile()({ actor: 'alice.test' });
+    expect(router.push).toHaveBeenCalledWith('/profile/alice.test');
+  });
+
+  it('uses the profile tab route on native when on the profile tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/profile/me.test');
+    useNavigateToProfile()({ actor: 'alice.test' });
+    expect(router.push).toHaveBeenCalledWith('/profile/alice.test');
+  });
+
+  it('uses the collapsed user-profile route on native when on the index tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/');
+    useNavigateToProfile()({ actor: 'alice.test' });
+    expect(router.push).toHaveBeenCalledWith('/user-profile/alice.test');
+  });
+
+  it('uses the per-tab variant for other tabs', () => {
+    Platform.OS = 'ios';
+    mockPathname('/messages/convo');
+    useNavigateToProfile()({ actor: 'alice.test' });
+    expect(router.push).toHaveBeenCalledWith('/messages/user-profile/alice.test');
+  });
+
+  it('does not push when already on the same profile path', () => {
+    Platform.OS = 'web';
+    mockPathname('/profile/alice.test');
+    useNavigateToProfile()({ actor: 'alice.test' });
+    expect(router.push).not.toHaveBeenCalled();
+  });
+});
+
+describe('useProfileHref', () => {
+  it('returns the top-level profile href on web', () => {
+    Platform.OS = 'web';
+    mockPathname('/anything');
+    expect(useProfileHref()('alice.test')).toBe('/profile/alice.test');
+  });
+
+  it('returns the profile tab href when on the profile tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/profile/me.test');
+    expect(useProfileHref()('alice.test')).toBe('/profile/alice.test');
+  });
+
+  it('returns the collapsed user-profile href when on the index tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/');
+    expect(useProfileHref()('alice.test')).toBe('/user-profile/alice.test');
+  });
+
+  it('returns the per-tab href for other tabs', () => {
+    Platform.OS = 'ios';
+    mockPathname('/bookmarks');
+    expect(useProfileHref()('alice.test')).toBe('/bookmarks/user-profile/alice.test');
+  });
+
+  it('encodes the actor', () => {
+    Platform.OS = 'web';
+    mockPathname('/anything');
+    expect(useProfileHref()('did:plc:a/b')).toBe(`/profile/${encodeURIComponent('did:plc:a/b')}`);
+  });
+
+  it('does not push (href-only helper)', () => {
+    Platform.OS = 'ios';
+    mockPathname('/');
+    useProfileHref()('alice.test');
+    expect(router.push).not.toHaveBeenCalled();
+  });
+});
+
+describe('useNavigateToFeed', () => {
+  it('uses the top-level profile feed route on web', () => {
+    Platform.OS = 'web';
+    mockPathname('/anything');
+    useNavigateToFeed()({ actor: 'alice.test', rKey: 'feed1' });
+    expect(router.push).toHaveBeenCalledWith('/profile/alice.test/feed/feed1');
+  });
+
+  it('uses the profile tab feed route on native when on the profile tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/profile/me.test');
+    useNavigateToFeed()({ actor: 'alice.test', rKey: 'feed1' });
+    expect(router.push).toHaveBeenCalledWith('/profile/alice.test/feed/feed1');
+  });
+
+  it('uses the collapsed user-profile feed route on the index tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/');
+    useNavigateToFeed()({ actor: 'alice.test', rKey: 'feed1' });
+    expect(router.push).toHaveBeenCalledWith('/user-profile/alice.test/feed/feed1');
+  });
+
+  it('uses the per-tab variant for other tabs', () => {
+    Platform.OS = 'ios';
+    mockPathname('/search/x');
+    useNavigateToFeed()({ actor: 'alice.test', rKey: 'feed1' });
+    expect(router.push).toHaveBeenCalledWith('/search/user-profile/alice.test/feed/feed1');
+  });
+
+  it('does not push when already on the same feed path', () => {
+    Platform.OS = 'web';
+    mockPathname('/profile/alice.test/feed/feed1');
+    useNavigateToFeed()({ actor: 'alice.test', rKey: 'feed1' });
+    expect(router.push).not.toHaveBeenCalled();
+  });
+});
+
+describe('useNavigateToGallery', () => {
+  it('uses the top-level profile gallery route on web', () => {
+    Platform.OS = 'web';
+    mockPathname('/anything');
+    useNavigateToGallery()({ actor: 'alice.test', rKey: 'gal1' });
+    expect(router.push).toHaveBeenCalledWith('/profile/alice.test/gallery/gal1');
+  });
+
+  it('uses the profile tab gallery route on native when on the profile tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/profile/me.test');
+    useNavigateToGallery()({ actor: 'alice.test', rKey: 'gal1' });
+    expect(router.push).toHaveBeenCalledWith('/profile/alice.test/gallery/gal1');
+  });
+
+  it('uses the collapsed user-profile gallery route on the index tab', () => {
+    Platform.OS = 'ios';
+    mockPathname('/');
+    useNavigateToGallery()({ actor: 'alice.test', rKey: 'gal1' });
+    expect(router.push).toHaveBeenCalledWith('/user-profile/alice.test/gallery/gal1');
+  });
+
+  it('uses the per-tab variant for other tabs', () => {
+    Platform.OS = 'ios';
+    mockPathname('/bookmarks');
+    useNavigateToGallery()({ actor: 'alice.test', rKey: 'gal1' });
+    expect(router.push).toHaveBeenCalledWith('/bookmarks/user-profile/alice.test/gallery/gal1');
+  });
+
+  it('does not push when already on the same gallery path', () => {
+    Platform.OS = 'web';
+    mockPathname('/profile/alice.test/gallery/gal1');
+    useNavigateToGallery()({ actor: 'alice.test', rKey: 'gal1' });
+    expect(router.push).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/utils/oauth/clientBinding.test.ts
+++ b/apps/akari/__tests__/utils/oauth/clientBinding.test.ts
@@ -1,0 +1,127 @@
+import type { Account } from '@/types/account';
+
+const mockRegisterDpopSigner = jest.fn();
+const mockUnregisterDpopSigner = jest.fn();
+const mockSignDpopProof = jest.fn((..._args: unknown[]) => 'signed-proof');
+const mockGetItem = jest.fn();
+
+jest.mock('@/bluesky-api', () => ({
+  registerDpopSigner: (...args: unknown[]) => mockRegisterDpopSigner(...args),
+  unregisterDpopSigner: (...args: unknown[]) => mockUnregisterDpopSigner(...args),
+}));
+
+jest.mock('@/utils/secureStorage', () => ({
+  storage: {
+    getItem: (...args: unknown[]) => mockGetItem(...args),
+  },
+}));
+
+jest.mock('@/utils/oauth/dpop', () => ({
+  signDpopProof: (...args: unknown[]) => mockSignDpopProof(...args),
+}));
+
+import {
+  bindOAuthAccount,
+  restoreOAuthBindingFromStorage,
+  unbindOAuthAccount,
+} from '@/utils/oauth/clientBinding';
+
+const oauthAccount: Account = {
+  did: 'did:plc:abc',
+  handle: 'alice.test',
+  pdsUrl: 'https://pds.test',
+  jwtToken: 'access-token-1',
+  refreshToken: 'refresh-1',
+  oauth: {
+    dpopPrivateKeyHex: 'aa'.repeat(32),
+    dpopPublicJwk: { kty: 'EC', crv: 'P-256', x: 'X', y: 'Y' },
+    authServer: { issuer: 'https://auth.test', token_endpoint: 'https://auth.test/token' },
+    expiresAt: 1_700_000_000,
+    scope: 'atproto',
+  },
+};
+
+const passwordAccount: Account = {
+  did: 'did:plc:pw',
+  handle: 'bob.test',
+  pdsUrl: 'https://pds.test',
+  jwtToken: 'bearer-token',
+  refreshToken: 'refresh-pw',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('bindOAuthAccount', () => {
+  it('registers a DPoP signer keyed by the access token for OAuth accounts', () => {
+    bindOAuthAccount(oauthAccount);
+    expect(mockRegisterDpopSigner).toHaveBeenCalledTimes(1);
+    const [accessJwt, signer] = mockRegisterDpopSigner.mock.calls[0];
+    expect(accessJwt).toBe('access-token-1');
+    expect(typeof signer).toBe('function');
+  });
+
+  it('is a no-op for handle/app-password accounts', () => {
+    bindOAuthAccount(passwordAccount);
+    expect(mockRegisterDpopSigner).not.toHaveBeenCalled();
+  });
+
+  it('the registered signer delegates to signDpopProof with the account keypair', async () => {
+    bindOAuthAccount(oauthAccount);
+    const signer = mockRegisterDpopSigner.mock.calls[0][1] as (input: {
+      method: string;
+      url: string;
+      nonce?: string;
+    }) => Promise<string>;
+
+    const proof = await signer({
+      method: 'POST',
+      url: 'https://pds.test/xrpc/foo',
+      nonce: 'srv-nonce',
+    });
+
+    expect(proof).toBe('signed-proof');
+    expect(mockSignDpopProof).toHaveBeenCalledWith({
+      keypair: {
+        privateKeyHex: 'aa'.repeat(32),
+        publicJwk: { kty: 'EC', crv: 'P-256', x: 'X', y: 'Y' },
+      },
+      htm: 'POST',
+      htu: 'https://pds.test/xrpc/foo',
+      nonce: 'srv-nonce',
+      accessToken: 'access-token-1',
+    });
+  });
+});
+
+describe('unbindOAuthAccount', () => {
+  it('unregisters the signer for the account access token', () => {
+    unbindOAuthAccount(oauthAccount);
+    expect(mockUnregisterDpopSigner).toHaveBeenCalledWith('access-token-1');
+  });
+});
+
+describe('restoreOAuthBindingFromStorage', () => {
+  it('rebinds the persisted current account when it is OAuth-authenticated', () => {
+    mockGetItem.mockReturnValue(oauthAccount);
+    restoreOAuthBindingFromStorage();
+    expect(mockGetItem).toHaveBeenCalledWith('currentAccount');
+    expect(mockRegisterDpopSigner).toHaveBeenCalledWith(
+      'access-token-1',
+      expect.any(Function),
+    );
+  });
+
+  it('does nothing when the current account is a non-OAuth account', () => {
+    mockGetItem.mockReturnValue(passwordAccount);
+    restoreOAuthBindingFromStorage();
+    expect(mockRegisterDpopSigner).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when there is no persisted current account', () => {
+    mockGetItem.mockReturnValue(null);
+    restoreOAuthBindingFromStorage();
+    expect(mockRegisterDpopSigner).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/utils/oauth/config.test.ts
+++ b/apps/akari/__tests__/utils/oauth/config.test.ts
@@ -1,0 +1,150 @@
+// Inject a controlled scope catalog so we can exercise every branch of
+// buildSelectedScopeString / defaultScopeSelection (required vs optional flat
+// scopes, tokens fan-out, requiredActions vs user-toggled repo actions).
+const flatScopes = [
+  { id: 'atproto', required: true, defaultEnabled: true, labelKey: 'l', descriptionKey: 'd' },
+  // optional, off by default
+  { id: 'optional-scope', required: false, defaultEnabled: false, labelKey: 'l', descriptionKey: 'd' },
+  // optional, on by default
+  { id: 'default-on', required: false, defaultEnabled: true, labelKey: 'l', descriptionKey: 'd' },
+  // required + token fan-out
+  { id: 'blobs', tokens: ['blobs?accept=image/*'], required: true, defaultEnabled: true, labelKey: 'l', descriptionKey: 'd' },
+];
+
+const repoScopes = [
+  {
+    collection: 'app.example.post',
+    actions: ['create', 'update', 'delete'],
+    defaultActions: ['create'],
+    requiredActions: ['create'],
+    labelKey: 'l',
+    descriptionKey: 'd',
+  },
+  {
+    collection: 'app.example.like',
+    actions: ['create', 'delete'],
+    defaultActions: ['create', 'delete'],
+    labelKey: 'l',
+    descriptionKey: 'd',
+  },
+];
+
+jest.mock('@/scripts/lib/oauth-scope-data', () => ({
+  flatScopes,
+  repoScopes,
+  buildFullScopeString: () => 'atproto full-scope-string',
+}));
+
+import {
+  OAUTH_CLIENT_ID,
+  OAUTH_FLAT_SCOPES,
+  OAUTH_FULL_SCOPE,
+  OAUTH_REDIRECT_URI,
+  OAUTH_REPO_SCOPES,
+  OAUTH_SCOPE,
+  buildSelectedScopeString,
+  defaultScopeSelection,
+  type ScopeSelection,
+} from '@/utils/oauth/config';
+
+describe('config constants (native / ios platform)', () => {
+  it('uses the native client metadata URL on non-web platforms', () => {
+    expect(OAUTH_CLIENT_ID).toBe(
+      'https://akari.lucidsoft.works/.well-known/oauth-client.json',
+    );
+  });
+
+  it('uses the reverse-DNS custom-scheme redirect on native', () => {
+    expect(OAUTH_REDIRECT_URI).toBe('works.lucidsoft.akari:/oauth/callback');
+  });
+
+  it('re-exports the (mocked) scope catalog', () => {
+    expect(OAUTH_FLAT_SCOPES).toBe(flatScopes);
+    expect(OAUTH_REPO_SCOPES).toBe(repoScopes);
+  });
+
+  it('OAUTH_FULL_SCOPE delegates to buildFullScopeString', () => {
+    expect(OAUTH_FULL_SCOPE).toBe('atproto full-scope-string');
+  });
+});
+
+describe('buildSelectedScopeString', () => {
+  it('forces required flat scopes on even when the selection omits them', () => {
+    const selection: ScopeSelection = { flat: {}, repo: {} };
+    const result = buildSelectedScopeString(selection);
+    expect(result).toContain('atproto');
+    // token fan-out expands to the literal tokens, not the id
+    expect(result).toContain('blobs?accept=image/*');
+    expect(result).not.toContain('blobs ');
+  });
+
+  it('drops optional flat scopes that the selection does not enable', () => {
+    const selection: ScopeSelection = { flat: { 'optional-scope': false }, repo: {} };
+    expect(buildSelectedScopeString(selection)).not.toContain('optional-scope');
+  });
+
+  it('includes optional flat scopes the selection enables', () => {
+    const selection: ScopeSelection = { flat: { 'optional-scope': true }, repo: {} };
+    expect(buildSelectedScopeString(selection)).toContain('optional-scope');
+  });
+
+  it('forces requiredActions on repo scopes regardless of selection', () => {
+    const selection: ScopeSelection = {
+      flat: {},
+      repo: { 'app.example.post': { create: false, update: false, delete: false } },
+    };
+    const result = buildSelectedScopeString(selection);
+    // create is a requiredAction -> always present
+    expect(result).toContain('repo:app.example.post?action=create');
+    // update/delete not selected -> absent
+    expect(result).not.toContain('repo:app.example.post?action=update');
+    expect(result).not.toContain('repo:app.example.post?action=delete');
+  });
+
+  it('includes repo actions the user toggled on', () => {
+    const selection: ScopeSelection = {
+      flat: {},
+      repo: { 'app.example.post': { update: true } },
+    };
+    const result = buildSelectedScopeString(selection);
+    expect(result).toContain('repo:app.example.post?action=create'); // required
+    expect(result).toContain('repo:app.example.post?action=update'); // toggled
+  });
+
+  it('handles repo collections missing entirely from the selection', () => {
+    // app.example.like has no requiredActions and is absent from selection.repo
+    const selection: ScopeSelection = { flat: {}, repo: {} };
+    const result = buildSelectedScopeString(selection);
+    expect(result).not.toContain('repo:app.example.like');
+  });
+
+  it('returns a single space-delimited string', () => {
+    const result = buildSelectedScopeString({ flat: {}, repo: {} });
+    expect(result.split(' ').every((t) => t.length > 0)).toBe(true);
+  });
+});
+
+describe('defaultScopeSelection', () => {
+  it('mirrors defaultEnabled on flat scopes', () => {
+    const { flat } = defaultScopeSelection();
+    expect(flat['atproto']).toBe(true);
+    expect(flat['optional-scope']).toBe(false);
+    expect(flat['default-on']).toBe(true);
+  });
+
+  it('sets each repo action true iff it is in defaultActions', () => {
+    const { repo } = defaultScopeSelection();
+    expect(repo['app.example.post']).toEqual({
+      create: true,
+      update: false,
+      delete: false,
+    });
+    expect(repo['app.example.like']).toEqual({ create: true, delete: true });
+  });
+});
+
+describe('OAUTH_SCOPE', () => {
+  it('is the scope string for the default selection', () => {
+    expect(OAUTH_SCOPE).toBe(buildSelectedScopeString(defaultScopeSelection()));
+  });
+});

--- a/apps/akari/__tests__/utils/oauth/config.web.test.ts
+++ b/apps/akari/__tests__/utils/oauth/config.web.test.ts
@@ -1,0 +1,31 @@
+// Covers the Platform.OS === 'web' branch of config.ts. The global jest
+// setup pins Platform.OS to 'ios', so we override it here and re-import the
+// module in isolation.
+
+jest.mock('@/scripts/lib/oauth-scope-data', () => ({
+  flatScopes: [],
+  repoScopes: [],
+  buildFullScopeString: () => '',
+}));
+
+describe('config constants (web platform)', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('uses the web client metadata URL and HTTPS redirect on web', () => {
+    jest.doMock('react-native', () => ({ Platform: { OS: 'web' } }));
+
+    let mod: typeof import('@/utils/oauth/config');
+    jest.isolateModules(() => {
+      mod = require('@/utils/oauth/config');
+    });
+
+    expect(mod!.OAUTH_CLIENT_ID).toBe(
+      'https://akari.lucidsoft.works/.well-known/oauth-client-web.json',
+    );
+    expect(mod!.OAUTH_REDIRECT_URI).toBe(
+      'https://akari.lucidsoft.works/oauth/callback',
+    );
+  });
+});

--- a/apps/akari/__tests__/utils/oauth/par.test.ts
+++ b/apps/akari/__tests__/utils/oauth/par.test.ts
@@ -1,0 +1,130 @@
+import type { DpopKeypair } from '@/utils/oauth/dpop';
+import type { AuthorizationServerMetadata } from '@/utils/oauth/discovery';
+
+const mockDpopFetch = jest.fn();
+
+jest.mock('@/utils/oauth/dpopFetch', () => ({
+  dpopFetch: (...args: unknown[]) => mockDpopFetch(...args),
+}));
+
+import {
+  pushAuthorizationRequest,
+  type PushedAuthorizationRequestInput,
+} from '@/utils/oauth/par';
+
+const authServer: AuthorizationServerMetadata = {
+  issuer: 'https://auth.test',
+  authorization_endpoint: 'https://auth.test/authorize',
+  token_endpoint: 'https://auth.test/token',
+  pushed_authorization_request_endpoint: 'https://auth.test/par',
+};
+
+const keypair: DpopKeypair = {
+  privateKeyHex: 'aa'.repeat(32),
+  publicJwk: { kty: 'EC', crv: 'P-256', x: 'X', y: 'Y' },
+};
+
+const baseInput: PushedAuthorizationRequestInput = {
+  authServer,
+  clientId: 'https://client.test/meta.json',
+  redirectUri: 'app:/cb',
+  scope: 'atproto transition:generic',
+  state: 'state-123',
+  codeChallenge: 'challenge-abc',
+  keypair,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('pushAuthorizationRequest', () => {
+  it('POSTs the PAR params to the PAR endpoint and returns request_uri + expiry', async () => {
+    mockDpopFetch.mockResolvedValue({
+      response: { ok: true, status: 201 },
+      body: { request_uri: 'urn:req:abc', expires_in: 90 },
+      nonce: 'srv-nonce',
+    });
+
+    const result = await pushAuthorizationRequest(baseInput);
+
+    expect(result).toEqual({
+      requestUri: 'urn:req:abc',
+      expiresIn: 90,
+      nonce: 'srv-nonce',
+    });
+
+    expect(mockDpopFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockDpopFetch.mock.calls[0];
+    expect(url).toBe('https://auth.test/par');
+    expect(init.method).toBe('POST');
+    expect(init.keypair).toBe(keypair);
+    expect(init.body).toEqual({
+      client_id: 'https://client.test/meta.json',
+      response_type: 'code',
+      redirect_uri: 'app:/cb',
+      scope: 'atproto transition:generic',
+      state: 'state-123',
+      code_challenge: 'challenge-abc',
+      code_challenge_method: 'S256',
+    });
+  });
+
+  it('omits login_hint when no handle is supplied', async () => {
+    mockDpopFetch.mockResolvedValue({
+      response: { ok: true, status: 201 },
+      body: { request_uri: 'urn:req:abc', expires_in: 90 },
+    });
+    await pushAuthorizationRequest(baseInput);
+    expect(mockDpopFetch.mock.calls[0][1].body.login_hint).toBeUndefined();
+  });
+
+  it('includes login_hint when a handle is supplied', async () => {
+    mockDpopFetch.mockResolvedValue({
+      response: { ok: true, status: 201 },
+      body: { request_uri: 'urn:req:abc', expires_in: 90 },
+    });
+    await pushAuthorizationRequest({ ...baseInput, loginHint: 'alice.test' });
+    expect(mockDpopFetch.mock.calls[0][1].body.login_hint).toBe('alice.test');
+  });
+
+  it('throws with the server error_description when present', async () => {
+    mockDpopFetch.mockResolvedValue({
+      response: { ok: false, status: 400 },
+      body: { error: 'invalid_request', error_description: 'bad scope' },
+    });
+    await expect(pushAuthorizationRequest(baseInput)).rejects.toThrow(
+      'PAR failed: bad scope',
+    );
+  });
+
+  it('falls back to the error code when no description is present', async () => {
+    mockDpopFetch.mockResolvedValue({
+      response: { ok: false, status: 400 },
+      body: { error: 'invalid_request' },
+    });
+    await expect(pushAuthorizationRequest(baseInput)).rejects.toThrow(
+      'PAR failed: invalid_request',
+    );
+  });
+
+  it('falls back to the HTTP status when the body has no error fields', async () => {
+    mockDpopFetch.mockResolvedValue({
+      response: { ok: false, status: 503 },
+      body: null,
+    });
+    await expect(pushAuthorizationRequest(baseInput)).rejects.toThrow(
+      'PAR failed: HTTP 503',
+    );
+  });
+
+  it('throws when the response is ok but request_uri is missing', async () => {
+    mockDpopFetch.mockResolvedValue({
+      response: { ok: true, status: 200 },
+      body: { expires_in: 90 },
+    });
+    await expect(pushAuthorizationRequest(baseInput)).rejects.toThrow(
+      'PAR failed: HTTP 200',
+    );
+  });
+});

--- a/apps/akari/__tests__/utils/oauth/pkce.test.ts
+++ b/apps/akari/__tests__/utils/oauth/pkce.test.ts
@@ -1,0 +1,82 @@
+import { sha256 } from '@noble/hashes/sha2.js';
+
+import {
+  codeChallengeFromVerifier,
+  generateCodeVerifier,
+} from '@/utils/oauth/pkce';
+
+function base64url(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 1) binary += String.fromCharCode(bytes[i]);
+  return globalThis
+    .btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+describe('generateCodeVerifier', () => {
+  it('returns a URL-safe base64 string with no padding', () => {
+    const verifier = generateCodeVerifier();
+    expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(verifier).not.toContain('=');
+  });
+
+  it('encodes 64 random bytes (86-char base64url, no padding)', () => {
+    // 64 bytes -> ceil(64/3)*4 = 88 base64 chars, minus 2 padding '=' = 86.
+    const verifier = generateCodeVerifier();
+    expect(verifier.length).toBe(86);
+  });
+
+  it('fills the buffer via crypto.getRandomValues and encodes that buffer', () => {
+    const spy = jest
+      .spyOn(globalThis.crypto, 'getRandomValues')
+      .mockImplementation(<T extends ArrayBufferView | null>(arr: T): T => {
+        const view = arr as unknown as Uint8Array;
+        for (let i = 0; i < view.length; i += 1) view[i] = i & 0xff;
+        return arr;
+      });
+
+    const verifier = generateCodeVerifier();
+    const expected = base64url(Uint8Array.from({ length: 64 }, (_, i) => i & 0xff));
+    expect(verifier).toBe(expected);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect((spy.mock.calls[0][0] as Uint8Array).length).toBe(64);
+
+    spy.mockRestore();
+  });
+
+  it('produces different verifiers across calls (real randomness)', () => {
+    expect(generateCodeVerifier()).not.toBe(generateCodeVerifier());
+  });
+});
+
+describe('codeChallengeFromVerifier', () => {
+  it('is the URL-safe base64 of SHA-256(verifier)', () => {
+    const verifier = 'test-verifier-value';
+    const expected = base64url(sha256(new TextEncoder().encode(verifier)));
+    expect(codeChallengeFromVerifier(verifier)).toBe(expected);
+  });
+
+  it('is deterministic for the same verifier', () => {
+    const verifier = generateCodeVerifier();
+    expect(codeChallengeFromVerifier(verifier)).toBe(
+      codeChallengeFromVerifier(verifier),
+    );
+  });
+
+  it('is URL-safe and unpadded', () => {
+    const challenge = codeChallengeFromVerifier('abc');
+    expect(challenge).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(challenge).not.toContain('=');
+    // S256 digest is 32 bytes -> 43 base64url chars.
+    expect(challenge.length).toBe(43);
+  });
+
+  it('matches the RFC 7636 appendix B test vector', () => {
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    expect(codeChallengeFromVerifier(verifier)).toBe(
+      'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+    );
+  });
+});

--- a/apps/akari/__tests__/utils/oauth/token.test.ts
+++ b/apps/akari/__tests__/utils/oauth/token.test.ts
@@ -1,0 +1,182 @@
+import type { DpopKeypair } from '@/utils/oauth/dpop';
+import type { AuthorizationServerMetadata } from '@/utils/oauth/discovery';
+
+const mockDpopFetch = jest.fn();
+
+jest.mock('@/utils/oauth/dpopFetch', () => ({
+  dpopFetch: (...args: unknown[]) => mockDpopFetch(...args),
+}));
+
+import {
+  exchangeCodeForTokens,
+  refreshTokens,
+  type ExchangeCodeInput,
+  type RefreshTokenInput,
+} from '@/utils/oauth/token';
+
+const authServer: AuthorizationServerMetadata = {
+  issuer: 'https://auth.test',
+  authorization_endpoint: 'https://auth.test/authorize',
+  token_endpoint: 'https://auth.test/token',
+  pushed_authorization_request_endpoint: 'https://auth.test/par',
+};
+
+const keypair: DpopKeypair = {
+  privateKeyHex: 'aa'.repeat(32),
+  publicJwk: { kty: 'EC', crv: 'P-256', x: 'X', y: 'Y' },
+};
+
+const okTokens = {
+  access_token: 'access-1',
+  refresh_token: 'refresh-1',
+  token_type: 'DPoP' as const,
+  scope: 'atproto',
+  expires_in: 3600,
+  sub: 'did:plc:abc',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('exchangeCodeForTokens', () => {
+  const input: ExchangeCodeInput = {
+    authServer,
+    clientId: 'client-1',
+    redirectUri: 'app:/cb',
+    code: 'auth-code',
+    codeVerifier: 'verifier-1',
+    keypair,
+    nonce: 'in-nonce',
+  };
+
+  it('POSTs the authorization_code grant and returns tokens + nonce', async () => {
+    mockDpopFetch.mockResolvedValue({
+      response: { ok: true, status: 200 },
+      body: okTokens,
+      nonce: 'out-nonce',
+    });
+
+    const result = await exchangeCodeForTokens(input);
+    expect(result).toEqual({ tokens: okTokens, nonce: 'out-nonce' });
+
+    const [url, init] = mockDpopFetch.mock.calls[0];
+    expect(url).toBe('https://auth.test/token');
+    expect(init.method).toBe('POST');
+    expect(init.keypair).toBe(keypair);
+    expect(init.nonce).toBe('in-nonce');
+    expect(init.body).toEqual({
+      grant_type: 'authorization_code',
+      client_id: 'client-1',
+      redirect_uri: 'app:/cb',
+      code: 'auth-code',
+      code_verifier: 'verifier-1',
+    });
+  });
+
+  it('throws with error_description on failure', async () => {
+    mockDpopFetch.mockResolvedValue({
+      response: { ok: false, status: 400 },
+      body: { error: 'invalid_grant', error_description: 'expired code' },
+    });
+    await expect(exchangeCodeForTokens(input)).rejects.toThrow(
+      'token exchange failed: expired code',
+    );
+  });
+
+  it('falls back to error code then HTTP status', async () => {
+    mockDpopFetch.mockResolvedValue({
+      response: { ok: false, status: 400 },
+      body: { error: 'invalid_grant' },
+    });
+    await expect(exchangeCodeForTokens(input)).rejects.toThrow(
+      'token exchange failed: invalid_grant',
+    );
+
+    mockDpopFetch.mockResolvedValue({
+      response: { ok: false, status: 500 },
+      body: null,
+    });
+    await expect(exchangeCodeForTokens(input)).rejects.toThrow(
+      'token exchange failed: HTTP 500',
+    );
+  });
+
+  it('throws when ok but access_token is missing', async () => {
+    mockDpopFetch.mockResolvedValue({
+      response: { ok: true, status: 200 },
+      body: { scope: 'atproto' },
+    });
+    await expect(exchangeCodeForTokens(input)).rejects.toThrow(
+      'token exchange failed: HTTP 200',
+    );
+  });
+});
+
+describe('refreshTokens', () => {
+  const input: RefreshTokenInput = {
+    authServer,
+    clientId: 'client-1',
+    refreshToken: 'old-refresh',
+    keypair,
+    nonce: 'in-nonce',
+  };
+
+  it('POSTs the refresh_token grant and returns tokens + nonce', async () => {
+    mockDpopFetch.mockResolvedValue({
+      response: { ok: true, status: 200 },
+      body: okTokens,
+      nonce: 'out-nonce',
+    });
+
+    const result = await refreshTokens(input);
+    expect(result).toEqual({ tokens: okTokens, nonce: 'out-nonce' });
+
+    const [url, init] = mockDpopFetch.mock.calls[0];
+    expect(url).toBe('https://auth.test/token');
+    expect(init.body).toEqual({
+      grant_type: 'refresh_token',
+      client_id: 'client-1',
+      refresh_token: 'old-refresh',
+    });
+    expect(init.nonce).toBe('in-nonce');
+  });
+
+  it('throws an error carrying status + oauthError on a dead refresh token', async () => {
+    mockDpopFetch.mockResolvedValue({
+      response: { ok: false, status: 400 },
+      body: { error: 'invalid_grant', error_description: 'token revoked' },
+    });
+
+    await expect(refreshTokens(input)).rejects.toMatchObject({
+      message: 'token refresh failed: token revoked',
+      status: 400,
+      oauthError: 'invalid_grant',
+    });
+  });
+
+  it('annotates the error for transient 5xx failures (no oauthError)', async () => {
+    mockDpopFetch.mockResolvedValue({
+      response: { ok: false, status: 503 },
+      body: null,
+    });
+
+    const err = (await refreshTokens(input).catch((e: unknown) => e)) as Error & {
+      status?: number;
+      oauthError?: string;
+    };
+    expect(err.message).toBe('token refresh failed: HTTP 503');
+    expect(err.status).toBe(503);
+    expect(err.oauthError).toBeUndefined();
+  });
+
+  it('throws when ok but access_token is missing', async () => {
+    mockDpopFetch.mockResolvedValue({
+      response: { ok: true, status: 200 },
+      body: { scope: 'atproto' },
+    });
+    await expect(refreshTokens(input)).rejects.toThrow(
+      'token refresh failed: HTTP 200',
+    );
+  });
+});

--- a/apps/akari/__tests__/utils/oauth/webStash.test.ts
+++ b/apps/akari/__tests__/utils/oauth/webStash.test.ts
@@ -1,0 +1,128 @@
+import {
+  clearOAuthFlow,
+  readOAuthFlow,
+  stashOAuthFlow,
+  type StashedOAuthFlow,
+} from '@/utils/oauth/webStash';
+
+const STASH_KEY = 'akari.oauth.in-flight.v1';
+
+const sampleFlow: StashedOAuthFlow = {
+  state: 'state-123',
+  codeVerifier: 'verifier-abc',
+  parNonce: 'nonce-xyz',
+  scope: 'atproto transition:generic',
+  identity: { did: 'did:plc:abc', handle: 'alice.test', pdsUrl: 'https://pds.test' },
+  authServer: {
+    issuer: 'https://auth.test',
+    authorization_endpoint: 'https://auth.test/authorize',
+    token_endpoint: 'https://auth.test/token',
+    pushed_authorization_request_endpoint: 'https://auth.test/par',
+  },
+  keypair: {
+    privateKeyHex: 'aa'.repeat(32),
+    publicJwk: { kty: 'EC', crv: 'P-256', x: 'X', y: 'Y' },
+  },
+};
+
+function makeMemoryStorage() {
+  const map = new Map<string, string>();
+  return {
+    getItem: jest.fn((k: string) => (map.has(k) ? map.get(k)! : null)),
+    setItem: jest.fn((k: string, v: string) => {
+      map.set(k, v);
+    }),
+    removeItem: jest.fn((k: string) => {
+      map.delete(k);
+    }),
+    _map: map,
+  };
+}
+
+describe('webStash with sessionStorage available', () => {
+  let storage: ReturnType<typeof makeMemoryStorage>;
+  let originalWindow: unknown;
+
+  beforeEach(() => {
+    storage = makeMemoryStorage();
+    originalWindow = (globalThis as { window?: unknown }).window;
+    (globalThis as { window?: unknown }).window = {
+      sessionStorage: storage,
+    };
+  });
+
+  afterEach(() => {
+    (globalThis as { window?: unknown }).window = originalWindow;
+  });
+
+  it('stashOAuthFlow serializes the flow into sessionStorage', () => {
+    stashOAuthFlow(sampleFlow);
+    expect(storage.setItem).toHaveBeenCalledWith(
+      STASH_KEY,
+      JSON.stringify(sampleFlow),
+    );
+  });
+
+  it('readOAuthFlow round-trips a stashed flow', () => {
+    stashOAuthFlow(sampleFlow);
+    expect(readOAuthFlow()).toEqual(sampleFlow);
+  });
+
+  it('readOAuthFlow returns null when nothing is stashed', () => {
+    expect(readOAuthFlow()).toBeNull();
+  });
+
+  it('readOAuthFlow returns null on malformed JSON', () => {
+    storage._map.set(STASH_KEY, '{not valid json');
+    expect(readOAuthFlow()).toBeNull();
+  });
+
+  it('clearOAuthFlow removes the stash entry', () => {
+    stashOAuthFlow(sampleFlow);
+    clearOAuthFlow();
+    expect(storage.removeItem).toHaveBeenCalledWith(STASH_KEY);
+    expect(readOAuthFlow()).toBeNull();
+  });
+});
+
+describe('webStash without window (native)', () => {
+  let originalWindow: unknown;
+
+  beforeEach(() => {
+    originalWindow = (globalThis as { window?: unknown }).window;
+    delete (globalThis as { window?: unknown }).window;
+  });
+
+  afterEach(() => {
+    (globalThis as { window?: unknown }).window = originalWindow;
+  });
+
+  it('stashOAuthFlow is a no-op', () => {
+    expect(() => stashOAuthFlow(sampleFlow)).not.toThrow();
+  });
+
+  it('readOAuthFlow returns null', () => {
+    expect(readOAuthFlow()).toBeNull();
+  });
+
+  it('clearOAuthFlow is a no-op', () => {
+    expect(() => clearOAuthFlow()).not.toThrow();
+  });
+});
+
+describe('webStash with window but no sessionStorage', () => {
+  let originalWindow: unknown;
+
+  beforeEach(() => {
+    originalWindow = (globalThis as { window?: unknown }).window;
+    (globalThis as { window?: unknown }).window = {};
+  });
+
+  afterEach(() => {
+    (globalThis as { window?: unknown }).window = originalWindow;
+  });
+
+  it('readOAuthFlow returns null when sessionStorage is undefined', () => {
+    expect(readOAuthFlow()).toBeNull();
+  });
+});

--- a/apps/akari/__tests__/utils/ozoneAvatars.test.ts
+++ b/apps/akari/__tests__/utils/ozoneAvatars.test.ts
@@ -1,0 +1,189 @@
+import {
+  fetchAvatarsByDid,
+  fetchProfilesByDid,
+  subjectDid,
+} from '@/utils/ozoneAvatars';
+import type { BlueskyApi } from '@/bluesky-api';
+
+function makeApi(getProfiles: jest.Mock): BlueskyApi {
+  return { getProfiles } as unknown as BlueskyApi;
+}
+
+describe('fetchAvatarsByDid', () => {
+  it('returns an empty map when no valid DIDs are supplied', async () => {
+    const getProfiles = jest.fn();
+    const out = await fetchAvatarsByDid(makeApi(getProfiles), 'jwt', []);
+    expect(out.size).toBe(0);
+    expect(getProfiles).not.toHaveBeenCalled();
+  });
+
+  it('filters out non-did entries and dedupes', async () => {
+    const getProfiles = jest.fn().mockResolvedValue({
+      profiles: [
+        { did: 'did:plc:a', avatar: 'https://cdn/a.jpg' },
+        { did: 'did:plc:b', avatar: 'https://cdn/b.jpg' },
+      ],
+    });
+    const out = await fetchAvatarsByDid(makeApi(getProfiles), 'jwt', [
+      'did:plc:a',
+      'did:plc:a',
+      'did:plc:b',
+      'not-a-did',
+      '',
+    ]);
+    expect(getProfiles).toHaveBeenCalledTimes(1);
+    expect(getProfiles).toHaveBeenCalledWith('jwt', ['did:plc:a', 'did:plc:b']);
+    expect(out.get('did:plc:a')).toBe('https://cdn/a.jpg');
+    expect(out.get('did:plc:b')).toBe('https://cdn/b.jpg');
+    expect(out.size).toBe(2);
+  });
+
+  it('returns empty map when all DIDs are invalid', async () => {
+    const getProfiles = jest.fn();
+    const out = await fetchAvatarsByDid(makeApi(getProfiles), 'jwt', [
+      'nope',
+      'also-nope',
+    ]);
+    expect(out.size).toBe(0);
+    expect(getProfiles).not.toHaveBeenCalled();
+  });
+
+  it('skips profiles missing a did or a string avatar', async () => {
+    const getProfiles = jest.fn().mockResolvedValue({
+      profiles: [
+        { did: 'did:plc:a', avatar: 'https://cdn/a.jpg' },
+        { did: 'did:plc:b' }, // no avatar
+        { did: 'did:plc:c', avatar: null }, // non-string avatar
+        { avatar: 'https://cdn/orphan.jpg' }, // no did
+      ],
+    });
+    const out = await fetchAvatarsByDid(makeApi(getProfiles), 'jwt', [
+      'did:plc:a',
+      'did:plc:b',
+      'did:plc:c',
+    ]);
+    expect(out.size).toBe(1);
+    expect(out.get('did:plc:a')).toBe('https://cdn/a.jpg');
+  });
+
+  it('chunks requests in batches of 25', async () => {
+    const dids = Array.from({ length: 60 }, (_, i) => `did:plc:${i}`);
+    const getProfiles = jest.fn().mockResolvedValue({ profiles: [] });
+    await fetchAvatarsByDid(makeApi(getProfiles), 'jwt', dids);
+    expect(getProfiles).toHaveBeenCalledTimes(3);
+    expect(getProfiles.mock.calls[0][1]).toHaveLength(25);
+    expect(getProfiles.mock.calls[1][1]).toHaveLength(25);
+    expect(getProfiles.mock.calls[2][1]).toHaveLength(10);
+  });
+
+  it('swallows errors and falls back to a partial/empty map', async () => {
+    const getProfiles = jest.fn().mockRejectedValue(new Error('boom'));
+    const out = await fetchAvatarsByDid(makeApi(getProfiles), 'jwt', ['did:plc:a']);
+    expect(out.size).toBe(0);
+  });
+
+  it('keeps results from successful chunks when a later chunk fails', async () => {
+    const dids = Array.from({ length: 26 }, (_, i) => `did:plc:${i}`);
+    const getProfiles = jest
+      .fn()
+      .mockResolvedValueOnce({
+        profiles: [{ did: 'did:plc:0', avatar: 'https://cdn/0.jpg' }],
+      })
+      .mockRejectedValueOnce(new Error('boom'));
+    const out = await fetchAvatarsByDid(makeApi(getProfiles), 'jwt', dids);
+    expect(out.get('did:plc:0')).toBe('https://cdn/0.jpg');
+    expect(out.size).toBe(1);
+  });
+});
+
+describe('fetchProfilesByDid', () => {
+  it('returns an empty map when no valid DIDs are supplied', async () => {
+    const getProfiles = jest.fn();
+    const out = await fetchProfilesByDid(makeApi(getProfiles), 'jwt', []);
+    expect(out.size).toBe(0);
+    expect(getProfiles).not.toHaveBeenCalled();
+  });
+
+  it('returns full profile-lite blobs and normalizes non-string fields to undefined', async () => {
+    const getProfiles = jest.fn().mockResolvedValue({
+      profiles: [
+        {
+          did: 'did:plc:a',
+          avatar: 'https://cdn/a.jpg',
+          handle: 'alice.test',
+          displayName: 'Alice',
+        },
+        {
+          did: 'did:plc:b',
+          avatar: 42, // non-string
+          handle: null, // non-string
+          displayName: undefined,
+        },
+        { handle: 'orphan.test' }, // no did -> skipped
+      ],
+    });
+    const out = await fetchProfilesByDid(makeApi(getProfiles), 'jwt', [
+      'did:plc:a',
+      'did:plc:b',
+    ]);
+    expect(out.size).toBe(2);
+    expect(out.get('did:plc:a')).toEqual({
+      avatar: 'https://cdn/a.jpg',
+      handle: 'alice.test',
+      displayName: 'Alice',
+    });
+    expect(out.get('did:plc:b')).toEqual({
+      avatar: undefined,
+      handle: undefined,
+      displayName: undefined,
+    });
+  });
+
+  it('chunks requests in batches of 25', async () => {
+    const dids = Array.from({ length: 51 }, (_, i) => `did:plc:${i}`);
+    const getProfiles = jest.fn().mockResolvedValue({ profiles: [] });
+    await fetchProfilesByDid(makeApi(getProfiles), 'jwt', dids);
+    expect(getProfiles).toHaveBeenCalledTimes(3);
+    expect(getProfiles.mock.calls[2][1]).toHaveLength(1);
+  });
+
+  it('swallows errors and returns an empty map', async () => {
+    const getProfiles = jest.fn().mockRejectedValue(new Error('boom'));
+    const out = await fetchProfilesByDid(makeApi(getProfiles), 'jwt', ['did:plc:a']);
+    expect(out.size).toBe(0);
+  });
+});
+
+describe('subjectDid', () => {
+  it('returns undefined for an undefined subject', () => {
+    expect(subjectDid(undefined)).toBeUndefined();
+  });
+
+  it('returns a direct did when present', () => {
+    expect(subjectDid({ did: 'did:plc:direct' })).toBe('did:plc:direct');
+  });
+
+  it('extracts the did from an at:// uri with a collection path', () => {
+    expect(
+      subjectDid({ uri: 'at://did:plc:xyz/app.bsky.feed.post/abc' }),
+    ).toBe('did:plc:xyz');
+  });
+
+  it('extracts the did from an at:// uri with no trailing slash', () => {
+    expect(subjectDid({ uri: 'at://did:plc:onlyrepo' })).toBe('did:plc:onlyrepo');
+  });
+
+  it('returns undefined when the uri is not an at:// uri', () => {
+    expect(subjectDid({ uri: 'https://example.com/foo' })).toBeUndefined();
+  });
+
+  it('returns undefined when neither did nor a usable uri is present', () => {
+    expect(subjectDid({ foo: 'bar' })).toBeUndefined();
+  });
+
+  it('prefers a direct did over a uri', () => {
+    expect(
+      subjectDid({ did: 'did:plc:direct', uri: 'at://did:plc:other/x/y' }),
+    ).toBe('did:plc:direct');
+  });
+});

--- a/apps/akari/__tests__/utils/postCardPressGuard.test.ts
+++ b/apps/akari/__tests__/utils/postCardPressGuard.test.ts
@@ -1,0 +1,39 @@
+import { isCardPressSuppressed, suppressCardPress } from '@/utils/postCardPressGuard';
+
+describe('postCardPressGuard', () => {
+  beforeEach(() => {
+    // jest.setup enables fake timers globally; pin the clock so Date.now()
+    // is deterministic across the suppression-window arithmetic.
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-05-29T00:00:00.000Z'));
+  });
+
+  it('is not suppressed by default', () => {
+    expect(isCardPressSuppressed()).toBe(false);
+  });
+
+  it('suppresses the card press immediately after onPressIn', () => {
+    suppressCardPress();
+    expect(isCardPressSuppressed()).toBe(true);
+  });
+
+  it('stays suppressed within the 350ms window', () => {
+    suppressCardPress();
+    jest.advanceTimersByTime(349);
+    expect(isCardPressSuppressed()).toBe(true);
+  });
+
+  it('clears suppression once the window elapses', () => {
+    suppressCardPress();
+    jest.advanceTimersByTime(351);
+    expect(isCardPressSuppressed()).toBe(false);
+  });
+
+  it('re-arms the window on a subsequent press', () => {
+    suppressCardPress();
+    jest.advanceTimersByTime(351);
+    expect(isCardPressSuppressed()).toBe(false);
+    suppressCardPress();
+    expect(isCardPressSuppressed()).toBe(true);
+  });
+});

--- a/apps/akari/__tests__/utils/queryClient.test.ts
+++ b/apps/akari/__tests__/utils/queryClient.test.ts
@@ -1,0 +1,103 @@
+import type { Query } from '@tanstack/react-query';
+
+const mockInstallAuthRefreshHandler = jest.fn();
+jest.mock('@/utils/authRefreshHandler', () => ({
+  installAuthRefreshHandler: (...args: unknown[]) => mockInstallAuthRefreshHandler(...args),
+}));
+
+type ShouldDehydrate = (query: Query) => boolean;
+type FocusListener = (cb: (focused: boolean) => void) => () => void;
+
+const queryWithStatus = (status: string): Query =>
+  ({ state: { status } }) as unknown as Query;
+
+const removeSubscription = jest.fn();
+
+/**
+ * Re-require react-native + react-query fresh, install spies on the *same*
+ * module instances queryClient.ts will pull in, set the platform, then load
+ * the module under test. resetModules() means the singletons are rebuilt per
+ * test, so spies have to be attached after the reset.
+ */
+const setup = (os: string) => {
+  jest.resetModules();
+  mockInstallAuthRefreshHandler.mockClear();
+  removeSubscription.mockClear();
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { focusManager } = require('@tanstack/react-query');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { AppState, Platform } = require('react-native');
+
+  Platform.OS = os;
+
+  const setEventListenerSpy = jest
+    .spyOn(focusManager, 'setEventListener')
+    .mockImplementation(() => {});
+  const appStateAddSpy = jest
+    .spyOn(AppState, 'addEventListener')
+    .mockReturnValue({ remove: removeSubscription } as unknown as ReturnType<
+      typeof AppState.addEventListener
+    >);
+
+  const mod = require('@/utils/queryClient');
+  return { mod, setEventListenerSpy, appStateAddSpy };
+};
+
+describe('queryClient module', () => {
+  it('exposes the cache age and buster constants', () => {
+    const { mod } = setup('ios');
+    expect(mod.REACT_QUERY_CACHE_MAX_AGE).toBe(1000 * 60 * 60 * 24);
+    expect(mod.REACT_QUERY_CACHE_BUSTER).toBe('akari@1');
+  });
+
+  it('builds a QueryClient with the expected query defaults', () => {
+    const { mod } = setup('ios');
+    const defaults = mod.queryClient.getDefaultOptions();
+    expect(defaults.queries?.gcTime).toBe(mod.REACT_QUERY_CACHE_MAX_AGE);
+    expect(defaults.queries?.retry).toBe(2);
+  });
+
+  it('only dehydrates successful queries', () => {
+    const { mod } = setup('ios');
+    const shouldDehydrate = mod.queryClient.getDefaultOptions().dehydrate
+      ?.shouldDehydrateQuery as ShouldDehydrate;
+    expect(shouldDehydrate(queryWithStatus('success'))).toBe(true);
+    expect(shouldDehydrate(queryWithStatus('pending'))).toBe(false);
+    expect(shouldDehydrate(queryWithStatus('error'))).toBe(false);
+  });
+
+  it('installs the auth refresh handler with the created client', () => {
+    const { mod } = setup('ios');
+    expect(mockInstallAuthRefreshHandler).toHaveBeenCalledTimes(1);
+    expect(mockInstallAuthRefreshHandler).toHaveBeenCalledWith(mod.queryClient);
+  });
+
+  it('wires AppState into the focus manager on native', () => {
+    const { setEventListenerSpy, appStateAddSpy } = setup('ios');
+    expect(setEventListenerSpy).toHaveBeenCalledTimes(1);
+
+    const registerListener = setEventListenerSpy.mock.calls[0][0] as FocusListener;
+    const handleFocus = jest.fn();
+
+    const cleanup = registerListener(handleFocus);
+    expect(appStateAddSpy).toHaveBeenCalledWith('change', expect.any(Function));
+
+    // Driving the AppState callback should forward active-ness to handleFocus.
+    const onChange = appStateAddSpy.mock.calls[0][1] as (status: string) => void;
+    onChange('active');
+    onChange('background');
+    expect(handleFocus).toHaveBeenNthCalledWith(1, true);
+    expect(handleFocus).toHaveBeenNthCalledWith(2, false);
+
+    // The returned cleanup removes the AppState subscription.
+    cleanup();
+    expect(removeSubscription).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the AppState wiring on web', () => {
+    const { setEventListenerSpy, appStateAddSpy } = setup('web');
+    expect(setEventListenerSpy).not.toHaveBeenCalled();
+    expect(appStateAddSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/akari/__tests__/utils/recipeDefinitions.test.ts
+++ b/apps/akari/__tests__/utils/recipeDefinitions.test.ts
@@ -1,0 +1,78 @@
+import { resolveDietaryRestrictions, resolveRecipeDefinition } from '@/utils/recipeDefinitions';
+
+describe('resolveRecipeDefinition', () => {
+  it('returns "N/A" when the token is undefined', () => {
+    expect(resolveRecipeDefinition(undefined, 'cuisine')).toBe('N/A');
+  });
+
+  it('resolves cooking method tokens', () => {
+    expect(resolveRecipeDefinition('exchange.recipe.defs#cookingMethodAirFrying', 'cookingMethod')).toBe('Air Frying');
+    expect(resolveRecipeDefinition('exchange.recipe.defs#cookingMethodNoCook', 'cookingMethod')).toBe('No Cook');
+  });
+
+  it('resolves category tokens', () => {
+    expect(resolveRecipeDefinition('exchange.recipe.defs#categoryEntree', 'category')).toBe('Entrée');
+    expect(resolveRecipeDefinition('exchange.recipe.defs#categorySide', 'category')).toBe('Side Dish');
+  });
+
+  it('resolves cuisine tokens', () => {
+    expect(resolveRecipeDefinition('exchange.recipe.defs#cuisineItalian', 'cuisine')).toBe('Italian');
+    expect(resolveRecipeDefinition('exchange.recipe.defs#cuisineTexMex', 'cuisine')).toBe('Tex-Mex');
+  });
+
+  it('resolves diet tokens', () => {
+    expect(resolveRecipeDefinition('exchange.recipe.defs#dietVegan', 'diet')).toBe('Vegan');
+    expect(resolveRecipeDefinition('exchange.recipe.defs#dietDiabetic', 'diet')).toBe('Diabetic Friendly');
+  });
+
+  it('resolves attribution tokens', () => {
+    expect(resolveRecipeDefinition('exchange.recipe.defs#attributionTypeOriginal', 'attribution')).toBe('Original');
+    expect(resolveRecipeDefinition('exchange.recipe.defs#attributionTypeProduct', 'attribution')).toBe('Product');
+  });
+
+  it('resolves publication tokens', () => {
+    expect(resolveRecipeDefinition('exchange.recipe.defs#publicationTypeBook', 'publication')).toBe('Book');
+    expect(resolveRecipeDefinition('exchange.recipe.defs#publicationTypeMagazine', 'publication')).toBe('Magazine');
+  });
+
+  it('resolves license tokens', () => {
+    expect(resolveRecipeDefinition('exchange.recipe.defs#licensePublicDomain', 'license')).toBe('Public Domain');
+    expect(resolveRecipeDefinition('exchange.recipe.defs#licenseCreativeCommonsByNcSa', 'license')).toBe('CC BY-NC-SA 4.0');
+  });
+
+  it('returns the raw token when it is not found in the mapping', () => {
+    expect(resolveRecipeDefinition('exchange.recipe.defs#unknownToken', 'cuisine')).toBe(
+      'exchange.recipe.defs#unknownToken',
+    );
+  });
+
+  it('returns the raw token for an unrecognized type', () => {
+    // @ts-expect-error exercising the default branch with an invalid type
+    expect(resolveRecipeDefinition('some-token', 'bogus')).toBe('some-token');
+  });
+});
+
+describe('resolveDietaryRestrictions', () => {
+  it('returns an empty array when tokens is undefined', () => {
+    expect(resolveDietaryRestrictions(undefined)).toEqual([]);
+  });
+
+  it('returns an empty array when tokens is empty', () => {
+    expect(resolveDietaryRestrictions([])).toEqual([]);
+  });
+
+  it('resolves each token to its human-readable description', () => {
+    expect(
+      resolveDietaryRestrictions([
+        'exchange.recipe.defs#dietVegan',
+        'exchange.recipe.defs#dietGlutenFree',
+      ]),
+    ).toEqual(['Vegan', 'Gluten Free']);
+  });
+
+  it('passes unknown tokens through unchanged', () => {
+    expect(resolveDietaryRestrictions(['exchange.recipe.defs#dietUnknown'])).toEqual([
+      'exchange.recipe.defs#dietUnknown',
+    ]);
+  });
+});

--- a/apps/akari/__tests__/utils/secureStorageBootstrap.test.ts
+++ b/apps/akari/__tests__/utils/secureStorageBootstrap.test.ts
@@ -1,0 +1,169 @@
+const mockGetItemAsync = jest.fn<Promise<string | null>, [string]>();
+const mockSetItemAsync = jest.fn<Promise<void>, [string, string, unknown?]>();
+
+jest.mock('expo-secure-store', () => ({
+  getItemAsync: (...args: [string]) => mockGetItemAsync(...args),
+  setItemAsync: (...args: [string, string, unknown?]) => mockSetItemAsync(...args),
+  AFTER_FIRST_UNLOCK: 'AFTER_FIRST_UNLOCK',
+}));
+
+const mockGetRandomBytes = jest.fn((size: number) => {
+  const bytes = new Uint8Array(size);
+  for (let i = 0; i < size; i += 1) bytes[i] = i % 256;
+  return bytes;
+});
+jest.mock('expo-crypto', () => ({
+  getRandomBytes: (size: number) => mockGetRandomBytes(size),
+}));
+
+const mockInitialiseSecureStorage = jest.fn();
+jest.mock('@/utils/secureStorage', () => ({
+  initialiseSecureStorage: (...args: unknown[]) => mockInitialiseSecureStorage(...args),
+}));
+
+const mockRecrypt = jest.fn();
+const mockMMKV = jest.fn((_config: unknown) => ({ recrypt: mockRecrypt }));
+jest.mock('react-native-mmkv', () => ({
+  MMKV: (config: unknown) => mockMMKV(config),
+}));
+
+const KEYCHAIN_ENTRY = 'akari.secureStorage.encryptionKey.v1';
+const GLOBAL_KEY = '__akari_secureStorageBootstrap_v1';
+
+const setPlatform = (os: string) => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { Platform } = require('react-native');
+  Platform.OS = os;
+};
+
+const loadModule = () => require('@/utils/secureStorageBootstrap');
+
+describe('bootstrapSecureStorage', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    delete (globalThis as unknown as Record<string, unknown>)[GLOBAL_KEY];
+    mockGetItemAsync.mockReset();
+    mockSetItemAsync.mockReset();
+    mockSetItemAsync.mockResolvedValue(undefined);
+    mockGetRandomBytes.mockClear();
+    mockInitialiseSecureStorage.mockClear();
+    mockRecrypt.mockReset();
+    mockMMKV.mockClear();
+    setPlatform('ios');
+  });
+
+  it('initialises with undefined on web without touching the keychain', async () => {
+    setPlatform('web');
+    const { bootstrapSecureStorage } = loadModule();
+    await bootstrapSecureStorage();
+    expect(mockInitialiseSecureStorage).toHaveBeenCalledWith(undefined);
+    expect(mockGetItemAsync).not.toHaveBeenCalled();
+    expect(mockSetItemAsync).not.toHaveBeenCalled();
+  });
+
+  it('reuses an existing keychain key on native', async () => {
+    mockGetItemAsync.mockResolvedValue('existing-key');
+    const { bootstrapSecureStorage } = loadModule();
+    await bootstrapSecureStorage();
+    expect(mockGetItemAsync).toHaveBeenCalledWith(KEYCHAIN_ENTRY);
+    expect(mockInitialiseSecureStorage).toHaveBeenCalledWith('existing-key');
+    // No key generation or persistence when one already exists.
+    expect(mockGetRandomBytes).not.toHaveBeenCalled();
+    expect(mockSetItemAsync).not.toHaveBeenCalled();
+    expect(mockMMKV).not.toHaveBeenCalled();
+  });
+
+  it('generates, migrates, and persists a new key on first launch', async () => {
+    mockGetItemAsync.mockResolvedValue(null);
+    const { bootstrapSecureStorage } = loadModule();
+    await bootstrapSecureStorage();
+
+    expect(mockGetRandomBytes).toHaveBeenCalledWith(32);
+
+    // A base64 key is generated and threaded through every step consistently.
+    const newKey = mockInitialiseSecureStorage.mock.calls[0][0] as string;
+    expect(typeof newKey).toBe('string');
+    expect(newKey.length).toBeGreaterThan(0);
+
+    // Legacy MMKV store is opened with the old key and recrypted to the new one.
+    expect(mockMMKV).toHaveBeenCalledWith({
+      id: 'secure-storage',
+      encryptionKey: 'dev-key-akari-v2-2024-secure-storage-encryption',
+    });
+    expect(mockRecrypt).toHaveBeenCalledWith(newKey);
+
+    // The new key is persisted with the right keychain accessibility.
+    expect(mockSetItemAsync).toHaveBeenCalledWith(KEYCHAIN_ENTRY, newKey, {
+      keychainAccessible: 'AFTER_FIRST_UNLOCK',
+    });
+
+    // Persist happens before init.
+    const setOrder = mockSetItemAsync.mock.invocationCallOrder[0];
+    const initOrder = mockInitialiseSecureStorage.mock.invocationCallOrder[0];
+    expect(setOrder).toBeLessThan(initOrder);
+  });
+
+  it('still completes when the legacy migration throws, warning in dev', async () => {
+    const dev = (globalThis as unknown as { __DEV__?: boolean }).__DEV__;
+    (globalThis as unknown as { __DEV__?: boolean }).__DEV__ = true;
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    mockGetItemAsync.mockResolvedValue(null);
+    mockMMKV.mockImplementation(() => {
+      throw new Error('no legacy store');
+    });
+    const { bootstrapSecureStorage } = loadModule();
+    await expect(bootstrapSecureStorage()).resolves.toBeUndefined();
+    // Migration failure is swallowed; the new key is still persisted and used.
+    expect(warnSpy).toHaveBeenCalledWith(
+      'secureStorage legacy migration skipped:',
+      expect.any(Error),
+    );
+    expect(mockSetItemAsync).toHaveBeenCalled();
+    expect(mockInitialiseSecureStorage).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+    (globalThis as unknown as { __DEV__?: boolean }).__DEV__ = dev;
+  });
+
+  it('stays silent about a failed migration outside dev', async () => {
+    const dev = (globalThis as unknown as { __DEV__?: boolean }).__DEV__;
+    (globalThis as unknown as { __DEV__?: boolean }).__DEV__ = false;
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    mockGetItemAsync.mockResolvedValue(null);
+    mockMMKV.mockImplementation(() => {
+      throw new Error('no legacy store');
+    });
+    const { bootstrapSecureStorage } = loadModule();
+    await expect(bootstrapSecureStorage()).resolves.toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(mockInitialiseSecureStorage).toHaveBeenCalledTimes(1);
+
+    warnSpy.mockRestore();
+    (globalThis as unknown as { __DEV__?: boolean }).__DEV__ = dev;
+  });
+
+  it('shares one in-flight promise across re-entrant calls', async () => {
+    mockGetItemAsync.mockResolvedValue('existing-key');
+    const { bootstrapSecureStorage } = loadModule();
+    const first = bootstrapSecureStorage();
+    const second = bootstrapSecureStorage();
+    expect(first).toBe(second);
+    await first;
+    // Only one bootstrap actually ran despite two calls.
+    expect(mockGetItemAsync).toHaveBeenCalledTimes(1);
+    expect(mockInitialiseSecureStorage).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the cached promise on failure so a retry can succeed', async () => {
+    mockGetItemAsync.mockRejectedValueOnce(new Error('keychain locked'));
+    const { bootstrapSecureStorage } = loadModule();
+    await expect(bootstrapSecureStorage()).rejects.toThrow('keychain locked');
+
+    // The failed promise must not be cached; a retry runs fresh and succeeds.
+    mockGetItemAsync.mockResolvedValue('existing-key');
+    await expect(bootstrapSecureStorage()).resolves.toBeUndefined();
+    expect(mockInitialiseSecureStorage).toHaveBeenCalledWith('existing-key');
+  });
+});

--- a/apps/akari/__tests__/utils/signupProviders.test.ts
+++ b/apps/akari/__tests__/utils/signupProviders.test.ts
@@ -1,0 +1,87 @@
+import {
+  DEFAULT_SIGNUP_PROVIDER,
+  getProviderPickerLabel,
+  SIGNUP_PROVIDER_ORDER,
+  SIGNUP_PROVIDERS,
+  type SignupProvider,
+  type SignupProviderId,
+} from '@/utils/signupProviders';
+
+describe('SIGNUP_PROVIDERS', () => {
+  const presetIds: Exclude<SignupProviderId, 'custom'>[] = [
+    'bsky',
+    'blacksky',
+    'selfhosted',
+    'eurosky',
+  ];
+
+  it('exposes exactly the four preset providers', () => {
+    expect(Object.keys(SIGNUP_PROVIDERS).toSorted()).toEqual(presetIds.toSorted());
+  });
+
+  it.each(presetIds)('gives provider %s a coherent shape', (id) => {
+    const provider: SignupProvider = SIGNUP_PROVIDERS[id];
+    // The map key must match the provider's own id.
+    expect(provider.id).toBe(id);
+    expect(typeof provider.label).toBe('string');
+    expect(provider.label.length).toBeGreaterThan(0);
+    expect(provider.pdsUrl).toMatch(/^https:\/\//);
+    expect(provider.handleSuffixes.length).toBeGreaterThan(0);
+    // Every suffix is a leading-dot domain.
+    for (const suffix of provider.handleSuffixes) {
+      expect(suffix.startsWith('.')).toBe(true);
+    }
+  });
+
+  it('lists multiple handle suffixes for blacksky with the default first', () => {
+    expect(SIGNUP_PROVIDERS.blacksky.handleSuffixes[0]).toBe('.blacksky.app');
+    expect(SIGNUP_PROVIDERS.blacksky.handleSuffixes.length).toBeGreaterThan(1);
+  });
+});
+
+describe('SIGNUP_PROVIDER_ORDER', () => {
+  it('orders every preset plus the custom escape hatch', () => {
+    expect(SIGNUP_PROVIDER_ORDER).toEqual([
+      'bsky',
+      'blacksky',
+      'selfhosted',
+      'eurosky',
+      'custom',
+    ]);
+  });
+
+  it('ends with the custom entry', () => {
+    expect(SIGNUP_PROVIDER_ORDER[SIGNUP_PROVIDER_ORDER.length - 1]).toBe('custom');
+  });
+
+  it('references each preset provider exactly once', () => {
+    const presets = SIGNUP_PROVIDER_ORDER.filter((id) => id !== 'custom');
+    expect(presets.toSorted()).toEqual(Object.keys(SIGNUP_PROVIDERS).toSorted());
+  });
+});
+
+describe('DEFAULT_SIGNUP_PROVIDER', () => {
+  it('defaults to a known preset provider', () => {
+    expect(DEFAULT_SIGNUP_PROVIDER).toBe('bsky');
+    expect(SIGNUP_PROVIDER_ORDER).toContain(DEFAULT_SIGNUP_PROVIDER);
+    expect(SIGNUP_PROVIDERS[DEFAULT_SIGNUP_PROVIDER as 'bsky']).toBeDefined();
+  });
+});
+
+describe('getProviderPickerLabel', () => {
+  it('returns the brand label for preset providers, ignoring the custom label', () => {
+    expect(getProviderPickerLabel('bsky', 'Custom')).toBe('Bluesky');
+    expect(getProviderPickerLabel('blacksky', 'Custom')).toBe('Blacksky');
+    expect(getProviderPickerLabel('selfhosted', 'Custom')).toBe('selfhosted.social');
+    expect(getProviderPickerLabel('eurosky', 'Custom')).toBe('eurosky.social');
+  });
+
+  it('returns the supplied custom label for the custom escape hatch', () => {
+    expect(getProviderPickerLabel('custom', 'Custom PDS')).toBe('Custom PDS');
+  });
+
+  it('passes the custom label through verbatim', () => {
+    expect(getProviderPickerLabel('custom', '')).toBe('');
+    expect(getProviderPickerLabel('custom', 'Mein eigener Server')).toBe('Mein eigener Server');
+  });
+});

--- a/apps/akari/__tests__/utils/skyblur.test.ts
+++ b/apps/akari/__tests__/utils/skyblur.test.ts
@@ -1,0 +1,80 @@
+import {
+  parseSkyblurUrl,
+  skyblurTextOf,
+  type SkyblurRecordValue,
+} from '@/utils/skyblur';
+
+describe('parseSkyblurUrl', () => {
+  it('returns null for nullish / empty input', () => {
+    expect(parseSkyblurUrl(undefined)).toBeNull();
+    expect(parseSkyblurUrl(null)).toBeNull();
+    expect(parseSkyblurUrl('')).toBeNull();
+  });
+
+  it('returns null for unparseable urls', () => {
+    expect(parseSkyblurUrl('not a url')).toBeNull();
+  });
+
+  it('returns null for non-skyblur hosts', () => {
+    expect(parseSkyblurUrl('https://example.com/post/did:plc:abc/3kxy')).toBeNull();
+  });
+
+  it('parses a valid skyblur post url into a ref', () => {
+    expect(parseSkyblurUrl('https://skyblur.uk/post/did:plc:abc/3kxy')).toEqual({
+      did: 'did:plc:abc',
+      rkey: '3kxy',
+      uri: 'at://did:plc:abc/uk.skyblur.post/3kxy',
+    });
+  });
+
+  it('tolerates a trailing slash and extra path segments', () => {
+    expect(parseSkyblurUrl('https://skyblur.uk/post/did:plc:abc/3kxy/')).toEqual({
+      did: 'did:plc:abc',
+      rkey: '3kxy',
+      uri: 'at://did:plc:abc/uk.skyblur.post/3kxy',
+    });
+  });
+
+  it('decodes percent-encoded did and rkey segments', () => {
+    expect(
+      parseSkyblurUrl('https://skyblur.uk/post/did%3Aplc%3Aabc/3k%78y'),
+    ).toEqual({
+      did: 'did:plc:abc',
+      rkey: '3kxy',
+      uri: 'at://did:plc:abc/uk.skyblur.post/3kxy',
+    });
+  });
+
+  it('returns null when the path is too short', () => {
+    expect(parseSkyblurUrl('https://skyblur.uk/post/did:plc:abc')).toBeNull();
+    expect(parseSkyblurUrl('https://skyblur.uk/')).toBeNull();
+  });
+
+  it('returns null when the first segment is not "post"', () => {
+    expect(parseSkyblurUrl('https://skyblur.uk/feed/did:plc:abc/3kxy')).toBeNull();
+  });
+
+  it('returns null when the did segment is not a did', () => {
+    expect(parseSkyblurUrl('https://skyblur.uk/post/notadid/3kxy')).toBeNull();
+  });
+});
+
+describe('skyblurTextOf', () => {
+  it('returns undefined when value is undefined', () => {
+    expect(skyblurTextOf(undefined)).toBeUndefined();
+  });
+
+  it('returns the text field when it is a string', () => {
+    const value: SkyblurRecordValue = { text: 'my favourite colour is [red].' };
+    expect(skyblurTextOf(value)).toBe('my favourite colour is [red].');
+  });
+
+  it('returns an empty string verbatim', () => {
+    expect(skyblurTextOf({ text: '' })).toBe('');
+  });
+
+  it('returns undefined when text is missing', () => {
+    expect(skyblurTextOf({ additional: 'extra' })).toBeUndefined();
+    expect(skyblurTextOf({})).toBeUndefined();
+  });
+});

--- a/apps/akari/__tests__/utils/streamPlace.test.ts
+++ b/apps/akari/__tests__/utils/streamPlace.test.ts
@@ -1,0 +1,228 @@
+import {
+  STREAM_PLACE_DEFAULT_HOST,
+  fetchStreamPlacePlaybackServers,
+  isStreamPlaceUri,
+  negotiateStreamPlaceWhep,
+} from '@/utils/streamPlace';
+
+describe('STREAM_PLACE_DEFAULT_HOST', () => {
+  it('is the canonical stream.place origin', () => {
+    expect(STREAM_PLACE_DEFAULT_HOST).toBe('https://stream.place');
+  });
+});
+
+describe('isStreamPlaceUri', () => {
+  it('returns false for nullish input', () => {
+    expect(isStreamPlaceUri(undefined)).toBe(false);
+    expect(isStreamPlaceUri(null)).toBe(false);
+    expect(isStreamPlaceUri('')).toBe(false);
+  });
+
+  it('returns false for an unparseable uri', () => {
+    expect(isStreamPlaceUri('not a url')).toBe(false);
+  });
+
+  it('matches stream.place', () => {
+    expect(isStreamPlaceUri('https://stream.place/alice')).toBe(true);
+  });
+
+  it('matches streamplace.com', () => {
+    expect(isStreamPlaceUri('https://streamplace.com/alice')).toBe(true);
+  });
+
+  it('strips a leading www. and lowercases the host', () => {
+    expect(isStreamPlaceUri('https://WWW.Stream.Place/alice')).toBe(true);
+  });
+
+  it('rejects subdomains that are not the bare allowed host', () => {
+    expect(isStreamPlaceUri('https://cdn.stream.place/alice')).toBe(false);
+  });
+
+  it('rejects unrelated hosts', () => {
+    expect(isStreamPlaceUri('https://youtube.com/watch')).toBe(false);
+  });
+});
+
+describe('negotiateStreamPlaceWhep', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('posts the SDP offer to the default host and returns the answer', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue('answer-sdp'),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await negotiateStreamPlaceWhep('did:plc:alice', 'offer-sdp');
+
+    expect(result).toEqual({ sdp: 'answer-sdp' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      'https://stream.place/xrpc/place.stream.playback.whep?streamer=did%3Aplc%3Aalice&rendition=source',
+    );
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe('offer-sdp');
+    expect(init.headers).toEqual({
+      'Content-Type': 'application/sdp',
+      Accept: 'application/sdp',
+    });
+  });
+
+  it('honors a custom playback host, rendition, and abort signal', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue('answer-sdp'),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const controller = new AbortController();
+
+    await negotiateStreamPlaceWhep('did:plc:bob', 'offer', {
+      playbackHost: 'https://edge.example',
+      rendition: '720p',
+      signal: controller.signal,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      'https://edge.example/xrpc/place.stream.playback.whep?streamer=did%3Aplc%3Abob&rendition=720p',
+    );
+    expect(init.signal).toBe(controller.signal);
+  });
+
+  it('throws with the response body text when the request is not ok', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      text: jest.fn().mockResolvedValue('upstream down'),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(negotiateStreamPlaceWhep('did:plc:alice', 'offer')).rejects.toThrow(
+      'WHEP negotiation failed (503): upstream down',
+    );
+  });
+
+  it('swallows a body-read error on a failed response', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: jest.fn().mockRejectedValue(new Error('read failed')),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(negotiateStreamPlaceWhep('did:plc:alice', 'offer')).rejects.toThrow(
+      'WHEP negotiation failed (500): ',
+    );
+  });
+
+  it('throws when the answer body is empty', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      text: jest.fn().mockResolvedValue(''),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(negotiateStreamPlaceWhep('did:plc:alice', 'offer')).rejects.toThrow(
+      'WHEP negotiation returned an empty SDP answer',
+    );
+  });
+});
+
+describe('fetchStreamPlacePlaybackServers', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('requests the default lookup host and returns string servers', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ servers: ['https://a.example', 'https://b.example'] }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await fetchStreamPlacePlaybackServers('did:plc:alice');
+
+    expect(result).toEqual({ servers: ['https://a.example', 'https://b.example'] });
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      'https://stream.place/xrpc/place.stream.playback.getPlaybackServer?stream=did%3Aplc%3Aalice',
+    );
+    expect(init.method).toBe('GET');
+    expect(init.headers).toEqual({ Accept: 'application/json' });
+  });
+
+  it('honors a custom lookup host and abort signal', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ servers: [] }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const controller = new AbortController();
+
+    await fetchStreamPlacePlaybackServers('did:plc:bob', {
+      lookupHost: 'https://lookup.example',
+      signal: controller.signal,
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      'https://lookup.example/xrpc/place.stream.playback.getPlaybackServer?stream=did%3Aplc%3Abob',
+    );
+    expect(init.signal).toBe(controller.signal);
+  });
+
+  it('filters out non-string entries from the servers array', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ servers: ['https://a.example', 42, null, { x: 1 }] }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await fetchStreamPlacePlaybackServers('did:plc:alice');
+    expect(result).toEqual({ servers: ['https://a.example'] });
+  });
+
+  it('returns an empty list when servers is missing or not an array', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({ servers: 'nope' }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await fetchStreamPlacePlaybackServers('did:plc:alice');
+    expect(result).toEqual({ servers: [] });
+  });
+
+  it('returns an empty list when the response omits servers', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({}),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await fetchStreamPlacePlaybackServers('did:plc:alice');
+    expect(result).toEqual({ servers: [] });
+  });
+
+  it('throws when the lookup response is not ok', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: jest.fn(),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(fetchStreamPlacePlaybackServers('did:plc:alice')).rejects.toThrow(
+      'getPlaybackServer failed (404)',
+    );
+  });
+});

--- a/apps/akari/__tests__/utils/systemLog.test.ts
+++ b/apps/akari/__tests__/utils/systemLog.test.ts
@@ -1,0 +1,119 @@
+import {
+  clearSystemLog,
+  getSystemLog,
+  installSystemLogConsoleHook,
+  recordEntry,
+  subscribeSystemLog,
+} from '@/utils/systemLog';
+
+describe('systemLog', () => {
+  beforeEach(() => {
+    clearSystemLog();
+  });
+
+  describe('recordEntry', () => {
+    it('appends an entry with level, message, and timestamp', () => {
+      const before = Date.now();
+      recordEntry('log', ['hello', 'world']);
+      const log = getSystemLog();
+      expect(log).toHaveLength(1);
+      expect(log[0].level).toBe('log');
+      expect(log[0].message).toBe('hello world');
+      expect(log[0].ts).toBeGreaterThanOrEqual(before);
+    });
+
+    it('serializes Error instances to their stack or message', () => {
+      const withStack = new Error('boom');
+      recordEntry('error', [withStack]);
+      expect(getSystemLog()[0].message).toBe(withStack.stack);
+    });
+
+    it('falls back to the error message when no stack is present', () => {
+      const noStack = new Error('no stack');
+      noStack.stack = undefined;
+      recordEntry('error', [noStack]);
+      expect(getSystemLog()[0].message).toBe('no stack');
+    });
+
+    it('JSON-stringifies plain objects', () => {
+      recordEntry('info', [{ a: 1 }, 42]);
+      expect(getSystemLog()[0].message).toBe('{"a":1} 42');
+    });
+
+    it('falls back to String() for non-serializable values', () => {
+      const circular: Record<string, unknown> = {};
+      circular.self = circular;
+      recordEntry('warn', [circular]);
+      expect(getSystemLog()[0].message).toBe('[object Object]');
+    });
+
+    it('trims the buffer to the max capacity (200)', () => {
+      for (let i = 0; i < 250; i++) {
+        recordEntry('log', [`entry-${i}`]);
+      }
+      const log = getSystemLog();
+      expect(log).toHaveLength(200);
+      // Oldest entries shifted out; the first remaining is entry-50.
+      expect(log[0].message).toBe('entry-50');
+      expect(log[log.length - 1].message).toBe('entry-249');
+    });
+
+    it('notifies subscribers on each record', () => {
+      const listener = jest.fn();
+      subscribeSystemLog(listener);
+      recordEntry('log', ['a']);
+      recordEntry('log', ['b']);
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('subscribeSystemLog', () => {
+    it('returns an unsubscribe function that stops notifications', () => {
+      const listener = jest.fn();
+      const unsubscribe = subscribeSystemLog(listener);
+      recordEntry('log', ['first']);
+      unsubscribe();
+      recordEntry('log', ['second']);
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('clearSystemLog', () => {
+    it('empties the buffer and notifies subscribers', () => {
+      recordEntry('log', ['x']);
+      const listener = jest.fn();
+      subscribeSystemLog(listener);
+      clearSystemLog();
+      expect(getSystemLog()).toHaveLength(0);
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('installSystemLogConsoleHook', () => {
+    it('captures console.log/info/warn/error into the buffer', () => {
+      // The hook self-installs on import; calling again is a no-op.
+      installSystemLogConsoleHook();
+
+      console.log('captured-log');
+      console.info('captured-info');
+      console.warn('captured-warn');
+      console.error('captured-error');
+
+      const messages = getSystemLog().map((e) => `${e.level}:${e.message}`);
+      expect(messages).toContain('log:captured-log');
+      expect(messages).toContain('info:captured-info');
+      expect(messages).toContain('warn:captured-warn');
+      expect(messages).toContain('error:captured-error');
+    });
+
+    it('is idempotent across multiple installs', () => {
+      installSystemLogConsoleHook();
+      installSystemLogConsoleHook();
+      clearSystemLog();
+      console.log('once');
+      // Should only record a single entry, not double-wrapped.
+      const entries = getSystemLog().filter((e) => e.message === 'once');
+      expect(entries).toHaveLength(1);
+    });
+  });
+});

--- a/apps/akari/__tests__/utils/tokimekiPoll.test.ts
+++ b/apps/akari/__tests__/utils/tokimekiPoll.test.ts
@@ -1,0 +1,72 @@
+import {
+  isTokimekiPollUrl,
+  pollEmbedUrlFromRecord,
+  pollUriFromEmbedUrl,
+} from '@/utils/tokimekiPoll';
+
+describe('isTokimekiPollUrl', () => {
+  it('matches http and https poll viewer urls', () => {
+    expect(isTokimekiPollUrl('https://poll.tokimeki.tech/p/did:plc:abc/3kxy')).toBe(true);
+    expect(isTokimekiPollUrl('http://poll.tokimeki.tech/p/did:plc:abc/3kxy')).toBe(true);
+  });
+
+  it('is case-insensitive on the scheme/host', () => {
+    expect(isTokimekiPollUrl('HTTPS://POLL.TOKIMEKI.TECH/p/x')).toBe(true);
+  });
+
+  it('does not match other hosts or paths', () => {
+    expect(isTokimekiPollUrl('https://poll.tokimeki.tech/q/x')).toBe(false);
+    expect(isTokimekiPollUrl('https://example.com/p/x')).toBe(false);
+    expect(isTokimekiPollUrl('not a url')).toBe(false);
+  });
+});
+
+describe('pollUriFromEmbedUrl', () => {
+  it('converts a valid viewer url into the poll record at:// uri', () => {
+    expect(
+      pollUriFromEmbedUrl('https://poll.tokimeki.tech/p/did:plc:abc/3kxy?options=4'),
+    ).toBe('at://did:plc:abc/tech.tokimeki.poll.poll/3kxy');
+  });
+
+  it('returns null for non-tokimeki hosts', () => {
+    expect(pollUriFromEmbedUrl('https://example.com/p/did:plc:abc/3kxy')).toBeNull();
+  });
+
+  it('returns null when the path is not a /p/<did>/<rkey> shape', () => {
+    expect(pollUriFromEmbedUrl('https://poll.tokimeki.tech/q/did:plc:abc/3kxy')).toBeNull();
+    expect(pollUriFromEmbedUrl('https://poll.tokimeki.tech/p/did:plc:abc')).toBeNull();
+  });
+
+  it('returns null when the did segment is not a did', () => {
+    expect(pollUriFromEmbedUrl('https://poll.tokimeki.tech/p/notadid/3kxy')).toBeNull();
+  });
+
+  it('returns null when the rkey is empty', () => {
+    expect(pollUriFromEmbedUrl('https://poll.tokimeki.tech/p/did:plc:abc/')).toBeNull();
+  });
+
+  it('returns null for unparseable urls', () => {
+    expect(pollUriFromEmbedUrl('not a url')).toBeNull();
+  });
+});
+
+describe('pollEmbedUrlFromRecord', () => {
+  it('builds a viewer url from a poll record at:// uri', () => {
+    expect(
+      pollEmbedUrlFromRecord('at://did:plc:abc/tech.tokimeki.poll.poll/3kxy', 4),
+    ).toBe('https://poll.tokimeki.tech/p/did:plc:abc/3kxy?options=4');
+  });
+
+  it('returns null when the uri is missing a did or rkey', () => {
+    expect(pollEmbedUrlFromRecord('at://', 4)).toBeNull();
+    expect(pollEmbedUrlFromRecord('at://did:plc:abc/tech.tokimeki.poll.poll/', 4)).toBeNull();
+    expect(pollEmbedUrlFromRecord('at://did:plc:abc', 4)).toBeNull();
+  });
+
+  it('round-trips with pollUriFromEmbedUrl', () => {
+    const uri = 'at://did:plc:abc/tech.tokimeki.poll.poll/3kxy';
+    const url = pollEmbedUrlFromRecord(uri, 2);
+    expect(url).not.toBeNull();
+    expect(pollUriFromEmbedUrl(url as string)).toBe(uri);
+  });
+});

--- a/apps/akari/jest.setup.js
+++ b/apps/akari/jest.setup.js
@@ -10,6 +10,8 @@ jest.mock('react-native-mmkv', () => {
       const store = stores.get(storeKey);
       return {
         getString: (key) => store.get(key),
+        getBoolean: (key) => store.get(key),
+        getNumber: (key) => store.get(key),
         set: (key, value) => store.set(key, value),
         delete: (key) => store.delete(key),
         contains: (key) => store.has(key),


### PR DESCRIPTION
## What

Second app-coverage wave (stacked on #408). **+403 tests** (akari suite 1467 → 1870), 65 new test files.

> Base is #408's branch so the diff is reviewable; GitHub will retarget to `main` once #408 merges.

### Utils (most ~100%)
`appView`, `blueskyApi` factories, `draftMapper`, `liveStatus`, `streamPlace`, `cdn`, `embedThumb`, `skyblur`, `blueskyOzone`, `featureFlags`, `postCardPressGuard`, `tokimekiPoll`, `signupProviders`, `queryClient`, `secureStorageBootstrap`, and the OAuth helpers (`pkce`, `config`, `par`, `token`, `webStash`, `clientBinding`).

### Query hooks
Remaining moderation/community/labeler/poll/links/mutes/stories/typeahead/session/pds queries.

### Mutation hooks
mute/pin/repost/feed-interaction/leaflet/draft/post-controls plus the auth + account storage setters (set/clear authentication, switch/remove account, wipe data, …).

## How
Established `renderHook` + `QueryClientProvider` pattern with `@/bluesky-api` and dependency hooks mocked; network and crypto mocked deterministically. The OAuth `pkce` test validates against the RFC 7636 vector.

## Notes
- Agents this round ran `tsc` + `oxlint` on their own test files (babel-jest doesn't type-check), so no post-hoc type fixes were needed.
- Remaining uncovered lines are in-`queryFn` defensive guards unreachable behind each query's `enabled` gate, plus a few `__DEV__` `console.warn` arms.
- Full gate green: lint, `tsc` (0 errors), tests (akari 1870 ✓).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lucid-softworks/codesmith/akari/pr/409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782671652&installation_id=136510994&pr_number=409&repository=lucid-softworks%2Fakari&return_to=https%3A%2F%2Fgithub.com%2Flucid-softworks%2Fakari%2Fpull%2F409&signature=83c2f744cce0928f8a80d205d687d22671c0baee7b030484f595e24e4cfb228e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->