### PR TITLE
ci: cache node_modules in the docs build job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,20 @@ jobs:
           node-version: 24.9.0
           cache: npm
 
+      # Cache node_modules itself (not just the ~/.npm download cache) so a
+      # lockfile-unchanged run skips the ~100s npm ci extract/link/postinstall.
+      - name: Cache node_modules
+        id: node-modules
+        uses: useblacksmith/cache@v5
+        with:
+          path: |
+            node_modules
+            apps/*/node_modules
+            packages/*/node_modules
+          key: node-modules-${{ runner.os }}-node24-${{ hashFiles('package-lock.json') }}
+
       - name: Install dependencies
+        if: steps.node-modules.outputs.cache-hit != 'true'
         run: npm ci
 
       - name: Build documentation site


### PR DESCRIPTION
## What

The `docs` workflow ran a bare `npm ci` (only `setup-node`'s `~/.npm` download cache), unlike `lint` and `test` which (since #403) cache `node_modules` itself via `useblacksmith/cache@v5` and skip `npm ci` on a lockfile-unchanged run.

Add the same cache step to the docs build job, with the **identical cache key** (`node-modules-${{ runner.os }}-node24-${{ hashFiles('package-lock.json') }}`). So the docs build shares the cache the other jobs populate and skips the ~100s install on a hit.

## Notes
- Only the install step is gated on the cache miss; everything else (turbo `build --filter=docs`, pages upload/deploy) is unchanged.
- Same pattern, same key as `lint.yml` / `test.yml` — verified the key matches across all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/lucid-softworks/codesmith/akari/pr/410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782672718&installation_id=136510994&pr_number=410&repository=lucid-softworks%2Fakari&return_to=https%3A%2F%2Fgithub.com%2Flucid-softworks%2Fakari%2Fpull%2F410&signature=4831df2ed31b91d3c2c80c9281e8b52da33a41aba714c8ac558561c9c5f3f927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->